### PR TITLE
Reload panel: restart real supervisor workers

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -420,6 +420,18 @@ def reload_chroma():
     return {"status": "reloaded"}
 
 
+@app.post("/supervisor/restart/{name}")
+def restart_worker(name: str):
+    """Proxies to the supervisor's own POST /supervisor/restart/{name} —
+    lets the UI restart a single worker process (api/web/chroma/kg) without
+    needing direct access to the supervisor's loopback-only control port,
+    same pattern as resource_lock.status()/process_status() already use for
+    read-only supervisor data on /status."""
+    return resource_lock.restart_worker(
+        "127.0.0.1", resource_lock.default_port(), name,
+    )
+
+
 @app.post("/reload")
 def reload_server():
     global _vault, _indexer, _chroma, _zotero

--- a/prisma/services/resource_lock.py
+++ b/prisma/services/resource_lock.py
@@ -121,6 +121,21 @@ def process_status(host: str, port: int, timeout: float = 3.0) -> dict:
         return {}
 
 
+def restart_worker(host: str, port: int, name: str, timeout: float = 10.0) -> dict:
+    """Restarts one supervisor-managed worker process (api/web/chroma/kg) —
+    for surfacing on the api process's UI-facing reload control without the
+    UI needing direct access to the supervisor's loopback-only control port.
+    Same fail-open-ish spirit as status()/process_status(): returns
+    {"error": ...} rather than raising if the supervisor isn't reachable or
+    the worker name is unknown."""
+    try:
+        resp = requests.post(f"http://{host}:{port}/supervisor/restart/{name}", timeout=timeout)
+        return resp.json()
+    except requests.RequestException as exc:
+        _log.warning("supervisor unreachable at %s:%d — could not restart %r: %s", host, port, name, exc)
+        return {"error": str(exc)}
+
+
 def release(host: str, port: int, resource: str | None, request_id: str | None, timeout: float = 3.0) -> None:
     if resource is None or request_id is None:
         return

--- a/tests/unit/services/test_resource_lock.py
+++ b/tests/unit/services/test_resource_lock.py
@@ -64,6 +64,23 @@ def test_process_status_returns_empty_dict_when_unreachable():
     assert result == {}
 
 
+def test_restart_worker_returns_supervisor_response_on_success():
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"status": "restarted", "worker": "api"}
+    with patch("prisma.services.resource_lock.requests.post", return_value=mock_resp) as mock_post:
+        result = resource_lock.restart_worker("127.0.0.1", 8760, "api")
+
+    mock_post.assert_called_once_with("http://127.0.0.1:8760/supervisor/restart/api", timeout=10.0)
+    assert result == {"status": "restarted", "worker": "api"}
+
+
+def test_restart_worker_returns_error_dict_when_unreachable():
+    with patch("prisma.services.resource_lock.requests.post", side_effect=requests.ConnectionError("down")):
+        result = resource_lock.restart_worker("127.0.0.1", 8760, "api")
+
+    assert "error" in result
+
+
 def test_lease_yields_true_and_releases_on_success():
     with patch("prisma.services.resource_lock.acquire", return_value=(True, "default", "req-1")) as mock_acquire, \
          patch("prisma.services.resource_lock.release") as mock_release:

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -155,6 +155,7 @@
 
   const DEFAULT_API = "http://127.0.0.1:8765";
   const DEFAULT_API_PORT = 8765;
+  const DEFAULT_SUPERVISOR_PORT = 8760;
 
   // The Web process (serving this page at /app) and the API process are
   // independent processes/ports (see ADR-012) — the page's own origin is no
@@ -698,25 +699,47 @@
 
   // ── Reload ──────────────────────────────────────────────────────────────────
 
-  type ReloadScope = "all" | "ui" | "config" | "indexers";
+  // Matches the supervisor's own worker set (prisma/server/supervisor.py's
+  // `workers` dict) — see GET /supervisor/status, proxied to the UI as
+  // serverStatus.processes.
+  const WORKER_NAMES = ["api", "web", "chroma", "kg"] as const;
+  type WorkerName = (typeof WORKER_NAMES)[number];
+  type ReloadScope = "all" | WorkerName;
   let reloading = $state(false);
   let reloadScope = $state<ReloadScope>("all");
 
-  const RELOAD_ENDPOINTS: Record<ReloadScope, string> = {
-    all:      "/reload",
-    ui:       "/reload/ui",
-    config:   "/reload/vault",
-    indexers: "/reload/indexer",
-  };
+  function supervisorBase(): string {
+    try {
+      const url = new URL(apiBase);
+      url.port = String(DEFAULT_SUPERVISOR_PORT);
+      return url.origin;
+    } catch {
+      return `http://127.0.0.1:${DEFAULT_SUPERVISOR_PORT}`;
+    }
+  }
+
+  async function restartWorker(name: WorkerName): Promise<void> {
+    // Restarting "api" by proxying through the api process itself would
+    // kill the very process handling this request before it can respond —
+    // hit the supervisor's own loopback control port directly instead
+    // (same reasoning the old code hit webBase directly for UI reloads
+    // rather than proxying those through the api process either).
+    if (name === "api") {
+      await fetch(`${supervisorBase()}/supervisor/restart/api`, { method: "POST" });
+    } else {
+      await fetch(`${apiBase}/supervisor/restart/${name}`, { method: "POST" });
+    }
+  }
 
   async function reloadServer() {
     reloading = true;
     try {
-      // /reload/ui lives on the Web process (it owns UI serving — see ADR-012);
-      // every other scope is an API-process concern.
-      const base = reloadScope === "ui" ? webBase : apiBase;
-      await fetch(`${base}${RELOAD_ENDPOINTS[reloadScope]}`, { method: "POST" });
-      if (reloadScope === "ui") {
+      if (reloadScope === "all") {
+        for (const name of WORKER_NAMES) await restartWorker(name);
+      } else {
+        await restartWorker(reloadScope);
+      }
+      if (reloadScope === "all" || reloadScope === "web") {
         window.location.reload();
       } else {
         await Promise.all([loadTree(), loadStreams(), loadChats(), loadZoteroStatus()]);
@@ -2095,10 +2118,11 @@
     <div class="settings-danger-zone">
       <div class="reload-scope">
         {#each [
-          { value: "all",      label: "All" },
-          { value: "ui",       label: "UI only" },
-          { value: "config",   label: "Config" },
-          { value: "indexers", label: "Indexers" },
+          { value: "all",    label: "All" },
+          { value: "api",    label: "API" },
+          { value: "web",    label: "Web (UI)" },
+          { value: "chroma", label: "Chroma" },
+          { value: "kg",     label: "Knowledge Graph" },
         ] as opt (opt.value)}
           <label class="reload-option">
             <input type="radio" name="reload-scope" value={opt.value} bind:group={reloadScope} />


### PR DESCRIPTION
## Summary
- Settings' reload panel (All/UI only/Config/Indexers) was hitting ad-hoc in-process reload endpoints that no longer matched what the supervisor actually manages.
- Replaces the scope list with the supervisor's real worker set (api/web/chroma/kg), via a new `POST /supervisor/restart/{name}` proxy on the api process.
- `api`'s own restart is special-cased to hit the supervisor's loopback control port directly instead of proxying through itself, which would kill the process handling the request before it could respond.

## Test plan
- [x] `pytest tests/` — 451 passed
- [x] `svelte-check` — 0 errors