### PR TITLE
Warn when a pool's configured models don't fit their VRAM budget

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -902,13 +902,18 @@ Replaced with a narrower, more useful **Knowledge Graph progress page**
       fit together" (the qwen2.5/qwen3:14b incident's real trigger) — it
       only makes sure every model *has* a real measured profile so that
       check becomes possible later without another live-discovery cycle.
-### Planned follow-up: warn when a pool's configured models don't fit together
 
-- [ ] Now that every configured model gets a real measured VRAM profile
-      (see above), `ResourceManager`/`_load_compute_pools()` could sum a
-      `model_affinity` pool's models' `vram_mb` (config or learned profile)
-      against its `vram_budget_mb` and warn (or refuse to start) at
-      config-load time when they don't fit together — catching the
-      qwen2.5:7b-32k / qwen3:14b-32k incident *before* a config change
-      ships, instead of a human reasoning through the arithmetic after the
-      fact once chat became unusable during a sync.
+### Resolved: warn when a pool's configured models don't fit together
+
+- [x] Implemented 2026-07-06 in `prisma/server/supervisor.py`:
+      `_check_pool_vram_fit()` sums each VRAM-budget-aware pool's models'
+      `vram_mb` (config value, falling back to a saved auto-profile) against
+      `vram_budget_mb`, logging a warning (not a hard failure — a pool that
+      doesn't fit today may still be fine if the user never runs both
+      models at once) naming the total, the budget, and any models excluded
+      from the sum for having neither a config value nor a profile yet.
+      Called twice in `main()`: once immediately at startup with whatever's
+      already known (config + previously saved profiles, no probe wait),
+      and again at the end of `_profile_missing_models()`'s probing pass so
+      newly-learned profiles can surface a conflict that was previously
+      "unknown, can't tell." Tests in `tests/unit/server/test_supervisor_resources.py`.

--- a/prisma/server/supervisor.py
+++ b/prisma/server/supervisor.py
@@ -170,6 +170,53 @@ def _probe_model_vram(base_url: str, model: str, timeout: float = 300.0) -> int 
     return resident[model]
 
 
+def _check_pool_vram_fit(
+    pool_models: dict[str, set[str]],
+    pool_vram_budget: dict[str, int | None],
+    affinity: set[str],
+    model_vram: dict[str, dict[str, int]],
+) -> dict[str, dict]:
+    """Sum each VRAM-budget-aware pool's configured models' vram_mb (a
+    config.yaml value, falling back to a saved auto-profile) against its
+    vram_budget_mb — catches "these models don't fit together" at
+    startup/config-load time instead of a human reasoning through the
+    arithmetic after chat becomes unusable during a sync (the real incident
+    in docs/qwen3-family-evaluation.md's Verdict section: qwen2.5:7b-32k +
+    qwen3:14b-32k + nomic-embed-text summed to 20400MB against a 14000MB
+    budget). Models with neither a config value nor a saved profile are
+    skipped from the sum (unknown, not zero) and reported separately, since
+    their absence makes this check optimistic rather than exact. Returns
+    {pool: {total_mb, budget_mb, unknown_models}} only for pools whose
+    already-known total exceeds budget — callers decide whether to just log
+    or hard-fail on that."""
+    saved_profiles = _load_vram_profiles()
+    problems: dict[str, dict] = {}
+    for pool_name in affinity:
+        budget = pool_vram_budget.get(pool_name)
+        if budget is None:
+            continue
+        configured = model_vram.get(pool_name, {})
+        total = 0
+        unknown: list[str] = []
+        for model in pool_models.get(pool_name, set()):
+            vram_mb = configured.get(model, saved_profiles.get(model))
+            if vram_mb is None:
+                unknown.append(model)
+            else:
+                total += vram_mb
+        if total > budget:
+            problems[pool_name] = {"total_mb": total, "budget_mb": budget, "unknown_models": unknown}
+            log.warning(
+                "vram fit: pool=%s configured models sum to %dMB, over its %dMB vram_budget_mb "
+                "(models excluded from this sum for having no config/profile value yet: %s) — "
+                "these models may not all coexist without an evict-and-reload cycle on every "
+                "switch between them; see docs/qwen3-family-evaluation.md's Verdict for a real "
+                "example of this failure mode",
+                pool_name, total, budget, unknown or "none",
+            )
+    return problems
+
+
 def _profile_missing_models(
     resources: "ResourceManager",
     pool_models: dict[str, set[str]],
@@ -191,10 +238,11 @@ def _profile_missing_models(
     used this session, in exchange for every configured model having a real
     profile before anything production-shaped needs one. Motivated directly
     by the qwen3:14b-32k / qwen2.5:7b-32k VRAM-conflict incident (see
-    docs/qwen3-family-evaluation.md's Verdict section) — the goal is for
-    the resource manager to eventually be able to sum a pool's models
-    against vram_budget_mb and flag "these don't fit together" before a
-    config change ships, not just react to it after the fact.
+    docs/qwen3-family-evaluation.md's Verdict section) — once every
+    configured model has a real profile, _check_pool_vram_fit() (called at
+    the end of this function) can sum a pool's models against
+    vram_budget_mb and flag "these don't fit together" before a config
+    change ships, not just react to it after the fact.
     """
     saved_profiles = _load_vram_profiles()
     for pool_name in affinity:
@@ -211,6 +259,11 @@ def _profile_missing_models(
             _save_vram_profile(model, vram_mb)
             resources.note_model_vram(pool_name, model, vram_mb)
             log.info("vram profile: %s measured at %dMB, saved", model, vram_mb)
+    # Re-check with the now-complete picture — a conflict previously
+    # "unknown model, can't tell" may now be a known "doesn't fit," since
+    # _check_pool_vram_fit re-reads the profile file fresh (includes
+    # whatever was just probed and saved above).
+    _check_pool_vram_fit(pool_models, pool_vram_budget, affinity, model_vram)
 
 
 def _load_compute_pools() -> tuple[
@@ -1036,6 +1089,11 @@ def main(
         capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram,
         model_background_limit, ollama_base_url=_ollama_base_url(),
     )
+    # Best-effort check with whatever's already known (config + previously
+    # saved profiles) — don't wait for the profiling thread below, which can
+    # take minutes if several models need a fresh probe. Re-checked with the
+    # complete picture at the end of that thread too.
+    _check_pool_vram_fit(pool_models, pool_vram_budget, affinity, model_vram)
     threading.Thread(
         target=_profile_missing_models,
         args=(resources, pool_models, pool_vram_budget, affinity, model_vram, _ollama_base_url()),

--- a/tests/unit/server/test_supervisor_resources.py
+++ b/tests/unit/server/test_supervisor_resources.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from prisma.server.supervisor import (
     ResourceManager,
+    _check_pool_vram_fit,
     _load_compute_pools,
     _load_vram_profiles,
     _probe_model_vram,
@@ -832,3 +833,52 @@ def test_profile_missing_models_skips_configured_and_saved_probes_only_the_rest(
     probe.assert_called_once_with("http://localhost:11434", "needs-probe")
     assert rm._model_vram["local-ollama"]["needs-probe"] == 9000
     assert _load_vram_profiles() == {"already-profiled": 1234, "needs-probe": 9000}
+
+
+def test_check_pool_vram_fit_flags_pool_over_budget_from_config_alone(tmp_path, monkeypatch):
+    monkeypatch.setattr("prisma.server.supervisor._model_vram_profile_path", lambda: tmp_path / "profiles.json")
+    pool_models = {"local-ollama": {"qwen2.5:7b-32k", "qwen3:14b-32k", "nomic-embed-text"}}
+    model_vram = {"local-ollama": {"qwen2.5:7b-32k": 7500, "qwen3:14b-32k": 11900, "nomic-embed-text": 1000}}
+
+    problems = _check_pool_vram_fit(pool_models, {"local-ollama": 14000}, {"local-ollama"}, model_vram)
+
+    assert problems == {"local-ollama": {"total_mb": 20400, "budget_mb": 14000, "unknown_models": []}}
+
+
+def test_check_pool_vram_fit_falls_back_to_saved_profile_when_config_missing(tmp_path, monkeypatch):
+    profile_path = tmp_path / "profiles.json"
+    monkeypatch.setattr("prisma.server.supervisor._model_vram_profile_path", lambda: profile_path)
+    _save_vram_profile("qwen3:14b-32k", 11900)
+    pool_models = {"local-ollama": {"qwen2.5:7b-32k", "qwen3:14b-32k"}}
+    model_vram = {"local-ollama": {"qwen2.5:7b-32k": 7500}}  # qwen3:14b-32k only has a saved profile
+
+    problems = _check_pool_vram_fit(pool_models, {"local-ollama": 14000}, {"local-ollama"}, model_vram)
+
+    assert problems["local-ollama"]["total_mb"] == 19400
+
+
+def test_check_pool_vram_fit_excludes_unknown_models_from_sum_and_reports_them(tmp_path, monkeypatch):
+    monkeypatch.setattr("prisma.server.supervisor._model_vram_profile_path", lambda: tmp_path / "profiles.json")
+    pool_models = {"local-ollama": {"qwen2.5:7b-32k", "qwen3:14b-32k", "brand-new-model"}}
+    model_vram = {"local-ollama": {"qwen2.5:7b-32k": 7500, "qwen3:14b-32k": 11900}}
+
+    problems = _check_pool_vram_fit(pool_models, {"local-ollama": 14000}, {"local-ollama"}, model_vram)
+
+    assert problems["local-ollama"]["unknown_models"] == ["brand-new-model"]
+    assert problems["local-ollama"]["total_mb"] == 19400  # unknown model excluded, not treated as 0
+
+
+def test_check_pool_vram_fit_returns_empty_when_pool_fits(tmp_path, monkeypatch):
+    monkeypatch.setattr("prisma.server.supervisor._model_vram_profile_path", lambda: tmp_path / "profiles.json")
+    pool_models = {"local-ollama": {"qwen2.5:7b-32k", "nomic-embed-text"}}
+    model_vram = {"local-ollama": {"qwen2.5:7b-32k": 7500, "nomic-embed-text": 1000}}
+
+    assert _check_pool_vram_fit(pool_models, {"local-ollama": 14000}, {"local-ollama"}, model_vram) == {}
+
+
+def test_check_pool_vram_fit_skips_pool_without_vram_budget(tmp_path, monkeypatch):
+    monkeypatch.setattr("prisma.server.supervisor._model_vram_profile_path", lambda: tmp_path / "profiles.json")
+    pool_models = {"local-ollama": {"model-a", "model-b"}}
+    model_vram = {"local-ollama": {"model-a": 999999, "model-b": 999999}}
+
+    assert _check_pool_vram_fit(pool_models, {"local-ollama": None}, {"local-ollama"}, model_vram) == {}


### PR DESCRIPTION
## Summary
- `_check_pool_vram_fit()` sums each VRAM-budget-aware pool's models' `vram_mb` (config value, falling back to a saved auto-profile from #27) against `vram_budget_mb`, logging a warning naming the total, budget, and any models excluded from the sum for lacking a known cost.
- Called at supervisor startup (best-effort, whatever's already known) and again at the end of the VRAM auto-profiling pass, so a conflict that was "unknown, can't tell" at boot can surface once profiling fills in the gaps.
- `TODO.md`'s follow-up item marked resolved.

## Test plan
- [x] `pytest tests/unit/server/test_supervisor_resources.py` — 61 passed (5 new)
- [x] `pytest tests/unit` — 398 passed
- [x] `docs/diagrams/gen.sh` — regenerated, no diff