### PR TITLE
Expose Ollama reachability in /status

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -355,6 +355,7 @@ def status():
         "chroma": _chroma.status(),
         "vault": vault_stats,
         "zotero": zotero_info,
+        "ollama": {"reachable": _indexer._ollama_ready()},
     }
 
 


### PR DESCRIPTION
Adds `ollama.reachable` to the `/status` response using the same socket probe already in `GraphifyIndexer._ollama_ready()`.