### PR TITLE
KG: sync_total reflects files needing reprocessing, not every vault file

### DIFF
--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -940,7 +940,7 @@ class KnowledgeGraphService:
         changed = 0
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
             next_index = 0
-            in_flight: dict[concurrent.futures.Future, None] = {}
+            in_flight: dict[concurrent.futures.Future, Path] = {}
 
             def _submit_next() -> None:
                 nonlocal next_index
@@ -949,7 +949,8 @@ class KnowledgeGraphService:
                 if next_index >= len(paths):
                     return
                 path = paths[next_index]
-                in_flight[pool.submit(self._extract_file, path, self._trust_tier_for(path), generation)] = None
+                future = pool.submit(self._extract_file, path, self._trust_tier_for(path), generation)
+                in_flight[future] = path
                 next_index += 1
 
             for _ in range(max_workers):
@@ -957,11 +958,11 @@ class KnowledgeGraphService:
             while in_flight:
                 done, _ = concurrent.futures.wait(list(in_flight), return_when=concurrent.futures.FIRST_COMPLETED)
                 for future in done:
-                    del in_flight[future]
+                    path = in_flight.pop(future)
                     if future.result():
                         changed += 1
                     if on_file_done:
-                        on_file_done()
+                        on_file_done(path)
                     _submit_next()
         return changed
 
@@ -996,14 +997,42 @@ class KnowledgeGraphService:
         try:
             all_files = [p for p in self._vault._all_md_files() if p.suffix in self.index_extensions]
             _log.info("knowledge graph full index start: %d files total", len(all_files))
-            self._set_activity(f"scanning {len(all_files)} file(s), up to {self._extraction_concurrency} concurrent")
+
+            # A fresh restart's full index still walks every file (a changed
+            # or brand-new file must never be missed), but most vault files
+            # already succeeded last time and are unchanged — an instant
+            # hash-check skip, no real work. Counting those toward "sync_total"
+            # made the progress page's "X of Y" wildly misleading: a full
+            # restart always starts back at "0 of 102," even though maybe 4
+            # files actually need real (slow, possibly failing) extraction —
+            # the other 98 are free. Pre-scanning by content hash up front
+            # lets the displayed total reflect only files that actually need
+            # work, matching what a restart will actually spend time on.
+            needs_processing: set[str] = set()
+            for path in all_files:
+                try:
+                    rel = str(path.relative_to(self._vault.root))
+                    text = path.read_text(encoding="utf-8", errors="replace")
+                except (OSError, ValueError):
+                    continue
+                content_hash = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+                with self._lock:
+                    if self._indexed_hash(rel) != content_hash:
+                        needs_processing.add(rel)
+
+            self._set_activity(
+                f"scanning {len(all_files)} file(s), {len(needs_processing)} need reprocessing, "
+                f"up to {self._extraction_concurrency} concurrent"
+            )
             with self._lock:
-                self._sync_total = len(all_files)
+                self._sync_total = len(needs_processing)
                 self._sync_done = 0
 
-            def _on_file_done() -> None:
+            def _on_file_done(path: Path) -> None:
+                rel = str(path.relative_to(self._vault.root))
                 with self._lock:
-                    self._sync_done += 1
+                    if rel in needs_processing:
+                        self._sync_done += 1
 
             changed = self._extract_files_concurrently(all_files, on_file_done=_on_file_done, generation=generation)
             with self._lock:

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -2,6 +2,7 @@
 graph module that replaces the third-party `graphify` pip dependency.
 See TODO.md and docs/wiki/adr/ADR-012-process-supervision.md.
 """
+import hashlib
 from pathlib import Path
 from unittest.mock import patch
 
@@ -550,7 +551,7 @@ def test_full_index_tracks_progress_while_running(kg, vault):
     def fake_extract_files_concurrently(paths, on_file_done=None, generation=None):
         seen_total["sync_total"] = kg.status()["sync_total"]
         if on_file_done:
-            on_file_done()
+            on_file_done(paths[0])
             seen_total["sync_done_after_one"] = kg.status()["sync_done"]
         return 0
 
@@ -559,6 +560,36 @@ def test_full_index_tracks_progress_while_running(kg, vault):
 
     assert seen_total["sync_total"] == 2
     assert seen_total["sync_done_after_one"] == 1
+
+
+def test_full_index_sync_total_excludes_already_indexed_files(kg, vault):
+    # Real bug this guards against: a fresh restart always walks every vault
+    # file (a changed/new file must never be missed), but most files already
+    # succeeded last time and are an instant hash-check skip — no real work.
+    # Counting those toward sync_total made "X of Y" wildly misleading (e.g.
+    # "0 of 102" on every restart even when only a couple of files actually
+    # need real extraction). sync_total must reflect only files whose
+    # content hash doesn't match what's already indexed.
+    already_indexed = vault.root / "notes" / "already.md"
+    already_indexed.write_text("---\ntype: note\n---\nUnchanged content.", encoding="utf-8")
+    needs_work = vault.root / "notes" / "new.md"
+    needs_work.write_text("---\ntype: note\n---\nBrand new content.", encoding="utf-8")
+
+    rel = str(already_indexed.relative_to(vault.root))
+    content_hash = hashlib.sha256(already_indexed.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+    with kg._lock:
+        kg._set_indexed_hash(rel, content_hash)
+
+    seen_total = {}
+
+    def fake_extract_files_concurrently(paths, on_file_done=None, generation=None):
+        seen_total["sync_total"] = kg.status()["sync_total"]
+        return 0
+
+    with patch.object(kg, "_extract_files_concurrently", side_effect=fake_extract_files_concurrently):
+        kg._full_index()
+
+    assert seen_total["sync_total"] == 1
 
 
 def test_extract_file_tracks_current_file_chunk_progress(kg, vault):


### PR DESCRIPTION
## Summary
The KG progress page's "X of Y" (`sync_total`/`sync_done`) counted every `.md` file in the vault, regardless of whether it actually needed real extraction work. Most files already succeeded and are unchanged — an instant hash-check skip. A restart always resets the counter to "0 of 102," even when only a handful of files (the ones that keep failing, e.g. Bricken/Hoffmann before their fixes) actually need real, possibly slow/failing work — making the progress bar look stuck or misleading across restarts when really it was mostly free skips plus a few genuinely slow files.

`_full_index()` now pre-scans all files by content hash (cheap: read + sha256, no LLM calls) before starting, and sets `sync_total` to the count that actually differs from what's indexed. The real processing loop is unchanged — every file is still walked (so a file that changes mid-scan is still caught) — only the displayed total/done counts change.

Also changed `_extract_files_concurrently`'s `on_file_done` callback to receive the completed file's `Path` (was argument-less), so `_full_index` can tell whether a given completed file was one that needed real work before counting it.

## Test plan
- [x] `pytest tests/unit` — 407 passed
- [x] New test: `sync_total` excludes an already-indexed, unchanged file, counting only the one that actually needs reprocessing
- [x] Updated existing progress-tracking test for the new `on_file_done(path)` signature