### PR TITLE
Route stream views through /streams/{slug}/view; surface collection_key

### DIFF
--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -27,6 +27,7 @@ Core pipeline is working:
 - Multiple output formats: HTML, PDF, LaTeX, Word
 - Performance: concurrent source search, LLM batching
 - Better CLI error messages and progress output
+- **Ollama resilience** — graceful degradation when Ollama is unavailable at startup or drops mid-session: ChromaDB full index currently silently skips if Ollama is offline during the 20s startup window and never retries; Graphify retries every 60s (already handles it). Both services should expose clear status to the server health endpoint, and ChromaDB should schedule a retry when Ollama becomes reachable again rather than waiting for the next file-change event.
 
 ---
 

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -587,6 +587,7 @@ def get_note(slug: str, format: str = "html"):
         rn.last_updated = node.last_updated
         rn.next_update = node.next_update
         rn.query = node.query
+        rn.collection_key = node.collection_key
     return rn
 
 
@@ -970,6 +971,11 @@ def get_stream(slug: str):
         return _stream_meta(_vault.get_stream(slug))
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
+
+
+@app.get("/streams/{slug}/view", response_model=RenderedNode)
+def get_stream_view(slug: str, format: str = "html"):
+    return get_note(slug, format)
 
 
 class StreamCreateRequest(BaseModel):

--- a/prisma/storage/models/vault_models.py
+++ b/prisma/storage/models/vault_models.py
@@ -208,6 +208,7 @@ class RenderedNode(BaseModel):
     last_updated: datetime | None = None
     next_update: datetime | None = None
     query: str | None = None
+    collection_key: str | None = None
 
 
 class StreamRunResult(BaseModel):


### PR DESCRIPTION
## Summary

- Adds \`GET /streams/{slug}/view\` endpoint — streams are YAML files in a dedicated directory, not vault notes, so they must not be served via \`/notes/\`
- Adds \`collection_key\` to \`RenderedNode\` so the desktop UI can auto-select the stream's Zotero collection when a stream is opened
- Notes Ollama resilience gap in roadmap (ChromaDB silently skips full index if Ollama is offline at startup)

## Test plan

- [x] \`GET /streams/{slug}/view\` returns 200 with rendered HTML for an existing stream
- [x] \`collection_key\` is populated in the response when the stream YAML has one