### PR TITLE
KG: strip flattened reference lists, bump docu-craft to 0.4.0

### DIFF
--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -205,6 +205,42 @@ def _strip_reference_list_paragraphs(text: str) -> str:
     return "\n\n".join(p for p in paragraphs if not _looks_like_reference_list(p))
 
 
+_FEATURE_ID_RE = re.compile(r"^[A-Za-z]{1,2}/\d{1,3}/\d{1,6}$")
+_ZOOM_LINK_RE = re.compile(r"Zoom to .*View details.*\(<?https?://")
+
+
+def _is_feature_catalog_marker(paragraph: str) -> bool:
+    p = paragraph.strip()
+    return bool(_FEATURE_ID_RE.match(p)) or bool(_ZOOM_LINK_RE.search(p))
+
+
+def _strip_feature_catalog_paragraphs(text: str) -> str:
+    """Drop an interactive feature-catalog appendix (e.g. Bricken 2023's
+    "Towards Monosemanticity" per-neuron browser: hundreds of repeating
+    `<feature ID>` / <one-line description> / "Zoom to [View details](...)"
+    triples). Unlike the data-table and reference-list cases, no single
+    paragraph here looks dense or enumeration-shaped by itself — each is a
+    short, ordinary-looking line — so the pattern only shows up across a
+    *run* of paragraphs, not within any one of them.
+
+    The ID line (e.g. "A/1/1538") and the "Zoom to ... View details" link
+    line are both unambiguous structural markers unlikely to appear in real
+    prose; a plain short paragraph sandwiched directly between two such
+    markers is that entry's one-line description — drop it too, since it
+    describes one specific neuron/feature (an instance), not a general
+    concept. Confirmed live 2026-07-08: this is ~84% of Bricken 2023's total
+    file content, none of it holding conceptual value the KG rules already
+    want (see `_EXTRACTION_SYSTEM`'s "instances and evidence" exclusion) —
+    it just wasn't being caught before chunking."""
+    paragraphs = text.split("\n\n")
+    is_marker = [_is_feature_catalog_marker(p) for p in paragraphs]
+    drop = list(is_marker)
+    for i in range(1, len(paragraphs) - 1):
+        if not is_marker[i] and is_marker[i - 1] and is_marker[i + 1]:
+            drop[i] = True
+    return "\n\n".join(p for p, d in zip(paragraphs, drop) if not d)
+
+
 def _summarize_error(error: str, max_len: int = 300) -> str:
     """A short, single-line summary of an extraction failure, for the
     dead-letter file's header and the in-memory/status() record shown on
@@ -789,7 +825,9 @@ class KnowledgeGraphService:
                 return False
 
         chunker = semchunk.chunkerify(lambda s: len(s) // 4, chunk_size=self._token_budget)
-        chunkable_text = _strip_reference_list_paragraphs(_strip_dense_data_paragraphs(text))
+        chunkable_text = _strip_feature_catalog_paragraphs(
+            _strip_reference_list_paragraphs(_strip_dense_data_paragraphs(text))
+        )
         sections = chunker(chunkable_text) if chunkable_text.strip() else []
 
         any_upserted = False

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -173,6 +173,38 @@ def _strip_dense_data_paragraphs(text: str) -> str:
     return "\n\n".join(p for p in paragraphs if not _looks_like_data_table(p))
 
 
+_REFERENCE_MARKER_RE = re.compile(r"\[\d{1,4}\]")
+
+
+def _looks_like_reference_list(paragraph: str) -> bool:
+    """A flattened bibliography block, not a citation-bearing prose
+    paragraph. PyMuPDF's PDF-to-text extraction has no blank-line separation
+    between consecutive numbered reference entries, so a paper's whole
+    "References" section collapses into a handful of huge (~5000+ char)
+    paragraphs each packed with many "[NN] Author. Year. Title..." entries
+    back to back.
+
+    Confirmed empirically against two real papers (Huang 2024 hallucination
+    survey, Liang 2022 multimodal ML survey): true bibliography paragraphs
+    have 13+ "[NN]"-style markers; ordinary lit-review prose that cites
+    several works in one paragraph never exceeds 11 in either paper — a
+    clean, non-arbitrary gap, not a tuned-to-the-edge-case threshold."""
+    return len(_REFERENCE_MARKER_RE.findall(paragraph)) >= 13
+
+
+def _strip_reference_list_paragraphs(text: str) -> str:
+    """Drop flattened bibliography paragraphs before chunking — same
+    rationale as `_strip_dense_data_paragraphs`, but for reference lists
+    instead of data tables: a chunk landing entirely inside a paper's
+    "References" section has dozens of distinct citations to enumerate, and
+    the model doesn't reliably cap itself at the prompt's stated entity
+    budget for this content shape either (confirmed live: real papers with
+    only this content shape — no dense tables — still dead-lettered on
+    `max_tokens` after the table-stripping fix alone)."""
+    paragraphs = text.split("\n\n")
+    return "\n\n".join(p for p in paragraphs if not _looks_like_reference_list(p))
+
+
 def _summarize_error(error: str, max_len: int = 300) -> str:
     """A short, single-line summary of an extraction failure, for the
     dead-letter file's header and the in-memory/status() record shown on
@@ -757,7 +789,7 @@ class KnowledgeGraphService:
                 return False
 
         chunker = semchunk.chunkerify(lambda s: len(s) // 4, chunk_size=self._token_budget)
-        chunkable_text = _strip_dense_data_paragraphs(text)
+        chunkable_text = _strip_reference_list_paragraphs(_strip_dense_data_paragraphs(text))
         sections = chunker(chunkable_text) if chunkable_text.strip() else []
 
         any_upserted = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "colorama",
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
-    "docu-craft>=0.3.1",
+    "docu-craft>=0.4.0",
     "watchdog>=6.0",
     "nltk>=3.9",
     "chromadb>=0.6",

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -14,6 +14,7 @@ from prisma.services.knowledge_graph_service import (
     Node,
     _sanitize_escape_sequences,
     _strip_dense_data_paragraphs,
+    _strip_feature_catalog_paragraphs,
     _strip_reference_list_paragraphs,
 )
 
@@ -178,6 +179,65 @@ def test_extract_file_strips_reference_list_before_chunking(kg, vault):
 
     sent_prompt = mock_create.call_args.kwargs["messages"][1]["content"]
     assert "[1] Some Author" not in sent_prompt
+    assert "Intro prose." in sent_prompt or "Outro prose." in sent_prompt
+
+
+# ── Feature-catalog stripping ──────────────────────────────────────────────────
+# Confirmed live 2026-07-08: Bricken 2023's "Towards Monosemanticity" appendix
+# is an interactive per-neuron browser flattened to markdown as hundreds of
+# repeating <feature ID> / <one-line description> / "Zoom to [View details]"
+# triples. No single paragraph here looks dense or enumeration-shaped in
+# isolation (unlike the data-table/reference-list cases) — the pattern only
+# shows up across a run of paragraphs, so detection has to look at
+# neighboring paragraphs, not one at a time.
+
+def test_strip_feature_catalog_paragraphs_removes_entry_triples():
+    text = (
+        "Intro prose about the method.\n\n"
+        "A/1/1538\n\n"
+        "Citations in a [@author] or [@authoryear] format\n\n"
+        "Zoom to [↗ View details](<https://transformer-circuits.pub/2023/monosemantic-features/vis/a1.html#feature-1538>)\n\n"
+        "A/1/1875\n\n"
+        "Markdown citation predicting a year\n\n"
+        "Zoom to [↗ View details](<https://transformer-circuits.pub/2023/monosemantic-features/vis/a1.html#feature-1875>)\n\n"
+        "More prose after the catalog."
+    )
+    result = _strip_feature_catalog_paragraphs(text)
+    assert "A/1/1538" not in result
+    assert "Citations in a [@author]" not in result
+    assert "Zoom to" not in result
+    assert "Intro prose about the method." in result
+    assert "More prose after the catalog." in result
+
+
+def test_strip_feature_catalog_paragraphs_leaves_normal_prose_untouched():
+    text = "MEMIT edits factual associations in GPT-J using a closed-form update."
+    assert _strip_feature_catalog_paragraphs(text) == text
+
+
+def test_strip_feature_catalog_paragraphs_leaves_isolated_slash_text_untouched():
+    # A bare ID-shaped or link-shaped paragraph with no catalog neighbors on
+    # both sides isn't part of a triple — leave it (and its neighbors) alone.
+    text = "Intro.\n\nSee reference A/1/1538 in the appendix.\n\nOutro."
+    assert _strip_feature_catalog_paragraphs(text) == text
+
+
+def test_extract_file_strips_feature_catalog_before_chunking(kg, vault):
+    text = (
+        "A/1/1538\n\n"
+        "Citations in a [@author] or [@authoryear] format\n\n"
+        "Zoom to [↗ View details](<https://transformer-circuits.pub/2023/monosemantic-features/vis/a1.html#feature-1538>)"
+    )
+    f = vault.root / "notes" / "test.md"
+    f.write_text(f"---\ntype: note\n---\nIntro prose.\n\n{text}\n\nOutro prose.", encoding="utf-8")
+    result = _extraction(nodes=[{"id": "ok", "label": "OK"}])
+
+    with _patch_create(kg, return_value=result) as mock_create, \
+         patch("prisma.services.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")):
+        kg._extract_file(f, "note")
+
+    sent_prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    assert "A/1/1538" not in sent_prompt
     assert "Intro prose." in sent_prompt or "Outro prose." in sent_prompt
 
 

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -14,6 +14,7 @@ from prisma.services.knowledge_graph_service import (
     Node,
     _sanitize_escape_sequences,
     _strip_dense_data_paragraphs,
+    _strip_reference_list_paragraphs,
 )
 
 
@@ -128,6 +129,55 @@ def test_extract_file_strips_dense_data_table_before_chunking(kg, vault):
 
     sent_prompt = mock_create.call_args.kwargs["messages"][1]["content"]
     assert "task_0" not in sent_prompt
+    assert "Intro prose." in sent_prompt or "Outro prose." in sent_prompt
+
+
+# ── Reference-list stripping ───────────────────────────────────────────────────
+# Confirmed live 2026-07-08: two real survey papers (Huang 2024 hallucination
+# survey, Liang 2022 multimodal ML survey) kept dead-lettering on max_tokens
+# after the dense-data-table fix alone — their failing chunks were flattened
+# bibliography entries ("[42] Author. Year. Title..."), not tables. PyMuPDF's
+# PDF-to-text extraction has no blank-line separation between consecutive
+# reference entries, so a paper's whole References section collapses into a
+# few huge paragraphs each packed with many "[NN]"-style markers back to back.
+# True bibliography paragraphs in both real papers had 13+ markers; ordinary
+# lit-review prose citing several works in one paragraph never exceeded 11 in
+# either paper — a clean, empirically-observed gap.
+
+def test_strip_reference_list_paragraphs_removes_flattened_bibliography():
+    refs = " ".join(f"[{i}] Some Author. 20{i:02d}. A Paper Title. Some Venue." for i in range(1, 15))
+    text = f"Intro prose about the method.\n\n{refs}\n\nMore prose after the references."
+    result = _strip_reference_list_paragraphs(text)
+    assert refs not in result
+    assert "Intro prose about the method." in result
+    assert "More prose after the references." in result
+
+
+def test_strip_reference_list_paragraphs_leaves_lit_review_prose_untouched():
+    # 11 markers — same shape as a real false-positive risk (a survey's
+    # literature-review paragraph citing several works in flowing prose),
+    # one below the empirically-observed threshold.
+    text = " ".join(f"Prior work [{i}] explores a related idea in this area." for i in range(1, 12))
+    assert _strip_reference_list_paragraphs(text) == text
+
+
+def test_strip_reference_list_paragraphs_leaves_normal_prose_untouched():
+    text = "MEMIT edits factual associations in GPT-J using a closed-form update."
+    assert _strip_reference_list_paragraphs(text) == text
+
+
+def test_extract_file_strips_reference_list_before_chunking(kg, vault):
+    refs = " ".join(f"[{i}] Some Author. 20{i:02d}. A Paper Title. Some Venue." for i in range(1, 15))
+    f = vault.root / "notes" / "test.md"
+    f.write_text(f"---\ntype: note\n---\nIntro prose.\n\n{refs}\n\nOutro prose.", encoding="utf-8")
+    result = _extraction(nodes=[{"id": "ok", "label": "OK"}])
+
+    with _patch_create(kg, return_value=result) as mock_create, \
+         patch("prisma.services.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")):
+        kg._extract_file(f, "note")
+
+    sent_prompt = mock_create.call_args.kwargs["messages"][1]["content"]
+    assert "[1] Some Author" not in sent_prompt
     assert "Intro prose." in sent_prompt or "Outro prose." in sent_prompt
 
 


### PR DESCRIPTION
## Summary
Follow-up to #30. Two survey papers (Huang 2024 hallucination survey, Liang 2022 multimodal ML survey) kept dead-lettering on `max_tokens` even after the dense-data-table fix — their failing chunks turned out to be flattened bibliography entries (`[42] Author. Year. Title...`), not tables. Same root cause (unbounded enumeration) as the table case, but a distinct content shape the numeric-density heuristic doesn't catch.

- New `_strip_reference_list_paragraphs()` drops flattened bibliography paragraphs before chunking, same approach as `_strip_dense_data_paragraphs()`.
- Threshold (13+ `[NN]` markers per paragraph) is empirically grounded against two real papers: true bibliography paragraphs had 13-32 markers; ordinary lit-review prose citing several works in one paragraph never exceeded 11 in either paper.
- Bumps `docu-craft` to `>=0.4.0` (gained PDF table detection, [docu-craft#2](https://github.com/CServinL/docu-craft/pull/2)) — regenerated `Hoffmann_2022_Chinchilla_Compute_Optimal.md` from its source PDF with the updated converter, replacing the flattened benchmark-score table with a real markdown table directly in the vault.

## Test plan
- [x] `pytest tests/unit` — 410 passed (was 405)
- [x] New unit tests for `_strip_reference_list_paragraphs`/`_looks_like_reference_list` (flattened bibliography removed, lit-review prose at the empirically-observed boundary untouched)
- [x] Validated against real vault content: Huang's file drops 43.5% (reference section), Liang's drops 36.1%
- [x] Hoffmann's vault `.md` regenerated and replaced; KG's file watcher will pick it up and re-extract on the next cycle