### PR TITLE
fix: close resource-safety and lost-update gaps found in self-audit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -710,3 +710,34 @@ several linked fixes:
 - [ ] Update/replace `tests/unit/services/test_graphify_service.py` and the
       graphify-specific parts of `tests/unit/server/test_supervisor_resources.py`.
 - [ ] Regenerate diagrams (`docs/diagrams/gen.sh`) once the new module lands.
+
+### Deferred from the correctness self-audit (2026-07-02)
+
+Found while auditing every LLM call site + the Excerpt/pinning data flow +
+supervisor concurrency after the kg `num_predict` incident. Critical/medium
+items were fixed in the same pass (see `chat_llm.py`, `supervisor.py`,
+`vault.py`, `app.py`, `knowledge_graph_service.py`). These are lower-severity
+and deliberately deferred rather than fixed blind:
+
+- [ ] `analysis_agent.py::assess_relevance()` logs via `print()` instead of
+      the `_log_ollama` logger every sibling method uses — observability
+      gap, not a behavior bug.
+- [ ] `analysis_agent.py::_relevance_chunk()` fails *open*
+      (`[True]*len(candidates)`) on error, while the identity-check methods
+      fail *closed* — needs a deliberate sign-off on which failure mode is
+      actually wanted here, not a reflexive flip.
+- [ ] Timeout values across `analysis_agent.py` are a mix of flat and
+      size-scaled — inconsistent in spirit but each individually reasonable;
+      revisit as a considered pass, not opportunistically.
+- [ ] VRAM-aware resource pool skips the budget check entirely if
+      `acquire(..., model=None)` — currently unreachable (every real caller
+      always passes `model=`), but a defensive gap for future callers.
+- [ ] Stale `pollExcerptRegeneration` interval (ui/src/routes/+page.svelte)
+      keeps firing up to one wasted request (~2s) after switching chats
+      before self-clearing — harmless, not fixed.
+- [x] Excerpt regeneration always overwrites the note body, so a hand-edit
+      to the Excerpt note is lost on the next pin/unpin. Decided: document
+      as an accepted limitation rather than build edit-detection — the
+      Excerpt is meant to be machine-owned, not hand-editable. See
+      `docs/wiki/adr/ADR-015-chat-excerpt-context-model.md`. Revisit only if
+      this becomes an actual pain point.

--- a/docs/wiki/adr/ADR-015-chat-excerpt-context-model.md
+++ b/docs/wiki/adr/ADR-015-chat-excerpt-context-model.md
@@ -173,6 +173,13 @@ built.
   one — real complexity cost for supporting both, though the alternative
   (picking one mode forever) would mean either wasting a large-context
   backend's headroom or risking overflow on a small-context one.
+- The Excerpt note is machine-owned: every pin/unpin regenerates its body
+  from the current pinned set and overwrites whatever was there. A direct
+  hand-edit to the Excerpt note is not preserved past the next regeneration.
+  Accepted as a known limitation rather than built out (edit-detection would
+  need its own diffing/merge design) — the Excerpt is meant to be read as a
+  distillation of the chat, not authored directly. See `TODO.md`'s
+  "Deferred from the correctness self-audit" section.
 
 ## Related
 

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -567,6 +567,12 @@ def create_chat(req: CreateChatRequest):
 
 _excerpt_regenerating_lock = threading.Lock()
 _excerpt_regenerating: dict[str, bool] = {}
+# Monotonic per-slug counter so a slower, stale regeneration thread can tell
+# it's been superseded by a newer pin/unpin before it overwrites the Excerpt
+# with outdated content, and so the *older* thread never clears
+# excerpt_regenerating out from under a still-running newer one (which would
+# make the UI stop polling before the real latest result is ready).
+_excerpt_generation: dict[str, int] = {}
 
 
 def _excerpt_summary_html(note_body: str) -> str | None:
@@ -632,21 +638,32 @@ def chat(req: ChatRequest):
             _log.warning("chat %r: excerpt note %r no longer exists", chat_node.slug, chat_node.excerpt_slug)
     user_msg = ChatMessage(role=ChatRole.user, content=req.message)
     assistant_msg = _chat_agent.respond(history, req.message, promoted_notes=promoted_notes)
-    _vault.save_chat(chat_node.slug, history + [user_msg, assistant_msg], model=_chat_agent.model)
+    # append_messages (not save_chat with the pre-call `history` snapshot)
+    # re-reads the chat's *current* messages atomically right before
+    # writing — closes the race where a DELETE /chats/{slug}/messages/{index}
+    # landing while respond() was still running would otherwise get
+    # silently reverted by this write.
+    _vault.append_messages(chat_node.slug, [user_msg, assistant_msg], model=_chat_agent.model)
     _activity.info("action=chat slug=%s tool_calls=%d", chat_node.slug, len(assistant_msg.tool_calls))
     return ChatResponse(
         chat_slug=chat_node.slug, reply=assistant_msg.content, tool_calls=assistant_msg.tool_calls,
     )
 
 
-def _regenerate_excerpt_now(slug: str, pinned_indices: list[int]) -> None:
+def _regenerate_excerpt_now(slug: str, pinned_indices: list[int], generation: int) -> None:
     """ADR-015: regenerates the chat's single Excerpt note from whatever's
     currently pinned, in whichever mode currently applies
     (ChatAgent.excerpt_mode(), budget-driven) — compressed (LLM-condensed
     Summary via ChatAgent.summarize() + load_excerpt_summary_prompt()) or
     verbatim (no LLM call, no Summary section, pinned turns kept exactly as
     written). Synchronous — call via _regenerate_excerpt_async unless
-    already off the request thread."""
+    already off the request thread.
+
+    `generation` is checked immediately before the actual write: if a newer
+    pin/unpin has since been dispatched for this chat, this call's result is
+    stale (it was likely computed from an older pinned set, possibly after a
+    slow summarize() call) and is discarded rather than overwriting the
+    newer request's — eventual — result."""
     chat_node = _vault.get_chat(slug)
     pinned_turns = [chat_node.messages[i] for i in pinned_indices]
     summary: str | None
@@ -660,7 +677,10 @@ def _regenerate_excerpt_now(slug: str, pinned_indices: list[int]) -> None:
             summary = _chat_agent.summarize(load_excerpt_summary_prompt(), turns_text)
             if summary is None:
                 summary = "(summary unavailable — the language model couldn't be reached; raw pinned turns below are still current)"
-    _vault.save_excerpt(slug, summary, pinned_turns)
+    with _excerpt_regenerating_lock:
+        if _excerpt_generation.get(slug) != generation:
+            return  # superseded by a newer pin/unpin — don't overwrite with stale content
+        _vault.save_excerpt(slug, summary, pinned_turns)
 
 
 def _regenerate_excerpt_async(slug: str, pinned_indices: list[int]) -> None:
@@ -672,16 +692,23 @@ def _regenerate_excerpt_async(slug: str, pinned_indices: list[int]) -> None:
     "regenerating" indicator (Chat.excerpt_regenerating, see
     _with_context_usage) until this clears, then refetches."""
     with _excerpt_regenerating_lock:
+        generation = _excerpt_generation.get(slug, 0) + 1
+        _excerpt_generation[slug] = generation
         _excerpt_regenerating[slug] = True
 
     def _run() -> None:
         try:
-            _regenerate_excerpt_now(slug, pinned_indices)
+            _regenerate_excerpt_now(slug, pinned_indices, generation)
         except Exception as exc:
             _log.warning("excerpt regeneration failed for chat %r: %s", slug, exc)
         finally:
             with _excerpt_regenerating_lock:
-                _excerpt_regenerating[slug] = False
+                # Only clear the flag if no newer request has superseded
+                # this one — otherwise an older, slower thread finishing
+                # after a newer one started would incorrectly tell the UI
+                # "done" while the real latest regeneration is still running.
+                if _excerpt_generation.get(slug) == generation:
+                    _excerpt_regenerating[slug] = False
 
     threading.Thread(target=_run, daemon=True, name=f"excerpt-regen-{slug}").start()
 

--- a/prisma/server/supervisor.py
+++ b/prisma/server/supervisor.py
@@ -545,39 +545,50 @@ class ResourceManager:
                 # own leases — on a strict (non-budget) pool every lease is
                 # already guaranteed to be for the same resident model, so
                 # the plain total is equivalent and cheaper.
-                limit = self._effective_capacity(name, model if name in self._model_affinity else None)
+                full_limit = self._effective_capacity(name, model if name in self._model_affinity else None)
+                total_in_use = (
+                    sum(1 for l in self._leases[name].values() if l["model"] == model)
+                    if vram_aware else len(self._leases[name])
+                )
                 # Interactive traffic (chat) must never queue behind bulk
                 # background work (kg extraction, chroma embedding) filling
                 # every slot. Background requests are capped below the
                 # model's full concurrency limit when a reservation is
-                # configured, guaranteeing at least (limit - background_limit)
-                # slots stay free for interactive callers at all times — no
-                # live preemption needed, just a smaller ceiling for the
-                # lower-priority tier.
-                #
-                # Critically, a background request's own count must only
-                # include *other background* leases, not interactive ones —
-                # counting interactive leases against background's reduced
-                # limit let a single active chat silently steal from
-                # background's own quota (observed: background denied at
-                # in_use=3/limit=3 with only 2 of those 3 leases actually
-                # being background). Interactive's own check is unaffected:
-                # it always compares against the full (unreduced) limit, so
-                # it never queues behind background regardless of this.
+                # configured, guaranteeing at least (full_limit -
+                # background_limit) slots stay free for interactive callers
+                # at all times — no live preemption needed, just a smaller
+                # ceiling for the lower-priority tier.
                 if priority == "background":
                     background_limit = self._model_background_limit.get(name, {}).get(model)
-                    if background_limit is not None:
-                        limit = min(limit, background_limit)
+                    limit = min(full_limit, background_limit) if background_limit is not None else full_limit
+                    # Two independent ceilings, both must hold:
+                    # 1. background-scoped in_use < limit — protects
+                    #    interactive's reservation. Must count only *other
+                    #    background* leases, not interactive ones — counting
+                    #    interactive against this reduced limit let a single
+                    #    active chat silently steal from background's own
+                    #    quota (observed: background denied at in_use=3/
+                    #    limit=3 with only 2 of those 3 leases actually being
+                    #    background).
+                    # 2. total_in_use < full_limit — without this, once
+                    #    interactive alone has already filled the pool to
+                    #    its real max_concurrent, background_in_use is still
+                    #    0 (zero *background* leases so far) and would be
+                    #    granted anyway, pushing the pool past its
+                    #    configured ceiling entirely (found live: fixing #1
+                    #    alone, in an earlier pass, introduced this — the
+                    #    background-only count was never checked against
+                    #    real total capacity at all).
                     in_use = sum(
                         1 for l in self._leases[name].values()
                         if l["priority"] == "background" and (not vram_aware or l["model"] == model)
                     )
+                    admitted = in_use < limit and total_in_use < full_limit
                 else:
-                    in_use = (
-                        sum(1 for l in self._leases[name].values() if l["model"] == model)
-                        if vram_aware else len(self._leases[name])
-                    )
-                if in_use < limit:
+                    limit = full_limit
+                    in_use = total_in_use
+                    admitted = in_use < limit
+                if admitted:
                     request_id = f"{holder}-{pid}-{uuid.uuid4().hex[:8]}"
                     self._leases[name][request_id] = {
                         "holder": holder, "pid": pid, "model": model,
@@ -593,8 +604,8 @@ class ResourceManager:
                 )
                 log.info(
                     "acquire denied: pool=%s holder=%s pid=%d model=%s priority=%s reason=capacity "
-                    "in_use=%d limit=%d current_leases=[%s]",
-                    name, holder, pid, model, priority, in_use, limit, holders,
+                    "in_use=%d limit=%d total_in_use=%d full_limit=%d current_leases=[%s]",
+                    name, holder, pid, model, priority, in_use, limit, total_in_use, full_limit, holders,
                 )
         return None, None
 

--- a/prisma/services/chat_llm.py
+++ b/prisma/services/chat_llm.py
@@ -37,7 +37,12 @@ class ChatLLM:
         self._ollama_host = ollama_host
         self._supervisor_host = supervisor_host
         self._supervisor_port = supervisor_port if supervisor_port is not None else resource_lock.default_port()
-        self._client = OpenAI(base_url=self._resolve_base_url(), api_key=self._resolve_api_key())
+        # timeout=180.0: without this, an OpenAI-SDK call has no default
+        # ceiling at all — found live: this call site was the one gap the
+        # kg-extraction num_predict bug didn't already cover elsewhere.
+        self._client = OpenAI(
+            base_url=self._resolve_base_url(), api_key=self._resolve_api_key(), timeout=180.0,
+        )
 
     @property
     def model(self) -> str:
@@ -92,6 +97,7 @@ class ChatLLM:
                     model=self._config.model,
                     messages=messages,
                     temperature=temperature,
+                    max_tokens=self._config.max_tokens,
                 )
             except Exception as exc:
                 _log.warning("chat completion failed: %s", exc)

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -382,7 +382,21 @@ class KnowledgeGraphService:
                             "prompt": prompt,
                             "stream": False,
                             "format": "json",
-                            "options": {"temperature": 0.1},
+                            # No cap here meant no defense against a
+                            # confused/looping generation for one section —
+                            # observed live: calls taking 2-5 minutes each
+                            # (some hitting this very timeout) on a GPU
+                            # sitting at ~32% utilization the whole time,
+                            # consistent with the model generating a very
+                            # long, repetitive output rather than being
+                            # compute/GPU-bound (single-stream decode is
+                            # memory-bound, so low GPU% during a long
+                            # generation is normal, not a sign of throttling).
+                            # 2000 matches token_budget itself — a structured
+                            # JSON extraction of one section's entities
+                            # shouldn't need to be longer than the section
+                            # it's summarizing.
+                            "options": {"temperature": 0.1, "num_predict": 2000},
                         },
                         # Larger sections (up to token_budget) take longer to
                         # process now that num_ctx is 32768 instead of 16384.
@@ -394,8 +408,18 @@ class KnowledgeGraphService:
         if resp.status_code != 200:
             _log.warning("extraction failed for %s: status=%d", rel_path, resp.status_code)
             return [], [], False
-        data = resp.json()
-        nodes, edges = _parse_extraction_response(data.get("response", ""))
+        # Deliberately outside both the lease and the request try/except
+        # above (releases the GPU slot before parsing) — but that left a
+        # gap: a malformed/truncated response body raised unhandled here,
+        # inside a thread-pool worker, instead of being treated as "this
+        # section's extraction failed, retry next cycle" like every other
+        # failure mode in this method.
+        try:
+            data = resp.json()
+            nodes, edges = _parse_extraction_response(data.get("response", ""))
+        except Exception as exc:
+            _log.warning("extraction response parse failed for %s: %s", rel_path, exc)
+            return [], [], False
         return nodes, edges, True
 
     def _extract_file(self, path: Path, trust_tier: str) -> bool:

--- a/prisma/services/vault.py
+++ b/prisma/services/vault.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import threading
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Iterator
@@ -173,6 +174,14 @@ class VaultService:
             NodeType.chat: self.root / default_chats,
             NodeType.stream: self.root / "streams",
         }
+        # Every chat write (save_chat/set_pinned_turns/save_excerpt) is a
+        # plain read-parse-write of a whole file with no locking — two
+        # requests for the same chat overlapping (e.g. quick successive
+        # pin/unpin clicks, or a pin racing a slow /chat completion) can
+        # each read stale state and one write silently clobbers the other's
+        # change. Chat writes are low-frequency; one process-wide lock is
+        # simple and sufficient — no need for per-slug lock management.
+        self._chat_write_lock = threading.Lock()
 
     def ensure_dirs(self) -> None:
         for d in self.default_dirs.values():
@@ -384,14 +393,38 @@ class VaultService:
         prisma-chat:7b -> prisma-llm:7b) would keep displaying its
         original, now-stale name forever, even though every subsequent
         turn actually used the current config's model."""
-        path = self._find_md(slug)
-        if path is None:
-            raise FileNotFoundError(f"chat not found: {slug!r}")
-        existing = path.read_text(encoding="utf-8")
-        fm, _ = _parse_frontmatter(existing)
-        if model is not None:
-            fm["model"] = model
-        path.write_text(_render_frontmatter(fm) + _render_chat_body(messages), encoding="utf-8")
+        with self._chat_write_lock:
+            path = self._find_md(slug)
+            if path is None:
+                raise FileNotFoundError(f"chat not found: {slug!r}")
+            existing = path.read_text(encoding="utf-8")
+            fm, _ = _parse_frontmatter(existing)
+            if model is not None:
+                fm["model"] = model
+            path.write_text(_render_frontmatter(fm) + _render_chat_body(messages), encoding="utf-8")
+        return self.get_chat(slug)
+
+    def append_messages(self, slug: str, new_messages: list[ChatMessage], model: str | None = None) -> Chat:
+        """Atomically append to whatever the chat's *current* on-disk
+        messages are, not a snapshot taken before some earlier operation
+        (e.g. an LLM call) started. `/chat`'s handler used to read
+        `history` before calling the model, then write `history +
+        [new turns]` once the call finished — if a `DELETE
+        /chats/{slug}/messages/{index}` landed in between, that stale
+        write would silently revive the just-deleted message. Reading and
+        writing under the same lock closes that window."""
+        with self._chat_write_lock:
+            path = self._find_md(slug)
+            if path is None:
+                raise FileNotFoundError(f"chat not found: {slug!r}")
+            existing = path.read_text(encoding="utf-8")
+            fm, content = _parse_frontmatter(existing)
+            if model is not None:
+                fm["model"] = model
+            current_messages = _parse_chat_body(content)
+            path.write_text(
+                _render_frontmatter(fm) + _render_chat_body(current_messages + new_messages), encoding="utf-8",
+            )
         return self.get_chat(slug)
 
     def set_pinned_turns(self, chat_slug: str, indices: list[int]) -> Chat:
@@ -400,13 +433,14 @@ class VaultService:
         needs an LLM call (ADR-015's compressed-mode Summary), which this
         pure-storage layer has no access to. Callers (app.py) call this
         first, then assemble the new Summary and call save_excerpt()."""
-        chat_path = self._find_md(chat_slug)
-        if chat_path is None:
-            raise FileNotFoundError(f"chat not found: {chat_slug!r}")
-        raw = chat_path.read_text(encoding="utf-8")
-        fm, content = _parse_frontmatter(raw)
-        fm["pinned_turns"] = sorted(set(indices))
-        chat_path.write_text(_render_frontmatter(fm) + content, encoding="utf-8")
+        with self._chat_write_lock:
+            chat_path = self._find_md(chat_slug)
+            if chat_path is None:
+                raise FileNotFoundError(f"chat not found: {chat_slug!r}")
+            raw = chat_path.read_text(encoding="utf-8")
+            fm, content = _parse_frontmatter(raw)
+            fm["pinned_turns"] = sorted(set(indices))
+            chat_path.write_text(_render_frontmatter(fm) + content, encoding="utf-8")
         return self.get_chat(chat_slug)
 
     def save_excerpt(self, chat_slug: str, summary: str | None, raw_turns: list[ChatMessage]) -> Note:
@@ -415,18 +449,28 @@ class VaultService:
         at all — pinned turns are the whole point in that mode), verbatim
         copy of the pinned turns below. Reuses the existing note
         (`Chat.excerpt_slug`) if one was already created for this chat,
-        rather than creating a new note per pin."""
-        chat = self.get_chat(chat_slug)
-        body = _render_excerpt_body(summary, raw_turns)
-        if chat.excerpt_slug:
-            return self.save_note(chat.excerpt_slug, body)
-        note = self.create_note(f"Excerpt — {chat.title}", body=body, promoted_from_chat=chat_slug)
-        chat_path = self._find_md(chat_slug)
-        raw = chat_path.read_text(encoding="utf-8")
-        fm, content = _parse_frontmatter(raw)
-        fm["excerpt_slug"] = note.slug
-        chat_path.write_text(_render_frontmatter(fm) + content, encoding="utf-8")
-        return note
+        rather than creating a new note per pin. If that note has since
+        been deleted out from under `excerpt_slug` (e.g. via the generic
+        delete-node endpoint, which has no special case for this), falls
+        back to creating a fresh one instead of raising — otherwise every
+        future pin/unpin for this chat would permanently fail with
+        `FileNotFoundError`, silently swallowed by the background
+        regeneration thread's blanket exception handler."""
+        with self._chat_write_lock:
+            chat = self.get_chat(chat_slug)
+            body = _render_excerpt_body(summary, raw_turns)
+            if chat.excerpt_slug:
+                try:
+                    return self.save_note(chat.excerpt_slug, body)
+                except FileNotFoundError:
+                    pass  # note deleted underneath us — fall through to create a fresh one
+            note = self.create_note(f"Excerpt — {chat.title}", body=body, promoted_from_chat=chat_slug)
+            chat_path = self._find_md(chat_slug)
+            raw = chat_path.read_text(encoding="utf-8")
+            fm, content = _parse_frontmatter(raw)
+            fm["excerpt_slug"] = note.slug
+            chat_path.write_text(_render_frontmatter(fm) + content, encoding="utf-8")
+            return note
 
     def get_any(self, slug: str) -> Note | Source | Chat | Stream:
         path = self._find_file(slug)

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -84,6 +84,15 @@ class ChatConfig(BaseModel):
             "Summary; a large one (a future cloud backend) can afford to keep them verbatim."
         ),
     )
+    max_tokens: int = Field(
+        2000,
+        description=(
+            "Hard cap on generated tokens per chat completion. Without this, a rambling or "
+            "confused generation has nothing to stop it (found live: the same gap in kg's "
+            "extraction calls let a single section's call run for minutes — see "
+            "knowledge_graph_service.py's _call_ollama_extract num_predict comment)."
+        ),
+    )
 
     @field_validator('provider')
     @classmethod

--- a/tests/unit/server/test_supervisor_resources.py
+++ b/tests/unit/server/test_supervisor_resources.py
@@ -657,6 +657,30 @@ def test_active_interactive_lease_does_not_shrink_backgrounds_own_quota():
     assert [r1, r2, r3] == ["local-ollama"] * 3  # background still gets its full quota of 3
 
 
+def test_background_denied_when_interactive_alone_fills_the_pool_to_full_capacity():
+    # Regression: the fix above (background counts only its own leases) went
+    # one step too far — it never checked background's request against the
+    # pool's *total* real capacity at all. If interactive traffic alone has
+    # already filled the pool to its full max_concurrent, a background
+    # request would see background_in_use=0 (zero background leases so far)
+    # and get granted anyway, pushing the pool past its configured ceiling.
+    rm = ResourceManager(
+        {"local-ollama": 6}, model_affinity={"local-ollama"},
+        model_background_limit={"local-ollama": {"prisma-llm:7b": 3}},
+    )
+    pid = os.getpid()
+
+    interactive_leases = [
+        rm.acquire("api", pid, model="prisma-llm:7b", priority="interactive")
+        for _ in range(6)
+    ]
+    assert all(r == "local-ollama" for r, _ in interactive_leases)  # fills the pool to its real max_concurrent
+
+    r_bg, rid_bg = rm.acquire("kg", pid, model="prisma-llm:7b", priority="background")
+
+    assert r_bg is None and rid_bg is None  # must not be granted just because background_in_use is 0
+
+
 def test_interactive_defaults_to_background_priority_when_unspecified():
     # Existing callers (kg, chroma) that don't pass priority at all must
     # keep today's behavior — capped at the background limit, not the full

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -186,6 +186,27 @@ def test_extract_file_one_bad_section_does_not_abort_others(kg, vault):
     assert result.has_next()
 
 
+def test_extract_file_survives_response_json_raising(kg, vault):
+    # Regression: resp.json() and _parse_extraction_response() used to run
+    # outside the request try/except, so a truncated/non-JSON HTTP body
+    # raised unhandled inside the thread-pool worker instead of being
+    # treated as "this section failed, retry next cycle" like every other
+    # failure mode in _call_ollama_extract.
+    f = vault.root / "notes" / "test.md"
+    f.write_text("---\ntype: note\n---\nSome content.", encoding="utf-8")
+    broken = MagicMock(status_code=200)
+    broken.json.side_effect = json.JSONDecodeError("bad", "doc", 0)
+
+    with patch("prisma.services.knowledge_graph_service.requests.post", return_value=broken), \
+         patch("prisma.services.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")), \
+         patch("prisma.services.resource_lock.release"):
+        changed = kg._extract_file(f, "note")
+
+    assert changed is False
+    with kg._lock:
+        assert kg._indexed_hash("notes/test.md") is None
+
+
 # ── Incremental caching ───────────────────────────────────────────────────────
 
 def test_extract_file_skips_unchanged_content(kg, vault):

--- a/tests/unit/services/test_vault_chat.py
+++ b/tests/unit/services/test_vault_chat.py
@@ -92,6 +92,42 @@ def test_save_chat_then_get_chat_roundtrip(vault):
     assert reloaded.model == chat.model  # frontmatter preserved across save
 
 
+def test_append_messages_appends_to_current_disk_state_not_a_stale_snapshot(vault):
+    # Regression: /chat used to write `history + [new turns]` from a
+    # `history` snapshot taken *before* a possibly-slow LLM call — if
+    # something else (e.g. a delete) changed the chat's messages while that
+    # call was running, the eventual write would silently revert it.
+    # append_messages must always append onto whatever's on disk *right
+    # now*, not a caller-held snapshot.
+    chat = vault.create_chat("Test Session")
+    vault.save_chat(chat.slug, [ChatMessage(role=ChatRole.user, content="original")])
+
+    # Simulate something else changing the chat on disk after a caller
+    # would have taken its own snapshot.
+    vault.save_chat(chat.slug, [
+        ChatMessage(role=ChatRole.user, content="original"),
+        ChatMessage(role=ChatRole.assistant, content="inserted by someone else"),
+    ])
+
+    updated = vault.append_messages(chat.slug, [ChatMessage(role=ChatRole.user, content="new turn")])
+
+    contents = [m.content for m in updated.messages]
+    assert contents == ["original", "inserted by someone else", "new turn"]
+
+
+def test_append_messages_updates_model_like_save_chat(vault):
+    chat = vault.create_chat("Test Session", model="old-model")
+
+    updated = vault.append_messages(chat.slug, [ChatMessage(role=ChatRole.user, content="hi")], model="new-model")
+
+    assert updated.model == "new-model"
+
+
+def test_append_messages_raises_for_missing_chat(vault):
+    with pytest.raises(FileNotFoundError):
+        vault.append_messages("does-not-exist", [ChatMessage(role=ChatRole.user, content="x")])
+
+
 def test_get_any_dispatches_chat_type_to_get_chat(vault):
     chat = vault.create_chat("Test Session")
     result = vault.get_any(chat.slug)
@@ -137,6 +173,24 @@ def test_save_excerpt_reuses_existing_note_instead_of_creating_another(vault):
 def test_save_excerpt_raises_for_missing_chat(vault):
     with pytest.raises(FileNotFoundError):
         vault.save_excerpt("does-not-exist", "X", [])
+
+
+def test_save_excerpt_recreates_note_if_excerpt_slug_points_to_a_deleted_note(vault):
+    # Real bug found in self-audit: the generic delete-node endpoint has no
+    # special case for clearing Chat.excerpt_slug, so deleting the Excerpt
+    # note directly used to permanently break every future pin/unpin for
+    # that chat (save_note raised FileNotFoundError, silently swallowed by
+    # the caller). Must fall back to creating a fresh note instead.
+    chat = vault.create_chat("Research Session")
+    first = vault.save_excerpt(chat.slug, "First summary.", [])
+    (vault.root / "notes" / f"{first.slug}.md").unlink()  # simulate deletion out from under excerpt_slug
+
+    second = vault.save_excerpt(chat.slug, "Second summary.", [])
+
+    assert (vault.root / "notes" / f"{second.slug}.md").exists()
+    reloaded = vault.get_chat(chat.slug)
+    assert reloaded.excerpt_slug == second.slug
+    assert "Second summary." in vault.get_note(second.slug).body
 
 
 def test_save_excerpt_verbatim_mode_omits_summary_section(vault):

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -541,7 +541,23 @@
       const r = await fetch(`${apiBase}/chats/${encodeURIComponent(slug)}`);
       if (!r.ok) { clearInterval(interval); return; }
       const fresh = await r.json();
-      if (activeChat?.slug === slug) activeChat = fresh;
+      // Merge only the Excerpt-related fields — never replace the whole
+      // object. A full replace here raced with sendChatMessage's optimistic
+      // append: if this poll's fetch happened to land while a /chat request
+      // was still in flight, `fresh.messages` wouldn't yet include the
+      // user's just-sent turn, and assigning it wholesale made that message
+      // visually vanish until the next reload.
+      if (activeChat?.slug === slug) {
+        activeChat = {
+          ...activeChat,
+          pinned_turns: fresh.pinned_turns,
+          excerpt_slug: fresh.excerpt_slug,
+          excerpt_regenerating: fresh.excerpt_regenerating,
+          excerpt_summary_html: fresh.excerpt_summary_html,
+          context_tokens_used: fresh.context_tokens_used,
+          context_tokens_max: fresh.context_tokens_max,
+        };
+      }
       if (!fresh.excerpt_regenerating) clearInterval(interval);
     }, 2000);
   }


### PR DESCRIPTION
## Summary
- `ChatLLM.complete()` had no timeout/`max_tokens` cap — added both, mirroring the same class of bug found and fixed in kg's `_call_ollama_extract` (the 12hr-extraction incident that triggered this audit).
- Supervisor's background-priority admission could push a pool past its real `max_concurrent` because it only checked background-scoped lease counts, never total in-use against the pool's actual ceiling. Now checks both.
- `vault.py` had no locking on any chat-file read-parse-write — fixed three concrete lost-update races: concurrent pin/unpin clobbering each other, `/chat` reviving a just-deleted message via a stale pre-call snapshot, and a slower stale excerpt-regeneration thread overwriting a newer one's result (via a new generation counter).
- `save_excerpt` now falls back to creating a fresh note if `Chat.excerpt_slug` points at a deleted one, instead of permanently breaking regeneration for that chat.
- UI's excerpt-regeneration poll now merges only excerpt-related fields instead of a full-object replace, so it can no longer clobber an optimistically-appended chat message from a concurrent send.
- kg's `_call_ollama_extract` now catches parse-time exceptions (`resp.json()` / response parsing) the same way it already handled request-time errors, instead of raising unhandled inside a thread-pool worker.

Low-severity findings from the same audit are recorded in `TODO.md` ("Deferred from the correctness self-audit") rather than rushed into this pass, along with the manual-edit-preservation decision documented in ADR-015.

## Test plan
- [x] `pytest tests/` — 405 passed
- [x] `cd ui && npm run check` — 0 errors, 0 warnings
- [ ] Live smoke-test (pin/unpin race, chat send during excerpt regeneration) once the server's running again — not required for this PR, follow-up noted in TODO.md