### PR TITLE
Supervisor VRAM auto-profiling; close remaining correctness self-audit gaps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -724,19 +724,46 @@ and deliberately deferred rather than fixed blind:
       gap, not a behavior bug. Fixed 2026-07-05 while wiring up Ollama call
       stats (see below): now uses `_log_ollama` with real timing, same as
       every sibling method.
-- [ ] `analysis_agent.py::_relevance_chunk()` fails *open*
+- [x] `analysis_agent.py::_relevance_chunk()` fails *open*
       (`[True]*len(candidates)`) on error, while the identity-check methods
-      fail *closed* — needs a deliberate sign-off on which failure mode is
-      actually wanted here, not a reflexive flip.
-- [ ] Timeout values across `analysis_agent.py` are a mix of flat and
-      size-scaled — inconsistent in spirit but each individually reasonable;
-      revisit as a considered pass, not opportunistically.
-- [ ] VRAM-aware resource pool skips the budget check entirely if
-      `acquire(..., model=None)` — currently unreachable (every real caller
-      always passes `model=`), but a defensive gap for future callers.
-- [ ] Stale `pollExcerptRegeneration` interval (ui/src/routes/+page.svelte)
-      keeps firing up to one wasted request (~2s) after switching chats
-      before self-clearing — harmless, not fixed.
+      fail *closed*. **Reviewed 2026-07-06, no change needed** — not
+      actually inconsistent once you look at what each boolean protects:
+      relevance failing open (treat as relevant) means a brief Ollama
+      outage never silently drops a possibly-good paper from the pipeline;
+      identity failing closed (assume NOT a duplicate) means the same
+      outage never silently merges two possibly-different papers into
+      one. Both defaults already share one underlying rule — "on LLM
+      failure, fail toward whatever loses the least data" — they just
+      read as opposite booleans because the two checks protect against
+      different mistakes (dropping vs. merging).
+- [x] Timeout values across `analysis_agent.py` are a mix of flat and
+      size-scaled. **Reviewed 2026-07-06, no change needed** — only
+      `check_identity_batch`'s LLM call actually scales (`timeout=10 + 15
+      * len(candidates)`), and that's because its response genuinely
+      scales with candidate count (one YES/NO + confidence + reason per
+      candidate). Every flat-timeout call site (`_get_ollama_summary`,
+      `assess_relevance`, `_relevance_chunk`, `_single_pair_check`) has a
+      response that stays small regardless of input size (a short
+      classification or a comma-separated number list) — the "mix" is
+      each call site correctly timed for its own actual output shape, not
+      an oversight.
+- [x] VRAM-aware resource pool skips the budget check entirely if
+      `acquire(..., model=None)`. **Fixed 2026-07-06** — this was
+      reachable, not just theoretical: `supervisor.py`'s HTTP handler
+      passes `body.get("model")` straight through, `None` if a request
+      simply omits it, and that's a real network boundary, not an
+      internal call every current client happens to populate correctly.
+      `ResourceManager.acquire()` now denies (fails safe) rather than
+      silently skipping the VRAM check when a vram-aware pool gets a
+      request with no model. Test:
+      `test_acquire_denies_vram_aware_pool_when_model_missing`.
+- [x] Stale `pollExcerptRegeneration` interval (ui/src/routes/+page.svelte)
+      kept firing up to one wasted request (~2s) after switching chats
+      before self-clearing. **Fixed 2026-07-06** — the interval handle is
+      now hoisted (`excerptPollInterval`) and cleared immediately at every
+      point that switches away from a chat (`openChat`, and the
+      Compute-pools/Knowledge-Graph nav buttons), instead of waiting for
+      the poll's own next 2s tick to notice and self-clear.
 - [x] Excerpt regeneration always overwrites the note body, so a hand-edit
       to the Excerpt note is lost on the next pin/unpin. Decided: document
       as an accepted limitation rather than build edit-detection — the
@@ -857,32 +884,31 @@ Replaced with a narrower, more useful **Knowledge Graph progress page**
       answer "do these two models coexist without thrashing" before
       config changes ship, rather than finding out live.
 
-### Planned: supervisor auto-profiles each configured model's real VRAM/GPU usage
+### Resolved: supervisor auto-profiles each configured model's real VRAM/GPU usage
 
-- [ ] Right now `compute_pools.*.models[].vram_mb` is a hand-measured
-      estimate cservinl enters manually (pull model, trivial generate,
-      read `/api/ps`'s `size_vram`, write the number into config.yaml —
-      exactly the manual process used throughout
-      `docs/qwen3-family-evaluation.md`). Automate this: when supervisor
-      starts, for any configured model missing a `vram_mb` entry, do a
-      one-time probe against the real running system (force a trivial
-      load, read `/api/ps`'s real reported VRAM) and persist the result
-      to a new file in the user's config folder (e.g.
-      `~/.config/prisma/model_vram_profiles.json`) as a distinct
-      "automated config" layer — `config.yaml`'s manual `vram_mb` (if
-      present) always wins over an auto-learned profile, which only fills
-      in what's missing.
-      **Real motivating case**: this exact session hit "these two models
-      don't fit together" (`qwen2.5:7b-32k` + `qwen3:14b-32k`) only by
-      manually reasoning through the arithmetic after the fact — with
-      real profiles for every configured model, `ResourceManager` could
-      compute "do all models configured for a pool with model_affinity
-      fit together" and warn or refuse at config-load time instead of a
-      human finding out live.
-      Open design question resolved: probe eagerly at supervisor startup
-      (not lazily on first real request, not an explicit admin-only
-      command) — scan configured models missing a profile and probe each
-      in the background right after startup. Trade-off accepted: this can
-      evict whatever's already resident and spends GPU time on a model
-      that might not get used this session, in exchange for profiles
-      existing before anything real needs them.
+- [x] Implemented 2026-07-06 in `prisma/server/supervisor.py`:
+      `_probe_model_vram()` force-loads a model via a trivial
+      `/api/generate` call and reads its real cost back from `/api/ps`;
+      `_load_vram_profiles()`/`_save_vram_profile()` persist to
+      `~/.config/prisma/model_vram_profiles.json`; `_profile_missing_models()`
+      runs once in a daemon thread at `main()` startup, skipping any model
+      that already has either a config.yaml `vram_mb` or a saved profile
+      (config always wins), and calls the new
+      `ResourceManager.note_model_vram()` so a freshly-learned profile takes
+      effect immediately, no restart needed. Still stdlib + yaml only, per
+      the module's existing constraint — no new dependencies. Tests in
+      `tests/unit/server/test_supervisor_resources.py`. This doesn't yet
+      make `ResourceManager` proactively warn "these configured models don't
+      fit together" (the qwen2.5/qwen3:14b incident's real trigger) — it
+      only makes sure every model *has* a real measured profile so that
+      check becomes possible later without another live-discovery cycle.
+### Planned follow-up: warn when a pool's configured models don't fit together
+
+- [ ] Now that every configured model gets a real measured VRAM profile
+      (see above), `ResourceManager`/`_load_compute_pools()` could sum a
+      `model_affinity` pool's models' `vram_mb` (config or learned profile)
+      against its `vram_budget_mb` and warn (or refuse to start) at
+      config-load time when they don't fit together — catching the
+      qwen2.5:7b-32k / qwen3:14b-32k incident *before* a config change
+      ships, instead of a human reasoning through the arithmetic after the
+      fact once chat became unusable during a sync.

--- a/prisma/server/supervisor.py
+++ b/prisma/server/supervisor.py
@@ -113,6 +113,106 @@ def _query_ollama_resident_mb(base_url: str, timeout: float = 2.0) -> dict[str, 
         return None
 
 
+def _model_vram_profile_path() -> Path:
+    return Path.home() / ".config" / "prisma" / "model_vram_profiles.json"
+
+
+def _load_vram_profiles() -> dict[str, int]:
+    """Auto-learned model -> real resident VRAM MB, from past
+    _probe_model_vram() runs. Distinct from compute_pools.*.models[].vram_mb
+    in config.yaml: that's a manual, user-curated estimate and always wins
+    when present (see _profile_missing_models) — this file only fills in
+    models nobody ever measured by hand."""
+    try:
+        path = _model_vram_profile_path()
+        return json.loads(path.read_text()) if path.exists() else {}
+    except Exception:
+        return {}
+
+
+def _save_vram_profile(model: str, vram_mb: int) -> None:
+    path = _model_vram_profile_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        profiles = _load_vram_profiles()
+        profiles[model] = vram_mb
+        path.write_text(json.dumps(profiles, indent=2))
+    except Exception as exc:
+        log.warning("failed to save vram profile for %s: %s", model, exc)
+
+
+def _probe_model_vram(base_url: str, model: str, timeout: float = 300.0) -> int | None:
+    """One-time empirical measurement: force `model` to load via a trivial
+    generate call, then read its real resident cost back from Ollama's own
+    `/api/ps` — the same manual process used throughout
+    docs/qwen3-family-evaluation.md, automated. Returns None (not 0) if the
+    probe itself fails (Ollama unreachable, model not pulled, etc.) — callers
+    must not treat that as "this model uses 0MB.\""""
+    import urllib.request
+    try:
+        req = urllib.request.Request(
+            f"{base_url}/api/generate",
+            data=json.dumps({
+                "model": model, "prompt": "hi", "stream": False, "options": {"num_predict": 1},
+            }).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            resp.read()
+    except Exception as exc:
+        log.warning("vram profile: failed to load %s for probing: %s", model, exc)
+        return None
+    resident = _query_ollama_resident_mb(base_url)
+    if resident is None or model not in resident:
+        log.warning("vram profile: %s loaded but not found in /api/ps afterward", model)
+        return None
+    return resident[model]
+
+
+def _profile_missing_models(
+    resources: "ResourceManager",
+    pool_models: dict[str, set[str]],
+    pool_vram_budget: dict[str, int | None],
+    affinity: set[str],
+    model_vram: dict[str, dict[str, int]],
+    base_url: str,
+) -> None:
+    """Run once at supervisor startup, in its own daemon thread — for any
+    model in a VRAM-budget-aware pool with neither a config.yaml `vram_mb`
+    nor a previously saved profile, probe it for real and persist the
+    result, updating the live ResourceManager immediately so it takes
+    effect without a restart.
+
+    Deliberately eager (runs right at startup, not lazily on first real
+    acquire() and not gated behind an explicit admin command): trade-off
+    accepted per cservinl's explicit choice — this can evict whatever's
+    already resident and spends GPU time on a model that might not even get
+    used this session, in exchange for every configured model having a real
+    profile before anything production-shaped needs one. Motivated directly
+    by the qwen3:14b-32k / qwen2.5:7b-32k VRAM-conflict incident (see
+    docs/qwen3-family-evaluation.md's Verdict section) — the goal is for
+    the resource manager to eventually be able to sum a pool's models
+    against vram_budget_mb and flag "these don't fit together" before a
+    config change ships, not just react to it after the fact.
+    """
+    saved_profiles = _load_vram_profiles()
+    for pool_name in affinity:
+        if pool_vram_budget.get(pool_name) is None:
+            continue  # not vram-budget-aware — nothing here to inform
+        configured = model_vram.get(pool_name, {})
+        for model in pool_models.get(pool_name, set()):
+            if model in configured or model in saved_profiles:
+                continue
+            log.info("vram profile: probing %s (pool=%s, no config or saved profile)", model, pool_name)
+            vram_mb = _probe_model_vram(base_url, model)
+            if vram_mb is None:
+                continue
+            _save_vram_profile(model, vram_mb)
+            resources.note_model_vram(pool_name, model, vram_mb)
+            log.info("vram profile: %s measured at %dMB, saved", model, vram_mb)
+
+
 def _load_compute_pools() -> tuple[
     dict[str, int], set[str], dict[str, set[str]], dict[str, dict[str, int]],
     dict[str, int | None], dict[str, dict[str, int]], dict[str, dict[str, int]],
@@ -445,6 +545,14 @@ class ResourceManager:
             for name in pools
         }
 
+    def note_model_vram(self, pool: str, model: str, vram_mb: int) -> None:
+        """Record a freshly-measured VRAM estimate for `model` in `pool`
+        without a full reload_config() — used by the startup auto-profiling
+        probe (_profile_missing_models) so a newly-learned profile takes
+        effect immediately, without needing a supervisor restart."""
+        with self._lock:
+            self._model_vram.setdefault(pool, {})[model] = vram_mb
+
     def _candidate_pools(self, pool: str | None, model: str | None) -> list[str]:
         if pool:
             return [pool]
@@ -539,6 +647,23 @@ class ResourceManager:
                                 self._vram_budget[name], resident,
                             )
                             continue
+                elif vram_aware and model is None:
+                    # A vram-aware pool can't check budget/model-busy without
+                    # knowing which model this is for — this endpoint is a
+                    # real network boundary (supervisor.py's HTTP handler
+                    # passes body.get("model") straight through, `None` if a
+                    # request simply omits it), not just an internal
+                    # in-process call every real client happens to populate
+                    # correctly today. Fail safe (deny) rather than silently
+                    # skip the check and let an unidentified model's lease
+                    # through uncounted against the VRAM budget.
+                    self._stats[name]["denied_vram_budget"] += 1
+                    log.info(
+                        "acquire denied: pool=%s holder=%s pid=%d priority=%s "
+                        "reason=vram_budget (no model given, cannot verify VRAM headroom)",
+                        name, holder, pid, priority,
+                    )
+                    continue
                 # Per-model overrides apply on any model_affinity pool. On a
                 # VRAM-budget pool several different models can hold leases
                 # at once, so the count must be scoped to just this model's
@@ -904,7 +1029,18 @@ def main(
         "kg": Worker("kg", [_venv_bin("uvicorn"), "prisma.server.kg_app:app", "--host", host, "--port", str(kg_port)],
                      stop_timeout=15.0, env={"PRISMA_SUPERVISOR_PORT": str(supervisor_port)}),
     }
-    resources = ResourceManager(*_load_compute_pools(), ollama_base_url=_ollama_base_url())
+    capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram, model_background_limit = (
+        _load_compute_pools()
+    )
+    resources = ResourceManager(
+        capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram,
+        model_background_limit, ollama_base_url=_ollama_base_url(),
+    )
+    threading.Thread(
+        target=_profile_missing_models,
+        args=(resources, pool_models, pool_vram_budget, affinity, model_vram, _ollama_base_url()),
+        daemon=True, name="vram-profiler",
+    ).start()
 
     supervisor = Supervisor(workers, resources)
     supervisor.start_all()

--- a/tests/unit/server/test_supervisor_resources.py
+++ b/tests/unit/server/test_supervisor_resources.py
@@ -9,7 +9,16 @@ import time
 from pathlib import Path
 from unittest.mock import patch
 
-from prisma.server.supervisor import ResourceManager, _load_compute_pools, _process_memory_mb, _system_info
+from prisma.server.supervisor import (
+    ResourceManager,
+    _load_compute_pools,
+    _load_vram_profiles,
+    _probe_model_vram,
+    _process_memory_mb,
+    _profile_missing_models,
+    _save_vram_profile,
+    _system_info,
+)
 
 
 def test_acquire_respects_pool_capacity():
@@ -547,6 +556,27 @@ def test_acquire_falls_back_to_strict_affinity_when_ollama_unreachable():
     assert rm.status()["local-ollama"]["stats"]["denied_model_busy"] == 1
 
 
+def test_acquire_denies_vram_aware_pool_when_model_missing():
+    # Real bug this guards against: supervisor.py's HTTP handler passes
+    # body.get("model") straight through, which is None if a request simply
+    # omits it — a real network-boundary case, not just a hypothetical
+    # internal caller. A vram-aware pool can't check budget/model-busy
+    # without knowing which model, so it must fail safe (deny) rather than
+    # silently skip the check and let an unidentified lease through
+    # uncounted against the VRAM budget.
+    rm = ResourceManager(
+        {"local-ollama": 4}, model_affinity={"local-ollama"},
+        vram_budget={"local-ollama": 14000},
+        model_vram={"local-ollama": {"qwen2.5:7b-32k": 7500}},
+    )
+    pid = os.getpid()
+
+    r, rid = rm.acquire("api", pid, model=None)
+
+    assert r is None and rid is None
+    assert rm.status()["local-ollama"]["stats"]["denied_vram_budget"] == 1
+
+
 def test_acquire_per_model_concurrency_still_enforced_on_vram_budget_pool():
     rm = ResourceManager(
         {"local-ollama": 4}, model_affinity={"local-ollama"},
@@ -747,3 +777,58 @@ def test_system_info_reports_cpu_count_and_memory():
     # memory fields may be None on non-Linux, but must be present as keys
     assert "memory_total_mb" in info
     assert "memory_available_mb" in info
+
+
+def test_probe_model_vram_returns_measured_value():
+    with patch("urllib.request.urlopen"), \
+         patch("prisma.server.supervisor._query_ollama_resident_mb", return_value={"qwen3:14b-32k": 11900}):
+        assert _probe_model_vram("http://localhost:11434", "qwen3:14b-32k") == 11900
+
+
+def test_probe_model_vram_returns_none_when_load_call_fails():
+    with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+        assert _probe_model_vram("http://localhost:11434", "qwen3:14b-32k") is None
+
+
+def test_probe_model_vram_returns_none_when_model_not_resident_after_load():
+    with patch("urllib.request.urlopen"), \
+         patch("prisma.server.supervisor._query_ollama_resident_mb", return_value={"other-model": 500}):
+        assert _probe_model_vram("http://localhost:11434", "qwen3:14b-32k") is None
+
+
+def test_save_and_load_vram_profiles_roundtrip(tmp_path, monkeypatch):
+    profile_path = tmp_path / "model_vram_profiles.json"
+    monkeypatch.setattr("prisma.server.supervisor._model_vram_profile_path", lambda: profile_path)
+
+    assert _load_vram_profiles() == {}
+    _save_vram_profile("qwen3:14b-32k", 11900)
+    _save_vram_profile("nomic-embed-text", 1000)
+    assert _load_vram_profiles() == {"qwen3:14b-32k": 11900, "nomic-embed-text": 1000}
+
+
+def test_note_model_vram_updates_live_resource_manager():
+    rm = ResourceManager({"local-ollama": 4}, model_affinity={"local-ollama"}, vram_budget={"local-ollama": 14000})
+    rm.note_model_vram("local-ollama", "qwen3:14b-32k", 11900)
+    assert rm._model_vram["local-ollama"]["qwen3:14b-32k"] == 11900
+
+
+def test_profile_missing_models_skips_configured_and_saved_probes_only_the_rest(tmp_path, monkeypatch):
+    profile_path = tmp_path / "model_vram_profiles.json"
+    monkeypatch.setattr("prisma.server.supervisor._model_vram_profile_path", lambda: profile_path)
+    _save_vram_profile("already-profiled", 1234)
+
+    rm = ResourceManager(
+        {"local-ollama": 4}, model_affinity={"local-ollama"}, vram_budget={"local-ollama": 14000},
+        model_vram={"local-ollama": {"already-configured": 5000}},
+    )
+    pool_models = {"local-ollama": {"already-configured", "already-profiled", "needs-probe"}}
+
+    with patch("prisma.server.supervisor._probe_model_vram", return_value=9000) as probe:
+        _profile_missing_models(
+            rm, pool_models, {"local-ollama": 14000}, {"local-ollama"},
+            {"local-ollama": {"already-configured": 5000}}, "http://localhost:11434",
+        )
+
+    probe.assert_called_once_with("http://localhost:11434", "needs-probe")
+    assert rm._model_vram["local-ollama"]["needs-probe"] == 9000
+    assert _load_vram_profiles() == {"already-profiled": 1234, "needs-probe": 9000}

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -247,6 +247,7 @@
   let hoverExpandTimer: ReturnType<typeof setTimeout> | null = null;
   let activeNode = $state<RenderedNode | null>(null);
   let activeChat = $state<ChatDetail | null>(null);
+  let excerptPollInterval: ReturnType<typeof setInterval> | undefined;
   let chatInput = $state("");
   let chatSending = $state(false);
   let serverOnline = $state(false);
@@ -470,6 +471,7 @@
   }
 
   async function openChat(slug: string) {
+    clearInterval(excerptPollInterval);  // stop any poll for the chat we're leaving, immediately
     activeNode = null;
     showResourcesPage = false;
     showKgProgressPage = false;
@@ -547,10 +549,15 @@
   }
 
   function pollExcerptRegeneration(slug: string) {
-    const interval = setInterval(async () => {
-      if (!activeChat || activeChat.slug !== slug) { clearInterval(interval); return; }
+    // Stop any prior poll immediately rather than letting it self-clear on
+    // its own next 2s tick — that gap is what let a stale poll fire one
+    // wasted request against the wrong (or no-longer-active) chat right
+    // after switching away.
+    clearInterval(excerptPollInterval);
+    excerptPollInterval = setInterval(async () => {
+      if (!activeChat || activeChat.slug !== slug) { clearInterval(excerptPollInterval); return; }
       const r = await fetch(`${apiBase}/chats/${encodeURIComponent(slug)}`);
-      if (!r.ok) { clearInterval(interval); return; }
+      if (!r.ok) { clearInterval(excerptPollInterval); return; }
       const fresh = await r.json();
       // Merge only the Excerpt-related fields — never replace the whole
       // object. A full replace here raced with sendChatMessage's optimistic
@@ -569,7 +576,7 @@
           context_tokens_max: fresh.context_tokens_max,
         };
       }
-      if (!fresh.excerpt_regenerating) clearInterval(interval);
+      if (!fresh.excerpt_regenerating) clearInterval(excerptPollInterval);
     }, 2000);
   }
 
@@ -1436,7 +1443,7 @@
             <button
               class="tree-file"
               class:active={showResourcesPage}
-              onclick={() => { activeNode = null; activeChat = null; showResourcesPage = true; showKgProgressPage = false; }}
+              onclick={() => { clearInterval(excerptPollInterval); activeNode = null; activeChat = null; showResourcesPage = true; showKgProgressPage = false; }}
             >
               <span class="tree-type-dot nt-stream"></span>
               <span class="tree-file-name">Compute pools</span>
@@ -1444,7 +1451,7 @@
             <button
               class="tree-file"
               class:active={showKgProgressPage}
-              onclick={() => { activeNode = null; activeChat = null; showResourcesPage = false; showKgProgressPage = true; }}
+              onclick={() => { clearInterval(excerptPollInterval); activeNode = null; activeChat = null; showResourcesPage = false; showKgProgressPage = true; }}
             >
               <span class="tree-type-dot nt-stream"></span>
               <span class="tree-file-name">Knowledge Graph</span>


### PR DESCRIPTION
## Summary
- Supervisor now auto-profiles any configured model's real VRAM cost at startup (`_probe_model_vram`, `_load_vram_profiles`/`_save_vram_profile`, `_profile_missing_models`) — persisted to `~/.config/prisma/model_vram_profiles.json`, config.yaml's manual `vram_mb` always wins. Motivated by the qwen2.5:7b-32k/qwen3:14b-32k VRAM conflict found this session (see `docs/qwen3-family-evaluation.md`).
- Closes the last 2 open items from the earlier correctness self-audit: `ResourceManager.acquire()` now fails safe (denies) instead of silently skipping the VRAM budget check when a vram-aware pool is called with `model=None`; `+page.svelte`'s `pollExcerptRegeneration` no longer leaks a stale `setInterval` when the user navigates away mid-poll.
- `TODO.md` updated to reflect both items resolved, with a new smaller follow-up split out (warn when a pool's configured models don't fit together, not yet built).

## Test plan
- [x] `pytest tests/unit/server/test_supervisor_resources.py` — 56 passed (6 new)
- [x] `pytest tests/unit` — 393 passed
- [x] `npm run check` in `ui/` — 0 errors
- [x] `npm run build` in `ui/` — succeeds
- [x] `docs/diagrams/gen.sh` — regenerated, no diff