### PR TITLE
Reorganize vault sidebar and switch UI icons to filled shapes

### DIFF
--- a/prisma/agents/chat_agent.py
+++ b/prisma/agents/chat_agent.py
@@ -120,9 +120,9 @@ class ChatAgent:
         return self._llm.complete(messages)
 
     def respond(
-        self, history: list[ChatMessage], user_text: str, promoted_notes: list[Note] | None = None,
+        self, history: list[ChatMessage], user_text: str, excerpt_notes: list[Note] | None = None,
     ) -> ChatMessage:
-        messages = [{"role": "system", "content": self._full_system_prompt(promoted_notes or [])}]
+        messages = [{"role": "system", "content": self._full_system_prompt(excerpt_notes or [])}]
         for m in self._bounded_history(history):
             messages.append({"role": m.role.value, "content": m.content})
         messages.append({"role": "user", "content": user_text})
@@ -158,25 +158,25 @@ class ChatAgent:
             tool_calls=tool_calls,
         )
 
-    def context_usage(self, history: list[ChatMessage], promoted_notes: list[Note] | None = None) -> tuple[int, int]:
+    def context_usage(self, history: list[ChatMessage], excerpt_notes: list[Note] | None = None) -> tuple[int, int]:
         """(tokens_used, max_tokens) for the UI's context label — the same
         assembly `respond()` sends (system prompt + tool section + Excerpt +
         bounded history), estimated with the same len(s)//4 heuristic used
         throughout this codebase. max_tokens is `max_history_tokens` (the
         session's configured budget), not the backend's raw context ceiling
         — see ADR-015's "Resolved" section for why."""
-        system_prompt = self._full_system_prompt(promoted_notes or [])
+        system_prompt = self._full_system_prompt(excerpt_notes or [])
         bounded = self._bounded_history(history)
         used = _estimate_tokens(system_prompt) + sum(_estimate_tokens(m.content) for m in bounded)
         return used, self._max_history_tokens
 
-    def _full_system_prompt(self, promoted_notes: list[Note]) -> str:
+    def _full_system_prompt(self, excerpt_notes: list[Note]) -> str:
         parts = [self._system_prompt, system_prompt_tool_section()]
-        if promoted_notes:
-            parts.append(self._promoted_context_block(promoted_notes))
+        if excerpt_notes:
+            parts.append(self._excerpt_context_block(excerpt_notes))
         return "\n\n".join(parts)
 
-    def _promoted_context_block(self, promoted_notes: list[Note]) -> str:
+    def _excerpt_context_block(self, excerpt_notes: list[Note]) -> str:
         # Deliberately NOT subject to _bounded_history's rolling truncation —
         # this is durable, user-curated ground truth for this conversation
         # (see TODO.md: "meeting notes," not the raw "meeting" transcript),
@@ -185,7 +185,7 @@ class ChatAgent:
             "Already established in this conversation (curated by the user "
             "— treat as settled, don't re-litigate or re-ask about these):",
         ]
-        for note in promoted_notes:
+        for note in excerpt_notes:
             lines.append(f"\n### {note.title}\n{note.body}")
         return "\n".join(lines)
 

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -596,15 +596,15 @@ def _with_context_usage(chat_node: Chat) -> Chat:
     """Attaches response-only fields (ADR-015) — not persisted, computed
     fresh on every response since they depend on the live-configured
     ChatAgent / in-memory regeneration state, not stored chat data."""
-    promoted_notes = []
+    excerpt_notes = []
     if chat_node.excerpt_slug:
         try:
             note = _vault.get_note(chat_node.excerpt_slug)
-            promoted_notes.append(note)
+            excerpt_notes.append(note)
             chat_node.excerpt_summary_html = _excerpt_summary_html(note.body)
         except FileNotFoundError:
             pass
-    used, maximum = _chat_agent.context_usage(chat_node.messages, promoted_notes=promoted_notes)
+    used, maximum = _chat_agent.context_usage(chat_node.messages, excerpt_notes=excerpt_notes)
     chat_node.context_tokens_used = used
     chat_node.context_tokens_max = maximum
     with _excerpt_regenerating_lock:
@@ -630,14 +630,14 @@ def chat(req: ChatRequest):
     # The chat's single Excerpt (ADR-015) is durable context — always
     # included, independent of the (bounded, rolling) raw history, so the
     # model doesn't re-litigate what's already been settled.
-    promoted_notes = []
+    excerpt_notes = []
     if chat_node.excerpt_slug:
         try:
-            promoted_notes.append(_vault.get_note(chat_node.excerpt_slug))
+            excerpt_notes.append(_vault.get_note(chat_node.excerpt_slug))
         except FileNotFoundError:
             _log.warning("chat %r: excerpt note %r no longer exists", chat_node.slug, chat_node.excerpt_slug)
     user_msg = ChatMessage(role=ChatRole.user, content=req.message)
-    assistant_msg = _chat_agent.respond(history, req.message, promoted_notes=promoted_notes)
+    assistant_msg = _chat_agent.respond(history, req.message, excerpt_notes=excerpt_notes)
     # append_messages (not save_chat with the pre-call `history` snapshot)
     # re-reads the chat's *current* messages atomically right before
     # writing — closes the race where a DELETE /chats/{slug}/messages/{index}

--- a/prisma/server/kg_app.py
+++ b/prisma/server/kg_app.py
@@ -145,6 +145,12 @@ def taint_file(rel: str = Query(...)):
     return {"tainted": tainted}
 
 
+@app.post("/clear_dead_letters")
+def clear_dead_letters():
+    removed = _kg.clear_dead_letters()
+    return {"removed": removed}
+
+
 @app.get("/entities_for_file")
 def entities_for_file(rel: str = Query(...)):
     return _kg.entities_for_file(rel)

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -520,6 +520,26 @@ class KnowledgeGraphService:
             self._current_file_chunks_done = 0
         threading.Thread(target=self._full_index, daemon=True, name="knowledge-graph-reindex").start()
 
+    def clear_dead_letters(self) -> int:
+        """Delete every dead-letter file on disk and reset the in-memory
+        drop counters/recent list. Does not touch `_dropped_chunks_total`'s
+        history for files already re-extracted successfully — those chunks
+        aren't dropped anymore, so nothing to preserve. Returns how many
+        files were deleted."""
+        dead_letter_dir = self._kg_dir / "dead_letters"
+        removed = 0
+        if dead_letter_dir.is_dir():
+            for path in dead_letter_dir.glob("*.txt"):
+                try:
+                    path.unlink()
+                    removed += 1
+                except OSError as exc:
+                    _log.warning("failed to remove dead-letter file %s: %s", path, exc)
+        with self._lock:
+            self._dropped_chunks.clear()
+            self._dropped_chunks_total = 0
+        return removed
+
     def _ollama_ready(self) -> bool:
         import socket
         try:

--- a/prisma/services/vault.py
+++ b/prisma/services/vault.py
@@ -162,7 +162,7 @@ class VaultService:
         self,
         vault_root: Path | str | None = None,
         default_notes: str = "notes",
-        default_sources: str = "sources",
+        default_sources: str = "Zotero Imported",
         default_chats: str = "chats",
     ) -> None:
         self.root = Path(vault_root or Path.home() / "prisma-vault").expanduser().resolve()
@@ -326,7 +326,7 @@ class VaultService:
             title=fm.get("title") or _first_heading(content) or path.stem,
             tags=list(dict.fromkeys(tags)),
             body=content,
-            promoted_from_chat=fm.get("promoted_from_chat"),
+            excerpt_of_chat=fm.get("excerpt_of_chat"),
             path=path,
             created_at=datetime.fromtimestamp(stat.st_mtime),
             modified_at=datetime.fromtimestamp(stat.st_mtime),
@@ -464,7 +464,7 @@ class VaultService:
                     return self.save_note(chat.excerpt_slug, body)
                 except FileNotFoundError:
                     pass  # note deleted underneath us — fall through to create a fresh one
-            note = self.create_note(f"Excerpt — {chat.title}", body=body, promoted_from_chat=chat_slug)
+            note = self.create_note(f"Excerpt — {chat.title}", body=body, excerpt_of_chat=chat_slug)
             chat_path = self._find_md(chat_slug)
             raw = chat_path.read_text(encoding="utf-8")
             fm, content = _parse_frontmatter(raw)
@@ -603,15 +603,15 @@ class VaultService:
 
     def create_note(
         self, title: str, body: str = "", tags: list[str] | None = None,
-        promoted_from_chat: str | None = None,
+        excerpt_of_chat: str | None = None,
     ) -> Note:
         self.ensure_dirs()
         slug = self._unique_slug(_slugify(title))
         fm = {"type": "note", "title": title}
         if tags:
             fm["tags"] = tags
-        if promoted_from_chat:
-            fm["promoted_from_chat"] = promoted_from_chat
+        if excerpt_of_chat:
+            fm["excerpt_of_chat"] = excerpt_of_chat
         path = self.default_dirs[NodeType.note] / f"{slug}.md"
         path.write_text(_render_frontmatter(fm) + body, encoding="utf-8")
         return self.get_note(slug)
@@ -765,12 +765,15 @@ class VaultService:
             return nodes
 
         streams_dir_name = self.default_dirs[NodeType.stream].name
+        chats_dir_name = self.default_dirs[NodeType.chat].name
         for entry in entries:
             name = entry.name
             if name in _SKIP_DIRS or name.startswith("."):
                 continue
             if entry.is_dir(follow_symlinks=True) and directory == self.root and name == streams_dir_name:
                 continue  # streams shown in the dedicated sidebar section, not the tree
+            if entry.is_dir(follow_symlinks=True) and directory == self.root and name == chats_dir_name:
+                continue  # chats shown in the dedicated sidebar section, not the tree
             if entry.is_dir(follow_symlinks=True):
                 children = self._tree_children(Path(entry.path))
                 if children:  # omit empty dirs
@@ -824,6 +827,8 @@ class VaultService:
                     else:
                         raw = path.read_text(encoding="utf-8")
                         fm, content = _parse_frontmatter(raw)
+                        if fm.get("excerpt_of_chat"):
+                            continue  # already shown in the chat's own Excerpt panel
                         nt = self._node_type_from_fm(fm)
                         title = fm.get("title") or _first_heading(content) or path.stem
                         stream_status = None

--- a/prisma/storage/models/vault_models.py
+++ b/prisma/storage/models/vault_models.py
@@ -78,7 +78,7 @@ class Note(VaultNodeBase):
     node_type: NodeType = NodeType.note
     body: str = ""
     status: NoteStatus = NoteStatus.active
-    promoted_from_chat: str | None = None
+    excerpt_of_chat: str | None = None
     original_ext: str | None = None
 
 
@@ -95,7 +95,7 @@ class Source(VaultNodeBase):
     doi: str | None = None
     body: str = ""
     # Extension of the companion original file, e.g. ".pdf", ".html", ".svg".
-    # Companion lives at sources/<slug><original_ext>. None when only .md exists.
+    # Companion lives at <Zotero Imported dir>/<slug><original_ext>. None when only .md exists.
     original_ext: str | None = None
 
 

--- a/tests/unit/agents/test_chat_agent.py
+++ b/tests/unit/agents/test_chat_agent.py
@@ -158,13 +158,13 @@ def _note(title: str, body: str) -> Note:
     return Note(slug=title.lower().replace(" ", "-"), title=title, body=body, path=Path(f"/tmp/{title}.md"))
 
 
-def test_respond_injects_promoted_notes_into_system_prompt():
+def test_respond_injects_excerpt_notes_into_system_prompt():
     llm = MagicMock()
     llm.complete.return_value = "ok"
     agent = _agent(llm=llm)
-    promoted = [_note("Key Decision", "We agreed to use Kùzu, not Neo4j.")]
+    excerpt = [_note("Key Decision", "We agreed to use Kùzu, not Neo4j.")]
 
-    agent.respond(history=[], user_text="what did we decide?", promoted_notes=promoted)
+    agent.respond(history=[], user_text="what did we decide?", excerpt_notes=excerpt)
 
     sent_messages = llm.complete.call_args[0][0]
     system_content = sent_messages[0]["content"]
@@ -173,29 +173,29 @@ def test_respond_injects_promoted_notes_into_system_prompt():
     assert "don't re-litigate" in system_content
 
 
-def test_respond_with_no_promoted_notes_has_no_established_block():
+def test_respond_with_no_excerpt_notes_has_no_established_block():
     llm = MagicMock()
     llm.complete.return_value = "ok"
     agent = _agent(llm=llm)
 
-    agent.respond(history=[], user_text="hello", promoted_notes=None)
+    agent.respond(history=[], user_text="hello", excerpt_notes=None)
 
     sent_messages = llm.complete.call_args[0][0]
     system_content = sent_messages[0]["content"]
     assert "Already established" not in system_content
 
 
-def test_respond_promoted_notes_survive_history_truncation():
-    # Regression guard for the whole point of this feature: promoted notes
+def test_respond_excerpt_notes_survive_history_truncation():
+    # Regression guard for the whole point of this feature: excerpt notes
     # must stay in context even when max_history_tokens forces the raw
     # turns that produced them to be dropped.
     llm = MagicMock()
     llm.complete.return_value = "ok"
     agent = _agent(llm=llm, max_history_tokens=1)  # drops virtually all raw history
-    promoted = [_note("Settled Point", "The answer was 42.")]
+    excerpt = [_note("Settled Point", "The answer was 42.")]
     history = [ChatMessage(role=ChatRole.user, content="x" * 400)]
 
-    agent.respond(history=history, user_text="remind me", promoted_notes=promoted)
+    agent.respond(history=history, user_text="remind me", excerpt_notes=excerpt)
 
     sent_messages = llm.complete.call_args[0][0]
     system_content = sent_messages[0]["content"]
@@ -291,12 +291,12 @@ def test_context_usage_counts_system_prompt_and_bounded_history():
     assert used > baseline
 
 
-def test_context_usage_includes_promoted_notes_in_the_count():
+def test_context_usage_includes_excerpt_notes_in_the_count():
     llm = MagicMock()
     agent = _agent(llm=llm, max_history_tokens=16000)
-    promoted = [_note("Excerpt", "x" * 4000)]
+    excerpt = [_note("Excerpt", "x" * 4000)]
 
-    with_excerpt, _ = agent.context_usage(history=[], promoted_notes=promoted)
+    with_excerpt, _ = agent.context_usage(history=[], excerpt_notes=excerpt)
     without_excerpt, _ = agent.context_usage(history=[])
 
     assert with_excerpt > without_excerpt

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -860,3 +860,28 @@ def test_dropped_chunks_total_is_zero_when_nothing_failed(kg):
     status = kg.status()
     assert status["dropped_chunks_total"] == 0
     assert status["dropped_chunks_recent"] == []
+
+
+def test_clear_dead_letters_removes_files_and_resets_counters(kg, vault):
+    f = vault.root / "notes" / "test.md"
+    f.write_text("---\ntype: note\n---\nSome content that will fail extraction.", encoding="utf-8")
+
+    with _patch_create(kg, side_effect=ValueError("validation retries exhausted")), \
+         patch("prisma.services.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")), \
+         patch("prisma.services.resource_lock.release"):
+        kg._extract_file(f, "note")
+
+    dead_letter = Path(kg.status()["dropped_chunks_recent"][0]["dead_letter_path"])
+    assert dead_letter.exists()
+
+    removed = kg.clear_dead_letters()
+
+    assert removed == 1
+    assert not dead_letter.exists()
+    status = kg.status()
+    assert status["dropped_chunks_total"] == 0
+    assert status["dropped_chunks_recent"] == []
+
+
+def test_clear_dead_letters_returns_zero_when_none_exist(kg):
+    assert kg.clear_dead_letters() == 0

--- a/tests/unit/services/test_vault_chat.py
+++ b/tests/unit/services/test_vault_chat.py
@@ -137,15 +137,15 @@ def test_get_any_dispatches_chat_type_to_get_chat(vault):
 
 # ── Excerpt: one Excerpt note per chat, Summary + pinned turns (ADR-015) ──────
 
-def test_save_excerpt_creates_note_with_promoted_from_chat(vault):
+def test_save_excerpt_creates_note_with_excerpt_of_chat(vault):
     chat = vault.create_chat("Research Session")
     turns = [ChatMessage(role=ChatRole.user, content="We agreed to use Kùzu, not Neo4j.")]
 
     note = vault.save_excerpt(chat.slug, "We chose Kùzu over Neo4j.", turns)
 
-    assert note.promoted_from_chat == chat.slug
+    assert note.excerpt_of_chat == chat.slug
     raw = (vault.root / "notes" / f"{note.slug}.md").read_text(encoding="utf-8")
-    assert f"promoted_from_chat: {chat.slug}" in raw
+    assert f"excerpt_of_chat: {chat.slug}" in raw
     assert "We chose Kùzu over Neo4j." in raw
 
 
@@ -236,3 +236,25 @@ def test_set_pinned_turns_records_indices_on_chat(vault):
 def test_set_pinned_turns_raises_for_missing_chat(vault):
     with pytest.raises(FileNotFoundError):
         vault.set_pinned_turns("does-not-exist", [0])
+
+
+# ── Tree: chats and Excerpts already shown in dedicated sidebar sections ──────
+
+def test_get_tree_excludes_chats_dir(vault):
+    vault.create_chat("Research Session")
+
+    names = [n.name for n in vault.get_tree()]
+
+    assert "chats" not in names
+
+
+def test_get_tree_excludes_excerpt_notes(vault):
+    chat = vault.create_chat("Research Session")
+    vault.save_excerpt(chat.slug, "Settled.", [])
+    vault.create_note("A Real Note", body="Some content.")
+
+    notes_dir = next(n for n in vault.get_tree() if n.name == "notes")
+    file_names = [c.name for c in notes_dir.children]
+
+    assert not any(name.startswith("excerpt-") for name in file_names)
+    assert any("a-real-note" in name for name in file_names)

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "rimraf .svelte-kit build && svelte-kit sync && vite build",
+    "build": "rimraf .svelte-kit build-next && svelte-kit sync && vite build && node scripts/swap-build.mjs",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },

--- a/ui/scripts/swap-build.mjs
+++ b/ui/scripts/swap-build.mjs
@@ -1,0 +1,22 @@
+// Swaps the freshly-built "build-next" directory into "build" with two
+// back-to-back renames instead of vite's rimraf-then-write, so
+// prisma serve's web process (mounting "build" live via CleanUrlStaticFiles)
+// never has a multi-second window where the directory is empty/partial and
+// every request 404s.
+import { existsSync, renameSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const uiDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const build = join(uiDir, "build");
+const buildNext = join(uiDir, "build-next");
+const buildOld = join(uiDir, "build-old");
+
+if (!existsSync(buildNext)) {
+  throw new Error(`swap-build: ${buildNext} does not exist — did the build step run?`);
+}
+
+if (existsSync(buildOld)) rmSync(buildOld, { recursive: true, force: true });
+if (existsSync(build)) renameSync(build, buildOld);
+renameSync(buildNext, build);
+if (existsSync(buildOld)) rmSync(buildOld, { recursive: true, force: true });

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -238,7 +238,7 @@
   let treeLoaded = $state(false);
   let sidebarEl = $state<HTMLElement | null>(null);
   // context menu
-  let ctxMenu = $state<{ x: number; y: number; slug: string | null; title: string; dirKey: string | null } | null>(null);
+  let ctxMenu = $state<{ x: number; y: number; slug: string | null; title: string; dirKey: string | null; isChat?: boolean } | null>(null);
   let ctxMovePicker = $state(false);
   let renameTarget = $state<{ slug: string; value: string } | null>(null);
   // drag and drop
@@ -916,7 +916,9 @@
 
   interface AppSettings { scale: number; server_url: string; }
 
-  const SCALE_OPTIONS = [1.0, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0];
+  const SCALE_MIN = 1.0;
+  const SCALE_MAX = 5.0;
+  const SCALE_STEP = 0.5;
 
   let showSettings = $state(false);
   let cfg = $state<AppSettings>({ scale: 1.0, server_url: untrack(() => apiBase) });
@@ -1248,6 +1250,14 @@
                 ondrop={(e) => onDirDrop(e, dirPath)}
               >
                 <span class="tree-chevron" class:open>{open ? "▾" : "▸"}</span>
+                <svg class="tree-dir-icon" viewBox="0 0 24 24" fill="currentColor">
+                  {#if open}
+                    <path d="M3 6h6l2 2h10v2H3V6Z" opacity="0.55"/>
+                    <path d="M2 10h19l-2 9a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1L2 10Z"/>
+                  {:else}
+                    <path d="M3 6h6l2 2h10v11a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1Z"/>
+                  {/if}
+                </svg>
                 <span class="tree-dir-name">{node.name}</span>
               </button>
               {#if open}
@@ -1287,7 +1297,7 @@
         <div class="section-header">
           <button class="section-toggle" onclick={() => toggleSection("vault")}>
             <span class="section-chevron" class:open={sectionOpen.vault}>{sectionOpen.vault ? "▾" : "▸"}</span>
-            <span class="section-label">Vault</span>
+            <span class="section-label">Notes and Sources</span>
           </button>
         </div>
         {#if sectionOpen.vault}
@@ -1297,7 +1307,7 @@
                 {@render treeNode(node, "")}
               {/each}
             {:else}
-              <div class="sidebar-empty">Empty vault</div>
+              <div class="sidebar-empty">No notes or sources yet</div>
             {/if}
           </div>
         {/if}
@@ -1345,7 +1355,7 @@
                   class="tree-file"
                   class:active={activeChat?.slug === c.slug}
                   onclick={() => openChat(c.slug)}
-                  oncontextmenu={(e) => { e.preventDefault(); ctxMenu = { x: e.clientX, y: e.clientY, slug: c.slug, title: c.title, dirKey: null }; ctxMovePicker = false; }}
+                  oncontextmenu={(e) => { e.preventDefault(); ctxMenu = { x: e.clientX, y: e.clientY, slug: c.slug, title: c.title, dirKey: null, isChat: true }; ctxMovePicker = false; }}
                 >
                   <span class="tree-type-dot nt-chat"></span>
                   <span class="tree-file-name">{c.title}</span>
@@ -1582,17 +1592,15 @@
                         title={activeChat?.pinned_turns.includes(i) ? "Unpin from Excerpt" : "Pin to Excerpt"}
                         onclick={() => togglePinTurn(i)}
                       >
-                        <svg viewBox="0 0 24 24" width="14" height="14" fill={activeChat?.pinned_turns.includes(i) ? "currentColor" : "none"} stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
                           <path d="M12 21s-7-6.5-7-11a7 7 0 0 1 14 0c0 4.5-7 11-7 11z"/>
-                          <circle cx="12" cy="10" r="2.5" fill={activeChat?.pinned_turns.includes(i) ? "#0d1420" : "none"}/>
                         </svg>
                       </button>
                       <button class="chat-turn-action" title="Delete this turn" onclick={() => deleteChatMessage(i)}>
-                        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                          <polyline points="3 6 5 6 21 6"/>
-                          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
-                          <path d="M10 11v6M14 11v6"/>
-                          <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+                        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                          <rect x="9" y="3" width="6" height="2" rx="1"/>
+                          <rect x="4" y="6" width="16" height="2" rx="1"/>
+                          <path d="M6 9h12l-1 11a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2L6 9Z"/>
                         </svg>
                       </button>
                     </span>
@@ -1629,8 +1637,8 @@
               <span class="chat-notes-title">Excerpt</span>
               {#if activeChat.excerpt_regenerating}
                 <span class="chat-notes-regenerating" title="Regenerating the Excerpt in the background — showing the previous version until it's ready">
-                  <svg class="spin" viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
-                    <path d="M21 12a9 9 0 1 1-3-6.7"/>
+                  <svg class="spin" viewBox="0 0 24 24" width="11" height="11" fill="currentColor">
+                    <path d="M12 12V3a9 9 0 1 1-9 9Z"/>
                   </svg>
                   regenerating…
                 </span>
@@ -1673,29 +1681,29 @@
                   <div class="resource-card-header">
                     <span class="resource-pool-icon" title={pool.type}>
                       {#if pool.type === "gpu"}
-                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
                           <rect x="6" y="6" width="12" height="12" rx="1"/>
-                          <rect x="9.5" y="9.5" width="5" height="5"/>
-                          <line x1="6" y1="9" x2="3" y2="9"/>
-                          <line x1="6" y1="12" x2="3" y2="12"/>
-                          <line x1="6" y1="15" x2="3" y2="15"/>
-                          <line x1="18" y1="9" x2="21" y2="9"/>
-                          <line x1="18" y1="12" x2="21" y2="12"/>
-                          <line x1="18" y1="15" x2="21" y2="15"/>
-                          <line x1="9" y1="6" x2="9" y2="3"/>
-                          <line x1="12" y1="6" x2="12" y2="3"/>
-                          <line x1="15" y1="6" x2="15" y2="3"/>
-                          <line x1="9" y1="18" x2="9" y2="21"/>
-                          <line x1="12" y1="18" x2="12" y2="21"/>
-                          <line x1="15" y1="18" x2="15" y2="21"/>
+                          <rect x="9.5" y="9.5" width="5" height="5" fill="#0d1420"/>
+                          <rect x="2" y="8.25" width="4" height="1.5" rx="0.5"/>
+                          <rect x="2" y="11.25" width="4" height="1.5" rx="0.5"/>
+                          <rect x="2" y="14.25" width="4" height="1.5" rx="0.5"/>
+                          <rect x="18" y="8.25" width="4" height="1.5" rx="0.5"/>
+                          <rect x="18" y="11.25" width="4" height="1.5" rx="0.5"/>
+                          <rect x="18" y="14.25" width="4" height="1.5" rx="0.5"/>
+                          <rect x="8.25" y="2" width="1.5" height="4" rx="0.5"/>
+                          <rect x="11.25" y="2" width="1.5" height="4" rx="0.5"/>
+                          <rect x="14.25" y="2" width="1.5" height="4" rx="0.5"/>
+                          <rect x="8.25" y="18" width="1.5" height="4" rx="0.5"/>
+                          <rect x="11.25" y="18" width="1.5" height="4" rx="0.5"/>
+                          <rect x="14.25" y="18" width="1.5" height="4" rx="0.5"/>
                         </svg>
                       {:else}
-                        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
                           <path d="M7 16a4 4 0 0 1-1-7.9 5 5 0 0 1 9.6-2.4A4.5 4.5 0 0 1 20 10a4 4 0 0 1-1 6H7z"/>
-                          <line x1="8" y1="17" x2="8" y2="20"/>
-                          <circle cx="8" cy="21" r="1" fill="currentColor" stroke="none"/>
-                          <line x1="14" y1="17" x2="14" y2="20"/>
-                          <circle cx="14" cy="21" r="1" fill="currentColor" stroke="none"/>
+                          <rect x="7.25" y="17" width="1.5" height="3" rx="0.75"/>
+                          <circle cx="8" cy="21" r="1"/>
+                          <rect x="13.25" y="17" width="1.5" height="3" rx="0.75"/>
+                          <circle cx="14" cy="21" r="1"/>
                         </svg>
                       {/if}
                     </span>
@@ -2058,11 +2066,16 @@
       {#if isTauri}
         <label class="setting-row">
           <span class="setting-label">Display scale</span>
-          <select bind:value={cfg.scale}>
-            {#each SCALE_OPTIONS as s}
-              <option value={s}>{s === 1.0 ? "1× (default)" : `${s}×`}</option>
-            {/each}
-          </select>
+          <div class="scale-slider-row">
+            <input
+              type="range"
+              min={SCALE_MIN}
+              max={SCALE_MAX}
+              step={SCALE_STEP}
+              bind:value={cfg.scale}
+            />
+            <span class="scale-slider-value">{cfg.scale === 1.0 ? "1× (default)" : `${cfg.scale}×`}</span>
+          </div>
           <span class="setting-hint">Applied immediately — persisted across restarts.</span>
         </label>
 
@@ -2109,7 +2122,9 @@
     <div class="ctx-menu" style="left:{ctxMenu.x}px; top:{ctxMenu.y}px">
       {#if !ctxMovePicker}
         {#if ctxMenu.slug}
-          <button class="ctx-item" onclick={() => ctxMovePicker = true}>Move to…</button>
+          {#if !ctxMenu.isChat}
+            <button class="ctx-item" onclick={() => ctxMovePicker = true}>Move to…</button>
+          {/if}
           <button class="ctx-item" onclick={() => { renameTarget = { slug: ctxMenu!.slug!, value: ctxMenu!.title }; ctxMenu = null; }}>Rename</button>
           <button class="ctx-item ctx-danger" onclick={() => doDelete(ctxMenu!.slug!)}>Delete</button>
         {/if}
@@ -2680,6 +2695,8 @@
 
   .tree-chevron { font-size: 9px; flex-shrink: 0; color: #2a4060; }
   .tree-chevron.open { color: #4a6a8a; }
+
+  .tree-dir-icon { width: 1em; height: 1em; flex-shrink: 0; color: #3a5a7a; }
 
   .tree-dir-name {
     overflow: hidden;
@@ -3705,6 +3722,27 @@
   }
   .setting-row select:focus,
   .setting-row input:focus { border-color: #4a9eff; }
+
+  .scale-slider-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .scale-slider-row input[type="range"] {
+    flex: 1;
+    width: auto;
+    padding: 0;
+    background: none;
+    border: none;
+    accent-color: #4a9eff;
+  }
+  .scale-slider-value {
+    font-size: 12px;
+    color: #e8edf8;
+    min-width: 84px;
+    text-align: right;
+    flex-shrink: 0;
+  }
 
   .setting-hint {
     font-size: 10px;

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -11,6 +11,13 @@ const config = {
   kit: {
     adapter: adapter({
       fallback: "index.html",
+      // Built into a staging directory, then atomically swapped into place by
+      // scripts/swap-build.mjs — building straight into "build" would leave
+      // prisma serve's web process (which mounts "build" live via
+      // CleanUrlStaticFiles) serving 404s for the several seconds the old
+      // output is deleted before the new one finishes writing.
+      pages: "build-next",
+      assets: "build-next",
     }),
     paths: {
       base: "/app",


### PR DESCRIPTION
## Summary
- Hide `chats/` and Excerpt notes from the vault tree — both were duplicated with their dedicated sidebar sections (Chats, and the chat's own Excerpt panel).
- Rename "Vault" sidebar label to "Notes and Sources"; repurpose the empty `sources/` dir as "Zotero Imported" (already the real code-level Zotero import target).
- Retire the "promote a chat to a note" naming (`Note.promoted_from_chat` -> `excerpt_of_chat`) — pinning turns already builds the Excerpt directly, there was never a separate manual promote action.
- Add `POST /clear_dead_letters` to clear KG dead-letter files/counters.
- Switch every hand-drawn SVG icon in the UI from stroke outlines to filled shapes (WebKit's stroke-width doesn't scale consistently with icon size at high browser zoom).
- Fix the UI build leaving a multi-second window where `prisma serve`'s web process 404s every request (vite's build script deleted `build/` before rewriting it) — now builds to a staging dir and swaps atomically.
- Replace the Display Scale dropdown with a slider (1x-5x, 0.5 steps).

## Test plan
- [x] `pytest tests/` — 449 passed
- [x] `svelte-check` — 0 errors
- [x] Verified live against a running `prisma serve`: tree no longer shows `chats/` or duplicate Excerpts, chat rename works via the existing generic rename endpoint, dead-letter clearing tested against real dead-letter files