### PR TITLE
Vault-sync (desktop<->server) + ADR-011 password auth + llama_cpp/openrouter providers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -917,3 +917,306 @@ Replaced with a narrower, more useful **Knowledge Graph progress page**
       and again at the end of `_profile_missing_models()`'s probing pass so
       newly-learned profiles can surface a conflict that was previously
       "unknown, can't tell." Tests in `tests/unit/server/test_supervisor_resources.py`.
+
+# Code quality assessment (2026-07-18) — pre-demo cleanup
+
+First-pass senior-level audit of `prisma/` (core package, ~18K LOC), done ahead of
+showing the project publicly to research-niche audiences. Goal: decide rewrite vs.
+targeted cleanup. Findings are evidence-based (grep/diff counts below), ranked most
+demo-blocking first.
+
+## 1. Duplicated Zotero client hierarchy (real refactor)
+
+Four classes reimplement overlapping CRUD (`get_collections`, `create_collection`,
+`delete_item`, `delete_collection`, `search_items`, `save_items*`, `get_item`,
+`add_item_to_collection`) with inconsistent return types:
+
+- `integrations/zotero/client.py` (`ZoteroClient`, aliased `ZoteroWebAPIClient` in
+  `unified_client.py`) — returns raw `Dict[str, Any]` / `List[Dict]`. **Violates the
+  CLAUDE.md rule that all structured data is Pydantic v2** — this is the one client
+  that doesn't follow it.
+- `integrations/zotero/hybrid_client.py` (`ZoteroHybridClient`) — returns typed
+  `ZoteroItem`/`ZoteroCollection`. Also has duplicate public/private pairs doing the
+  same check: `has_api_config()` / `_has_api_config()`, `has_local_server_config()` /
+  `_has_local_server_config()` — pick one, delete the other.
+- `integrations/zotero/local_api_client.py` (`ZoteroLocalAPIClient`) — typed, mostly
+  consistent with hybrid_client.
+- `integrations/zotero/desktop_client.py` (`ZoteroDesktopClient`) — smaller surface,
+  some overlap with the above three.
+- `integrations/zotero/unified_client.py` (`ZoteroClient` facade) — a `from_config`
+  factory wrapping the three above; doesn't hide the inconsistency, just routes to it.
+
+None of these are dead code — all four are actively imported and constructed via the
+`unified_client.py` factory. This is duplication carried across sessions, not
+leftover cruft.
+
+**Fix size:** real refactor. Define one typed interface (the architecture doc already
+calls this out implicitly — `unified_client.py` was clearly meant to be the seam),
+make `client.py`/`ZoteroWebAPIClient` return the same Pydantic models as the other
+two, delete the duplicate has_*/​_has_* pairs, and audit for other near-duplicate
+methods across the four files before assuming the facade fully hides the mess.
+
+## 2. Inconsistent exception handling (medium — needs a policy, then a sweep)
+
+`prisma/` (core package only) has **220** `except Exception` blocks, of which **27**
+are bare `except Exception: pass` with no logging at all — e.g.
+`server/app.py:125`, `:174`, `:179`, `:496`. Others in the same file log properly with
+context (`server/app.py:239`, `:257`, `:714` — `_log.warning("...: %s", exc)`). No
+visible policy for which failures are safe to swallow silently vs. which need at
+least a log line; this looks like different sessions handling errors differently
+rather than a deliberate design.
+
+**Fix size:** medium. Needs a decision first (e.g. "swallow only for known-optional
+best-effort paths, and even then log at debug level") then a mechanical sweep — not
+a redesign, but touches most files in the package.
+
+## 3. Duplicated test suites — abandoned migration (quick fix, high value)
+
+`tests-sets/README.md` documents a deliberate reorganization ("Tests are organized by
+what they need to run, not by layer") with its own rule ("Only our code is tested").
+But the **old** `tests/unit/` + `tests/integration/` tree was never deleted after
+`tests-sets/` was created:
+
+- 9 of 14 sampled `tests-sets/mocked/**/test_*.py` files are **byte-identical**
+  (`diff -q` confirmed) to a same-named file still sitting in `tests/unit/`, e.g.
+  `test_models.py` (303 lines), `test_debug_output.py` (277 lines),
+  `test_zotero_integration.py` (271 lines).
+- Net effect: whole test files are maintained (or silently drift) in two places at
+  once, and `tests/` has no README explaining why it still exists alongside
+  `tests-sets/`.
+
+**Fix size:** quick, high-value. Confirm `tests-sets/` + `tests/integration/`
+(the real-API suite, not mocked) already covers everything `tests/unit` covers, point
+CI at `tests-sets/run-all.sh` only, then delete the old `tests/` tree. This alone
+meaningfully shrinks the "is this project well-maintained" first impression for a
+demo audience poking at the repo.
+
+## 4. `server/app.py` is oversized for what the architecture doc describes (real refactor, lower priority)
+
+1,692 lines, ~48 routes. The architecture doc describes `app.py` as "API process —
+REST + WebSocket, no UI mount," implying a thin routing layer, but route handlers
+appear to carry business logic inline rather than delegating to `services/`
+(spot-checked; not exhaustively verified line-by-line — worth a follow-up pass
+specifically diffing route-handler bodies against what `services/` already exposes).
+Also contains a startup-timing helper using a mutable-default-arg static-variable
+trick (`_t(label, _t0=[0.0])`, line 30) — works, but is the kind of clever-but-obscure
+pattern a future contributor will trip over.
+
+**Fix size:** real refactor, but lower priority than #1–#3 — it's a maintainability
+smell, not something a demo audience will see directly.
+
+## Overall verdict
+
+**Not a rewrite.** The architecture itself (supervised multi-process design, flat-MD
+vault, typed Pydantic responses as the stated convention, offline-first Zotero
+handling) is sound and mostly followed — the problems found are consistent with
+**several different sessions solving the same problem without consolidating**, not
+with the design being wrong. No `@dataclass` violations were found (the one convention
+check that came back clean), and the two large services (`knowledge_graph_service.py`,
+`supervisor.py`, both >1000 lines) were not deep-audited in this pass — worth a
+follow-up if a full cleanup effort is scoped.
+
+Recommended order (each is independently shippable):
+1. Delete the duplicated old `tests/` tree (#3) — cheapest, immediate demo-facing win.
+2. Consolidate the Zotero client hierarchy (#1) — highest risk of actually confusing
+   or breaking behavior for a new contributor, and the CLAUDE.md violation in
+   `client.py` is a concrete, fixable target.
+3. Establish and sweep an exception-handling policy (#2) — mechanical once decided.
+4. `app.py` route/service-boundary cleanup (#4) — do last, lower external visibility.
+
+This does **not** require "a good programmer to come in and rewrite it" — it needs 3-4
+focused cleanup passes in the order above. A single competent contributor (human or
+AI, working file-by-file with tests as a guardrail) could realistically clear #1 and
+#3 in short order, with #1/#2 (Zotero) being the one item worth extra care since it
+touches active, working code paths.
+
+## Deferred feature: vault unlock over LAN instead of an at-rest key (2026-07-22)
+
+Follows up on the "Encryption at rest ... deferred" line in `docs/ontologia.md`.
+Context: the vault is planned to live on a Longhorn-backed volume (Forge/k3s), with
+an app-level encrypted overlay (gocryptfs, chosen for portability — the encrypted
+directory doesn't care what storage backend sits under it, same reasoning as the
+existing rclone-crypt setup used elsewhere) instead of Longhorn's native
+volume-encryption (which ties the key to a Kubernetes Secret sitting on the same
+disk as the data — protects against disk reuse/resale, not against "someone took
+the whole machine").
+
+**Design discussed:** Prisma starts with the vault *locked* — gocryptfs not
+mounted, vault-dependent features (chat, search, KG, streams touching vault
+content) unavailable. An API endpoint, reachable only on the local
+network/WireGuard (never public-facing), accepts the vault passphrase and
+triggers the gocryptfs mount; only then does the rest of the app become fully
+operational.
+
+**Why this over just storing the key in a Secret:** avoids the passphrase sitting
+at rest on the same physical disk as the encrypted data (the same caveat already
+accepted for Longhorn's own encryption key). This is a middle ground between
+"fully automatic" (zero friction, same exposure as a plain Secret) and "fully
+manual" (requires physical presence at the console, which conflicts with Prisma
+needing to run background jobs unattended on an always-on server) — unlock is a
+network call, so the user can script it for convenience (call it right after
+every restart) or do it by hand for extra caution, same automatic-vs-manual
+choice already made consciously for the root disk (no LUKS, so the server
+reboots unattended) and for gdrive-crypt (key saved, not re-typed).
+
+**Not yet designed:**
+- Where the "locked" state actually gates each subsystem (supervisor level?
+  per-route dependency check?) — needs a look at `supervisor.py` before
+  committing to an approach.
+- Auth on the unlock endpoint itself (network-restricted isn't the same as
+  unauthenticated).
+- Behavior on pod restart: locked again every time, by design — needs the
+  supervisor's crash-recoverable process model (ADR-012) to cleanly re-enter
+  the locked state rather than assuming vault access persists.
+
+## Deferred: package prisma-desktop as a Flatpak (2026-07-25)
+
+Raised, not started — user has higher-priority work right now. `flatpak` +
+`org.gnome.Platform//50` (matching webkit2gtk-4.1, same as the host) are
+already installed on Anvil; `flatpak-builder` is not. Two approaches
+discussed, decision not yet made:
+1. **Pragmatic**: `cargo build --release` outside the sandbox, manifest just
+   packages the binary + assets + `.desktop` file. Fast, fine for personal
+   use on Anvil, not Flathub-submittable as-is (Flathub requires sandboxed,
+   network-free builds).
+2. **Flathub-correct**: build the Rust binary *inside* the sandbox with no
+   network access, which needs `flatpak-cargo-generator` to vendor every
+   crate's sources offline first. More work, needed only if `prisma-desktop`
+   is meant to eventually publish on Flathub.
+
+## Desktop↔server sync via prisma-api, not OS-level file sync (2026-07-22, revised 2026-07-24, implemented 2026-07-25)
+
+Corrects an assumption made earlier in the same planning session: prisma-desktop
+(local, anvil) and a server-side Prisma instance (Forge/k3s) do **not** share one
+vault folder at the OS/filesystem level. Options considered and rejected for the
+desktop↔server link specifically: NFS (not practical/safe to expose to the
+internet — no real auth story for that), Syncthing, rclone (crypt + `bisync`).
+All of these treat the vault as "just files to sync" and know nothing about
+Prisma's own side effects on vault state (KG re-index triggers, Zotero
+collection writes, embedding generation) — a blind file-level sync can't
+coordinate any of that, and reintroduces exactly the dual-writer/corruption risk
+that the whole compute-pool/active-passive discussion in this session was
+trying to avoid.
+
+**Revised design (2026-07-24), supersedes the "each instance owns its own KG"
+call below:** prisma-desktop never runs its own KG or Chroma at all — those
+stay exclusively server-side, full stop, not "independently duplicated per
+instance." Two reasons: (1) re-running extraction/embedding generation on
+every instance is wasted, duplicated compute over the same content, and (2) it
+avoids two independently-evolving knowledge graphs that could disagree with
+each other — a problem the original "each instance owns its own KG
+independently" design created but never actually solved (see its own
+"not yet designed" list below, which never answered *how* two independent KGs
+reconcile). There's also a hardware argument: a desktop/laptop may have a
+weak or no GPU, and KG extraction + embedding generation are long-running,
+resource-heavy jobs you don't want competing with whatever you're actively
+doing on that machine — the server, already dedicated to this, is the right
+place for it regardless of "local-first" as a general philosophy. Local-first
+applies to the *vault* (your own notes, yours, editable offline) — it doesn't
+have to extend to the heavy derived processing on top of it.
+
+**What desktop actually owns:** a local copy of the vault's `.md` files only —
+plain files on disk, edited with whatever external editor the user prefers
+(prisma-desktop is not a text editor). A filesystem watcher
+(`watchdog` — prisma's server side already depends on this, reuse the same
+library rather than a new one) detects local create/modify/delete and pushes
+each change to the server over the API. Sync unit is the **whole file**, not a
+diff — vault notes are small enough that this isn't worth the complexity yet.
+Server-side changes to the vault (auto-saved papers, stream discovery writes)
+push a **WebSocket** notification to connected desktop instances, which then
+pull just the changed file(s) — this is the other half of "not OS-level
+sync": both directions go through Prisma's own API/WS, never a shared mount.
+
+**Why an API over a file-sync tool:** an HTTPS API is the standard,
+well-understood way to expose functionality across the open internet safely
+(proper auth, already need TLS regardless per the ClusterIssuer/Ingress work
+done alongside this). It also means prisma-desktop can reach the server from
+**any** network, not just when on the same LAN/WireGuard as Forge — file-sync-
+based approaches were implicitly LAN-bound.
+
+**Where this lives:** inside `prisma-desktop` itself (extending it well beyond
+its current "thin Tauri shell, zero local storage" state — see its own
+README/CLAUDE.md), not a separate background daemon. `prisma-desktop` already
+has tray/background OS-integration via Tauri, which this can build on.
+
+**Implemented (2026-07-25):**
+- Server: `GET /sync/manifest`, `GET/PUT/DELETE /sync/file` (`prisma/server/sync_routes.py`,
+  path-based, not slug-based — new `VaultService.read_by_path`/`write_by_path`/
+  `delete_by_path`/`list_md_manifest` in `services/vault.py`). Reuses the existing
+  `vault_change` WS event (two new `action` values: `sync_write`/`sync_delete`)
+  rather than a dedicated sync-specific surface.
+- Echo-loop prevention: `broadcast()` gained `exclude_client_id` — desktop
+  identifies its WS connection via `?client_id=<uuid>` and its own pushes via
+  an `X-Sync-Client-Id` header, so its own writes don't echo back to it as an
+  incoming change.
+- Conflict resolution: last-write-wins by mtime (`PUT /sync/file`'s
+  `expected_mtime` 409s on mismatch), with the losing version preserved as a
+  `<path>.conflict-<ts>.md` sibling on the desktop side rather than silently
+  discarded — real, documented data-loss potential for a genuinely-simultaneous
+  edit, accepted given this is a single-user tool.
+- Initial reconciliation: desktop diffs its local walk + `sync_state.json`
+  (per-path last-synced mtime) against the server's manifest at startup —
+  see `prisma-desktop/src-tauri/src/sync/manifest.rs`'s `reconcile()` for the
+  exact tracked/untracked lifecycle table (new-local, new-remote, and the two
+  ambiguous delete-vs-edit cases, each resolved in favor of not losing data).
+- **A prerequisite this surfaced, also implemented**: the server had *no
+  authentication at all* despite ADR-011 already specifying password-mode
+  auth for exactly this LAN scenario. Implemented the password-mode tier only
+  (`prisma/server/auth.py`: zone-classifying ASGI middleware, `POST
+  /auth/login`, JWT signed by `sha256(password_hash)` so a password rotation
+  invalidates all sessions with no separate secret to manage, WS auth via the
+  `Sec-WebSocket-Protocol` subprotocol since browsers can't set custom
+  handshake headers). OIDC/WAN tier remains unimplemented and is explicitly
+  rejected at config-load time if configured (`server.auth.mode: oidc` fails
+  validation) — out of scope for a LAN-only feature. `prisma auth
+  hash-password` CLI added to generate `server.auth.password_hash`.
+- Desktop-side Rust: `src-tauri/src/auth/` (login/session, `auth.json` store)
+  and `src-tauri/src/sync/` (fs-watcher push, WS pull, reconciliation) — see
+  `prisma-desktop`'s own README "Vault Sync & Auth" section. New direct deps:
+  `reqwest`, `tokio` (time only), `tokio-tungstenite`, `notify` +
+  `notify-debouncer-full`, `tauri-plugin-dialog`, `uuid`.
+- `prisma/ui`: `src/lib/auth.ts` + `LoginScreen.svelte`, shown on any 401.
+  Under Tauri, login goes through the `sync_login` command so one password
+  prompt covers both the Rust sync engine's session and the UI's own
+  `apiFetch` calls; pure browser/PWA calls `POST /auth/login` directly.
+  `tauri.conf.json`'s CSP was widened (`connect-src`/`img-src`/`frame-src`
+  from loopback-only to `http:`/`https:`/`ws:`/`wss:`) since it silently
+  blocked any non-loopback `server_url` before this.
+
+**Known limitations, not fixed (scope calls, not oversights):**
+- This only applies to the Tauri-wrapped desktop build. A pure browser/PWA
+  client (Android, iOS, desktop browser tab) has no persistent local
+  filesystem to sync into and keeps talking to the server directly — it only
+  picks up the auth/login-screen half of this work, not the sync engine.
+  **Explicitly discussed and deferred (2026-07-25), not ruled out:** the only
+  real path to local-disk sync from a browser is the **File System Access
+  API** (`showDirectoryPicker()`), which would need its own implementation in
+  `prisma/ui` (JS/TS, not Rust) — this is a different technology, not an
+  extension of `prisma-desktop`'s sync engine, with real platform limits to
+  weigh before starting: Chromium-only (no Firefox, no Safari/iOS — a real
+  gap given "mobile PWA" is one of this project's stated deployment models),
+  no native fs-watch equivalent to the `notify` crate (would need polling,
+  with the latency/battery cost that implies), and less durable permission
+  grants than a native app's unrestricted disk access (the browser can
+  require re-prompting for the directory after a browser restart or period
+  of inactivity). Revisit as its own scoped session if browser/PWA local-edit
+  parity becomes a priority.
+- `web_app.py` (the static UI-asset process, port 8766) and `kg_app.py` (the
+  internal KG worker, only ever reached loopback-to-loopback by `app.py`
+  itself) are **not** gated by `AuthMiddleware` — only the main API process
+  (`server/app.py`, port 8765) is. Static assets are low-sensitivity and the
+  KG worker is never LAN-reachable directly, so this was a deliberate choice,
+  not an oversight — worth revisiting if that assumption changes.
+- Two call sites can't carry an `Authorization` header at all: the note
+  HTML-source `<iframe>` preview (fixed by loading it as a blob URL via
+  `apiFetch` instead of a direct `src=`) and the "open in external browser"
+  action for the same view (`shellOpen`, a full OS-level navigation — left
+  unfixed; would need a short-lived signed URL token to close properly, real
+  scope creep beyond this feature).
+- Diagrams in both repos' `docs/diagrams/` were not regenerated (`sysatlas`
+  isn't installed in either repo's current environment) — do `bash
+  docs/diagrams/gen.sh` in both repos once it is, per each repo's own
+  CLAUDE.md checklist.
+- How this interacts with the vault-unlock-over-LAN feature above — encryption-
+  at-rest is still deferred to a future session (as of 2026-07-24), so a
+  locked/encrypted vault's interaction with sync is still unresolved.

--- a/docs/llamacpp-vulkan-forge-vs-anvil-benchmark.md
+++ b/docs/llamacpp-vulkan-forge-vs-anvil-benchmark.md
@@ -1,0 +1,66 @@
+# llama.cpp + Vulkan: forge vs. anvil, initial benchmark
+
+Context: setting up a local llama.cpp (Vulkan backend) dev loop on both `forge`
+(the always-on home server, no dedicated GPU) and `anvil` (daily-driver
+workstation, also no dedicated GPU) so Prisma can eventually talk to either
+Ollama or llama.cpp as interchangeable backends, tested locally on both
+machines before anything ships to either box for real. Run 2026-07-23, while
+the 4090M laptop (the machine all prior model-evaluation docs in this folder
+used) is out for repair.
+
+## Hardware
+
+| | forge | anvil |
+|---|---|---|
+| CPU | AMD Ryzen 7 PRO 6850U (8C/16T) | AMD Ryzen AI 5 PRO 340 (6C/12T, up to 4.9GHz) |
+| GPU | Radeon 680M (RDNA2, "Rembrandt") | Radeon 840M (RDNA3.5, "Krackan1") |
+| Matrix cores (Vulkan) | **none** | **`KHR_coopmat`** (cooperative matrix support) |
+| RAM | 27GB, shared (UMA, no dedicated VRAM) | 22GB, shared (UMA, no dedicated VRAM) |
+| Role | always-on server, models stay resident (`ttl: 0`) | interactive workstation, models load on-demand (`ttl`-based auto-unload) |
+
+Both built from the same `ggml-org/llama.cpp` source (commit `c0bc8591e`),
+`-DGGML_VULKAN=ON`, installed at `/opt/llama.cpp` (root-owned), RPATH patched
+to `$ORIGIN` via `patchelf` for relocatability.
+
+## Method
+
+`llama-bench -m Qwen2.5-3B-Instruct-Q4_K_M.gguf -ngl 99`, full GPU offload,
+default settings otherwise. Same model file (`bartowski/Qwen2.5-3B-Instruct-GGUF`,
+Q4_K_M, 1.79GiB) on both machines.
+
+## Results
+
+| | forge (680M, no matrix cores) | anvil (840M, `coopmat`) |
+|---|---|---|
+| pp512 (prompt processing, compute-bound) | **651.78 t/s** | 247.34 t/s |
+| tg128 (generation, memory-bandwidth-bound) | 33.01 t/s | **35.88 t/s** |
+
+## Analysis
+
+Two results, in opposite directions from what "newer architecture + hardware
+matrix acceleration" would suggest at first glance:
+
+- **tg128 (decode)**: anvil slightly ahead (35.88 vs 33.01 t/s), consistent
+  with decode being memory-bandwidth-bound rather than compute-bound — matrix
+  cores don't help here regardless of generation, this is just whichever
+  machine's RAM subsystem is faster.
+- **pp512 (prefill)**: anvil is **2.6x slower** than forge, despite having
+  `coopmat` matrix-core support that forge's 680M completely lacks (forge
+  reports `matrix cores: none` in `ggml_vulkan`'s device log). Not root-caused
+  yet, but the leading hypothesis is **compute unit (CU) count**, not
+  architecture generation: forge's 680M (Rembrandt) is a relatively
+  CU-generous config for its class; the 840M here is a lower/mid tier
+  "Ryzen AI 5" part, and RDNA-generation improvements plus a `coopmat`
+  efficiency win on paper don't necessarily overcome having meaningfully
+  fewer raw shader/compute units to begin with. Not confirmed via an actual
+  CU-count lookup for either chip — flagged as a follow-up if this matters
+  enough to chase further.
+
+## Takeaway for the Prisma dev-loop setup
+
+Don't assume "newer chip generation" or "has matrix cores" predicts faster
+inference — measure per-machine, per-workload (prefill vs decode behave
+completely differently), same as every other model-choice finding in this
+folder. anvil is not a strict upgrade over forge for this purpose: better for
+decode-heavy/short-generation workloads, meaningfully worse for anything
+prompt-processing-heavy (e.g. feeding it long context).

--- a/docs/nuextract-2.0-kg-extraction-evaluation.md
+++ b/docs/nuextract-2.0-kg-extraction-evaluation.md
@@ -1,0 +1,104 @@
+# NuExtract-2.0-4B evaluation for KG extraction
+
+Closes a gap flagged in `docs/kg-extraction-context-length.md` and
+`docs/qwen3-family-evaluation.md`: both prior investigations tested generic
+instruct-tuned chat models (qwen2.5:3b/7b, qwen3 family) prompted for
+extraction — neither ever tested a model actually specialized for structured
+extraction. NuExtract-2.0 (NuMind, built on Qwen2.5) is exactly that. Run
+2026-07-24 on Anvil (Radeon 840M, Vulkan), `NuExtract-2.0-4B-Q4_K_M` served
+via `llama-swap`.
+
+## Method
+
+Real, manually-verifiable content: title/authors/abstract/introduction of
+"Attention Is All You Need" (Vaswani et al. 2017), fetched from arXiv —
+clearly entity-rich (Transformer, BLEU, WMT 2014, named authors, etc.),
+same kind of source material the prior docs used. Tested three ways.
+
+## Round 1: Prisma's real extraction pipeline, unmodified
+
+Ran through the actual `KnowledgeGraphService`/`instructor` pipeline (same
+`_EXTRACTION_SYSTEM` natural-language prompt every other model in this
+project's docs was tested with), via `/mark_stale` + `/entities_for_file`,
+both on a fresh vault and after a full `/drop_index` reset (to rule out
+stale/orphaned graph data from an unrelated vault-restore issue this
+session).
+
+**Result: 0 entities, 0 edges — both times.** No error, no dead-letter, no
+validation failure — `Extraction.model_validate()` happily accepted an
+empty `{"nodes": [], "edges": []}`-shaped response. Same content, tested
+against `qwen2.5-3b` earlier the same session, produced 4 correct entities
+and 3 correct edges without issue.
+
+Inspecting the raw (non-Instructor-validated) response for this same call
+explained why:
+
+```
+{"model": {"name": "string", "architecture": "string"}, "tasks": [{"task_name": "verbatim-string", "score": "number"}], "entities": ["verbatim-string"]}
+```
+
+NuExtract-2.0 wasn't attempting extraction at all — it echoed back a
+schema-shaped guess with literal type placeholders (`"string"`,
+`"verbatim-string"`, `"number"`) instead of real values. This is the
+model's own expected *input* format leaking into its output: NuExtract-2.0
+is trained to take a JSON **template** (field names + type placeholders)
+as part of the prompt and fill it with real extracted values — Prisma's
+natural-language rule-based prompt (EXTRACTED/INFERRED/AMBIGUOUS
+confidence tiers, inclusion/exclusion rules, `<untrusted_source>` wrapping)
+gives it nothing resembling that template, so it appears to have
+hallucinated a plausible-looking template shape instead of extracting.
+
+## Round 2: proper template-based prompting, verified working
+
+NuExtract's real usage convention passes the template via
+`extra_body.chat_template_kwargs.template` (an OpenAI-API extension some
+serving frameworks support by injecting the template into the model's
+Jinja chat template at render time). Confirmed `llama-server` honors this
+correctly with the official minimal example first, before trusting any
+result on harder content:
+
+```python
+extra_body={"chat_template_kwargs": {"template": '{"store": "verbatim-string"}'}}
+messages=[{"role": "user", "content": "Yesterday I went shopping at Bunnings"}]
+# → {"store": "Bunnings"}  — exactly right, mechanism genuinely works
+```
+
+With the templating mechanism verified working, ran the same real paper
+content (abstract + introduction, ~1500-2000 chars) against two template
+shapes:
+
+| Template | Result |
+|---|---|
+| `{"entities": [{"name": "verbatim-string", "type": "string"}], "relations": [{"source": "verbatim-string", "relation": "string", "target": "verbatim-string"}]}` | `{"entities": [], "relations": []}` |
+| `{"entities": ["verbatim-string"]}` (simplest possible) | `{"entities": []}` |
+
+**Both empty**, despite: (a) the templating mechanism itself confirmed
+correct via the control test above, (b) the simplest possible schema tried
+in the second row, (c) content that unambiguously contains extractable
+entities a human (or qwen2.5-class model) finds immediately — "Transformer",
+"BLEU", "WMT 2014", the paper's own named authors.
+
+## Conclusion
+
+**NuExtract-2.0-4B (Q4_K_M) does not work for this task, with either
+prompting convention tried.** This isn't a "wrong prompt format" problem
+(Round 1's hypothesis going in) — Round 2 ruled that out directly by using
+NuExtract's own real convention, verified functional on a trivial case,
+and it still failed on real content. Possible explanations not
+distinguished by this test: the 4B/Q4_K_M combination may be too degraded
+for open-ended "find all the entities" extraction (as opposed to
+NuExtract's likely stronger suited use case — pulling a few specific known
+fields out of semi-structured documents, e.g. invoices, forms), or
+open-ended multi-entity/multi-relation KG construction may simply be
+outside what NuExtract's fine-tuning targeted at all, regardless of
+quantization.
+
+**Recommendation**: don't adopt NuExtract-2.0-4B for Prisma's KG extraction.
+Combined with `docs/qwen3-family-evaluation.md`'s verdict (nothing in the
+Qwen3 generation beat it either), `qwen2.5:7b-32k`-class remains the only
+model that has actually demonstrated reliable KG extraction quality across
+every controlled test in this project to date. Untested: NuExtract at
+higher precision (Q8/F16) or the 8B variant — not tried here since the 4B
+Q4_K_M result was unambiguous enough (verified-correct templating,
+simplest-possible schema, still empty) that a quantization/size argument
+alone seems unlikely to fully explain it, though not proven impossible.

--- a/docs/wiki/adr/ADR-011-authentication-strategy.md
+++ b/docs/wiki/adr/ADR-011-authentication-strategy.md
@@ -2,7 +2,10 @@
 
 **Date:** 2026-06-30
 **Author:** CServinL
-**Status:** Accepted
+**Status:** Accepted — password mode implemented 2026-07-25 (`server/auth.py`,
+driven by the desktop vault-sync feature needing it as a prerequisite; see
+TODO.md). OIDC/WAN mode remains unimplemented and is rejected at config-load
+time if `server.auth.mode: oidc` is set.
 
 ## Context
 

--- a/prisma/agents/analysis_agent.py
+++ b/prisma/agents/analysis_agent.py
@@ -18,6 +18,22 @@ from ..services import resource_lock
 
 _ollama_log = logging.getLogger("prisma.ollama")
 
+
+class _NormalizedResponse:
+    """Duck-types the slice of requests.Response this module's callers
+    actually use (.status_code, .json()) — lets _call_ollama_generate return
+    a uniform Ollama-native-shaped payload ({"response": ...}, parseable by
+    OllamaGenerateResponse) regardless of which backend actually served the
+    call, so no downstream call site needs to know or care which provider
+    answered."""
+
+    def __init__(self, status_code: int, payload: dict) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
 _RESOURCE_HOLDER = "api"  # must match the worker name supervisor.py restarts, so a crash releases our leases
 
 
@@ -32,14 +48,21 @@ class AnalysisAgent:
         self._supervisor_host = supervisor_host
         self._supervisor_port = supervisor_port if supervisor_port is not None else resource_lock.default_port()
 
-    def _call_ollama_generate(self, prompt: str, options: dict, timeout: float) -> requests.Response | None:
-        """Single choke point for every Ollama /api/generate call in this agent.
+    def _call_ollama_generate(
+        self, prompt: str, options: dict, timeout: float
+    ) -> "requests.Response | _NormalizedResponse | None":
+        """Single choke point for every LLM completion call in this agent
+        (Ollama's native /api/generate, or llama.cpp's OpenAI-compatible
+        /v1/chat/completions — provider from llm.provider in config).
 
         Wraps the supervisor's compute-pool lease (ADR-012) around the existing
         process-local concurrency semaphore, so this agent can't run concurrently
         against the same GPU/LLM backend as Graphify or ChromaDB indexing.
         Returns None if no compute pool is free right now — callers should
-        treat that the same as any other LLM failure.
+        treat that the same as any other LLM failure. Always returns
+        something exposing .status_code/.json() shaped like Ollama's
+        {"response": ...} payload (see _NormalizedResponse) — callers don't
+        need their own provider branch.
         """
         with resource_lock.lease(
             self._supervisor_host, self._supervisor_port, holder=_RESOURCE_HOLDER, model=self.model,
@@ -47,6 +70,30 @@ class AnalysisAgent:
             if not granted:
                 return None
             with self._inference_sem:
+                if self.llm_config.provider == "llama_cpp":
+                    resp = requests.post(
+                        f"{self.base_url}/v1/chat/completions",
+                        json={
+                            "model": self.model,
+                            "messages": [{"role": "user", "content": prompt}],
+                            "temperature": options.get("temperature", 0.7),
+                            "max_tokens": options.get("num_predict"),
+                        },
+                        timeout=timeout,
+                    )
+                    if resp.status_code != 200:
+                        return _NormalizedResponse(resp.status_code, {})
+                    content = resp.json()["choices"][0]["message"]["content"]
+                    # OllamaGenerateResponse requires model/created_at/done —
+                    # synthesize them; llama.cpp's OpenAI-compatible response
+                    # has no equivalents (Ollama-specific fields, not part of
+                    # the shape being translated from).
+                    return _NormalizedResponse(resp.status_code, {
+                        "model": self.model,
+                        "created_at": datetime.utcnow().isoformat() + "Z",
+                        "response": content,
+                        "done": True,
+                    })
                 return requests.post(
                     f"{self.base_url}/api/generate",
                     json={"model": self.model, "prompt": prompt, "stream": False, "options": options},

--- a/prisma/cli/commands/auth.py
+++ b/prisma/cli/commands/auth.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Auth CLI Commands
+
+Generates the bcrypt password hash used by ADR-011's password-mode auth
+(server.auth.mode: password in config.yaml) — the server never sees or
+stores the plaintext password itself.
+"""
+
+import getpass
+
+import bcrypt
+import click
+
+
+@click.group(name='auth')
+def auth_group():
+    """Server authentication management (ADR-011)."""
+    pass
+
+
+@auth_group.command('hash-password')
+def hash_password():
+    """Prompt for a password and print its bcrypt hash.
+
+    Paste the output into ~/.config/prisma/config.yaml under
+    server.auth.password_hash, and set server.auth.mode: password.
+    """
+    pw = getpass.getpass("Password: ")
+    if not pw:
+        raise click.ClickException("password cannot be empty")
+    confirm = getpass.getpass("Confirm password: ")
+    if pw != confirm:
+        raise click.ClickException("passwords did not match")
+    hashed = bcrypt.hashpw(pw.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+    click.echo(hashed)

--- a/prisma/cli/prisma_cli.py
+++ b/prisma/cli/prisma_cli.py
@@ -12,6 +12,7 @@ import click
 
 from .commands.streams import streams_group
 from .commands.zotero import zotero_group
+from .commands.auth import auth_group
 
 
 @click.group()
@@ -380,6 +381,7 @@ def reload_resources(supervisor_port: int):
 
 cli.add_command(streams_group)
 cli.add_command(zotero_group)
+cli.add_command(auth_group)
 
 
 if __name__ == '__main__':

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -38,6 +38,9 @@ from fastapi import FastAPI, HTTPException, Query, Request, WebSocket, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from prisma.server.access_log import AccessLogMiddleware
+from prisma.server.auth import (
+    AuthMiddleware, LoginRequest, LoginResponse, classify_zone, issue_token, verify_password,
+)
 _t("fastapi ok")
 
 _t("importing coordinator")
@@ -86,30 +89,38 @@ _t("chat ok")
 
 # ── WebSocket connection manager ──────────────────────────────────────────────
 
-_ws_clients: set[WebSocket] = set()
+_ws_clients: dict[WebSocket, str | None] = {}
 _ws_clients_lock = threading.Lock()
 _ws_loop: asyncio.AbstractEventLoop | None = None
 
 
-async def _ws_broadcast(event: dict) -> None:
+async def _ws_broadcast(event: dict, exclude_client_id: str | None = None) -> None:
     msg = json.dumps(event)
     dead: set[WebSocket] = set()
     with _ws_clients_lock:
-        clients = set(_ws_clients)
-    for ws in clients:
+        clients = dict(_ws_clients)
+    for ws, client_id in clients.items():
+        if exclude_client_id is not None and client_id == exclude_client_id:
+            continue
         try:
             await ws.send_text(msg)
         except Exception:
             dead.add(ws)
     if dead:
         with _ws_clients_lock:
-            _ws_clients.difference_update(dead)
+            for ws in dead:
+                _ws_clients.pop(ws, None)
 
 
-def broadcast(event: dict) -> None:
-    """Thread-safe fire-and-forget broadcast to all connected WS clients."""
+def broadcast(event: dict, exclude_client_id: str | None = None) -> None:
+    """Thread-safe fire-and-forget broadcast to all connected WS clients.
+
+    `exclude_client_id` skips the connection that identified itself with
+    that same id on connect (`/ws?client_id=...`) — used by /sync/file
+    writes so a client's own push doesn't echo straight back to it as an
+    incoming server-side change."""
     if _ws_loop is not None and _ws_loop.is_running():
-        asyncio.run_coroutine_threadsafe(_ws_broadcast(event), _ws_loop)
+        asyncio.run_coroutine_threadsafe(_ws_broadcast(event, exclude_client_id), _ws_loop)
 
 
 # ── Vault root / config helpers ───────────────────────────────────────────────
@@ -157,7 +168,8 @@ def _build_chroma(vault: "VaultService") -> ChromaIndexer:
     try:
         rcfg = ConfigLoader().get_retrieval_config()
         return ChromaIndexer(vault, embedding_model=rcfg.embedding_model,
-                              ollama_base_url=rcfg.ollama_base_url, chroma_port=rcfg.chroma_port)
+                              ollama_base_url=rcfg.ollama_base_url, provider=rcfg.provider,
+                              chroma_port=rcfg.chroma_port)
     except Exception:
         return ChromaIndexer(vault)
 
@@ -278,6 +290,14 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Prisma", version="0.1.0", lifespan=lifespan)
 
+# Registered before CORSMiddleware so it ends up as the *innermost* layer —
+# Starlette applies middlewares in reverse-of-registration order, so CORS
+# (added next) wraps this and answers browser preflight (OPTIONS, no
+# Authorization header) before it ever reaches auth gating. Getting this
+# order backwards silently breaks all browser/PWA access once
+# server.auth.mode is "password" (see ADR-011).
+app.add_middleware(AuthMiddleware)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["tauri://localhost"],
@@ -291,6 +311,18 @@ app.add_middleware(
 )
 
 app.add_middleware(AccessLogMiddleware)
+
+# Getter callables, not the objects themselves — /reload-style endpoints
+# below rebind the _vault/_indexer module globals at runtime (`global
+# _vault; _vault = VaultService(...)`), and a router that captured them by
+# value at include_router() time would keep talking to a stale, replaced
+# instance after a reload.
+from prisma.server.sync_routes import build_sync_router  # noqa: E402
+app.include_router(build_sync_router(
+    get_vault=lambda: _vault,
+    broadcast_fn=broadcast,
+    mark_stale_fn=lambda: _indexer.mark_stale(),
+))
 
 _executor = ThreadPoolExecutor(max_workers=2)
 _jobs: dict[str, dict] = {}
@@ -451,11 +483,49 @@ def health():
     return {"status": "ok", "online": connectivity.is_online}
 
 
+@app.post("/auth/login", response_model=LoginResponse)
+def auth_login(req: LoginRequest, request: Request):
+    """Exempt from AuthMiddleware's own zone gating (chicken-and-egg — you
+    need to reach this before you have a token), so the wan/mode checks are
+    repeated here directly rather than relying on the middleware."""
+    from datetime import datetime, timezone
+
+    from prisma.utils.config import ConfigLoader
+    server_cfg = ConfigLoader().get_server_config()
+    auth_cfg = server_cfg.auth
+    if auth_cfg.mode != "password":
+        raise HTTPException(status_code=404, detail="password auth is not enabled")
+
+    client_host = request.client.host if request.client else "127.0.0.1"
+    forwarded_for = request.headers.get("x-forwarded-for")
+    zone = classify_zone(client_host, forwarded_for, server_cfg.trusted_proxies)
+    if zone == "wan":
+        raise HTTPException(status_code=403, detail="wan access is not permitted")
+
+    if not verify_password(req.password, auth_cfg.password_hash):
+        raise HTTPException(status_code=401, detail="invalid password")
+
+    token, expires_at = issue_token(auth_cfg.password_hash, auth_cfg.session_ttl_hours)
+    return LoginResponse(
+        token=token,
+        expires_at=datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(),
+    )
+
+
 @app.websocket("/ws")
-async def websocket_endpoint(ws: WebSocket):
-    await ws.accept()
+async def websocket_endpoint(ws: WebSocket, client_id: str | None = Query(None)):
+    # Echo the "bearer" subprotocol back when the client offered one (see
+    # AuthMiddleware/_bearer_from_ws) — strict browser WebSocket clients
+    # reject a handshake response that doesn't confirm one of the
+    # subprotocols they offered. `client_id` (desktop sends a persisted
+    # UUID) lets broadcast() skip echoing a sync push back to its own
+    # sender — see _ws_broadcast/exclude_client_id.
+    if "bearer" in ws.scope.get("subprotocols", []):
+        await ws.accept(subprotocol="bearer")
+    else:
+        await ws.accept()
     with _ws_clients_lock:
-        _ws_clients.add(ws)
+        _ws_clients[ws] = client_id
     try:
         while True:
             await ws.receive_text()  # keeps connection alive; client sends nothing
@@ -463,7 +533,7 @@ async def websocket_endpoint(ws: WebSocket):
         pass
     finally:
         with _ws_clients_lock:
-            _ws_clients.discard(ws)
+            _ws_clients.pop(ws, None)
 
 
 @app.get("/status")

--- a/prisma/server/auth.py
+++ b/prisma/server/auth.py
@@ -1,0 +1,191 @@
+"""Server-side authentication — ADR-011, password mode only.
+
+Zone-based gating (see docs/wiki/deployment-models.md): the `local` zone
+(loopback) never needs auth; the `lan` zone (RFC1918) requires a valid
+session token whenever `server.auth.mode: password`; the `wan` zone is
+always rejected — `mode: oidc` is documented for a future WAN tier but is
+rejected at config-load time (utils/config.py) since it isn't implemented.
+
+Pure ASGI middleware, not `BaseHTTPMiddleware`: the latter only sees the
+`"http"` scope, but the `/ws` upgrade needs the exact same zone gating.
+"""
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import time
+from typing import Literal
+
+import bcrypt
+import jwt
+from pydantic import BaseModel
+
+from prisma.utils.config import ConfigLoader
+
+Zone = Literal["local", "lan", "wan"]
+
+# /auth/login must stay reachable with no token yet (chicken-and-egg); /health
+# is a plain liveness probe with no sensitive content — both predate auth.
+_EXEMPT_PATHS = {"/health", "/auth/login"}
+_ALGO = "HS256"
+
+
+class LoginRequest(BaseModel):
+    password: str
+
+
+class LoginResponse(BaseModel):
+    token: str
+    expires_at: str
+
+
+# ── password hashing ──────────────────────────────────────────────────────────
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    if not password_hash:
+        return False
+    try:
+        return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+    except ValueError:
+        return False
+
+
+# ── session tokens ────────────────────────────────────────────────────────────
+
+def _signing_key(password_hash: str) -> bytes:
+    # Derived from the password hash rather than a separately stored secret —
+    # rotating the password invalidates every outstanding session for free,
+    # with no extra secret to generate, persist, or leak.
+    return hashlib.sha256(password_hash.encode("utf-8")).digest()
+
+
+def issue_token(password_hash: str, ttl_hours: int) -> tuple[str, float]:
+    """Returns (token, expires_at_epoch_seconds)."""
+    now = time.time()
+    exp = now + ttl_hours * 3600
+    token = jwt.encode({"iat": now, "exp": exp}, _signing_key(password_hash), algorithm=_ALGO)
+    return token, exp
+
+
+def decode_token(token: str, password_hash: str) -> dict | None:
+    try:
+        return jwt.decode(token, _signing_key(password_hash), algorithms=[_ALGO])
+    except jwt.PyJWTError:
+        return None
+
+
+# ── zone classification ───────────────────────────────────────────────────────
+
+def _is_loopback(host: str) -> bool:
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host == "localhost"
+
+
+def _is_private(host: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return ip.is_private and not ip.is_loopback
+
+
+def classify_zone(direct_host: str, forwarded_for: str | None, trusted_proxies: list[str]) -> Zone:
+    """`direct_host` is the actual TCP peer (`scope['client'][0]`).
+    `X-Forwarded-For` is honored only when the direct connection itself
+    comes from a trusted proxy address — otherwise a WAN client could just
+    set the header itself to spoof a local/LAN origin."""
+    candidate = direct_host
+    if forwarded_for and direct_host in trusted_proxies:
+        candidate = forwarded_for.split(",")[0].strip()
+    if _is_loopback(candidate):
+        return "local"
+    if _is_private(candidate):
+        return "lan"
+    return "wan"
+
+
+# ── ASGI middleware ────────────────────────────────────────────────────────────
+
+def _get_header(scope: dict, name: bytes) -> str | None:
+    for k, v in scope.get("headers") or []:
+        if k.lower() == name:
+            return v.decode("latin-1")
+    return None
+
+
+def _bearer_from_http(scope: dict) -> str | None:
+    auth = _get_header(scope, b"authorization")
+    if auth and auth.lower().startswith("bearer "):
+        return auth[7:].strip()
+    return None
+
+
+def _bearer_from_ws(scope: dict) -> str | None:
+    # Browsers can't set custom headers on a WS handshake but can set
+    # subprotocols — the client sends ["bearer", "<jwt>"] and the endpoint
+    # itself must echo one of the offered values via accept(subprotocol=...).
+    raw = _get_header(scope, b"sec-websocket-protocol")
+    if not raw:
+        return None
+    parts = [p.strip() for p in raw.split(",")]
+    if len(parts) >= 2 and parts[0] == "bearer":
+        return parts[1]
+    return None
+
+
+class AuthMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        if scope.get("path", "") in _EXEMPT_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        server_cfg = ConfigLoader().get_server_config()
+        auth_cfg = server_cfg.auth
+        client = scope.get("client")
+        direct_host = client[0] if client else "127.0.0.1"
+        forwarded_for = _get_header(scope, b"x-forwarded-for")
+        zone = classify_zone(direct_host, forwarded_for, server_cfg.trusted_proxies)
+
+        if zone == "wan":
+            await self._reject(scope, send, 403, "wan access is not permitted (oidc mode not implemented)")
+            return
+
+        if zone == "local" or auth_cfg.mode == "none":
+            await self.app(scope, receive, send)
+            return
+
+        # zone == "lan" and mode == "password" — "oidc" is rejected at
+        # config-load time, so this is the only remaining combination.
+        token = _bearer_from_http(scope) if scope["type"] == "http" else _bearer_from_ws(scope)
+        if not token or decode_token(token, auth_cfg.password_hash) is None:
+            await self._reject(scope, send, 401, "authentication required")
+            return
+
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    async def _reject(scope, send, status: int, detail: str) -> None:
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.close", "code": 4401 if status == 401 else 4403})
+            return
+        body = json.dumps({"detail": detail}).encode("utf-8")
+        await send({
+            "type": "http.response.start",
+            "status": status,
+            "headers": [(b"content-type", b"application/json")],
+        })
+        await send({"type": "http.response.body", "body": body})

--- a/prisma/server/kg_app.py
+++ b/prisma/server/kg_app.py
@@ -12,6 +12,7 @@ place `KnowledgeGraphService` may run.
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -44,12 +45,72 @@ def _resolve_vault_root() -> Path:
 
 def _ollama_model() -> str:
     try:
+        from prisma.utils.config import ConfigLoader
+        return ConfigLoader().get_llm_config().model
+    except Exception:
+        return "qwen2.5:7b-32k"
+
+
+def _llm_base_url() -> str:
+    # Delegates to LLMConfig.base_url (utils/config.py) rather than
+    # re-deriving the per-provider URL shape here — that property already
+    # knows ollama/llama_cpp are OpenAI-compatible on {host}/v1 while
+    # openrouter's is the fixed https://openrouter.ai/api/v1, so this stays
+    # correct as providers are added instead of drifting from it.
+    try:
+        from prisma.utils.config import ConfigLoader
+        return ConfigLoader().get_llm_config().base_url
+    except Exception:
+        return "http://localhost:11434"
+
+
+def _llm_provider() -> str:
+    try:
+        from prisma.utils.config import ConfigLoader
+        return ConfigLoader().get_llm_config().provider
+    except Exception:
+        return "ollama"
+
+
+def _llm_api_key() -> str:
+    # Only meaningful for provider=openrouter — ollama/llama_cpp's local
+    # OpenAI-compat servers don't check the key at all (dummy value kept for
+    # API compatibility with the openai SDK, which requires a non-empty
+    # string). Mirrors ChatLLM._resolve_api_key's same env-var-by-name
+    # pattern (ADR-014) — the real key never lives in config.yaml itself.
+    try:
+        from prisma.utils.config import ConfigLoader
+        cfg = ConfigLoader().get_llm_config()
+        if cfg.provider == "openrouter":
+            if not cfg.api_key_env:
+                raise RuntimeError("llm.provider is 'openrouter' but llm.api_key_env is not set")
+            key = os.environ.get(cfg.api_key_env)
+            if not key:
+                raise RuntimeError(f"llm.api_key_env={cfg.api_key_env!r} is not set in the environment")
+            return key
+    except Exception:
+        _log.warning("could not resolve openrouter API key for KG extraction", exc_info=True)
+    return "ollama"
+
+
+def _llm_context_window() -> int | None:
+    # Static override for providers with no live-queryable endpoint
+    # (openrouter) — see LLMConfig.context_window's own docstring.
+    try:
+        from prisma.utils.config import ConfigLoader
+        return ConfigLoader().get_llm_config().context_window
+    except Exception:
+        return None
+
+
+def _max_output_fraction() -> float:
+    try:
         import yaml
         cfg_path = Path.home() / ".config" / "prisma" / "config.yaml"
         cfg = yaml.safe_load(cfg_path.read_text()) or {}
-        return cfg.get("llm", {}).get("model", "qwen2.5:7b-32k")
+        return float(cfg.get("kg", {}).get("max_output_fraction", 0.25))
     except Exception:
-        return "qwen2.5:7b-32k"
+        return 0.25
 
 
 def _index_extensions() -> tuple[str, ...]:
@@ -99,6 +160,11 @@ _vault = VaultService(vault_root=_resolve_vault_root())
 _kg = KnowledgeGraphService(
     _vault,
     ollama_model=_ollama_model(),
+    ollama_base_url=_llm_base_url(),
+    provider=_llm_provider(),
+    api_key=_llm_api_key(),
+    context_window_override=_llm_context_window(),
+    max_output_fraction=_max_output_fraction(),
     index_extensions=_index_extensions(),
     extraction_concurrency=_extraction_concurrency(),
     token_budget=_token_budget(),

--- a/prisma/server/supervisor.py
+++ b/prisma/server/supervisor.py
@@ -224,6 +224,7 @@ def _profile_missing_models(
     affinity: set[str],
     model_vram: dict[str, dict[str, int]],
     base_url: str,
+    pool_provider: dict[str, str] | None = None,
 ) -> None:
     """Run once at supervisor startup, in its own daemon thread — for any
     model in a VRAM-budget-aware pool with neither a config.yaml `vram_mb`
@@ -243,11 +244,21 @@ def _profile_missing_models(
     the end of this function) can sum a pool's models against
     vram_budget_mb and flag "these don't fit together" before a config
     change ships, not just react to it after the fact.
+
+    Skips `provider: llama_cpp` pools entirely — `_probe_model_vram` forces a
+    load via Ollama's native /api/generate, which llama-server/llama-swap
+    don't implement. Those pools must have `vram_mb` set explicitly in
+    config for every model (no auto-profiling fallback) — see
+    docs/llamacpp-vulkan-forge-vs-anvil-benchmark.md in this repo for real
+    measured numbers to use as a starting point.
     """
     saved_profiles = _load_vram_profiles()
+    pool_provider = pool_provider or {}
     for pool_name in affinity:
         if pool_vram_budget.get(pool_name) is None:
             continue  # not vram-budget-aware — nothing here to inform
+        if pool_provider.get(pool_name, "ollama") == "llama_cpp":
+            continue
         configured = model_vram.get(pool_name, {})
         for model in pool_models.get(pool_name, set()):
             if model in configured or model in saved_profiles:
@@ -269,13 +280,14 @@ def _profile_missing_models(
 def _load_compute_pools() -> tuple[
     dict[str, int], set[str], dict[str, set[str]], dict[str, dict[str, int]],
     dict[str, int | None], dict[str, dict[str, int]], dict[str, dict[str, int]],
+    dict[str, str],
 ]:
     """Named compute pools and their concurrency limits, e.g.:
 
         compute_pools:
           - name: local-ollama       # a single GPU / single Ollama instance
             type: gpu                # models here can genuinely coexist in VRAM
-            provider: ollama          # informational — for humans reading this file
+            provider: ollama          # ollama | llama_cpp — see note below
             max_concurrent: 3         # fallback for any model below with no override
             vram_budget_mb: 14000     # total VRAM this pool may commit across ALL resident models
             models:
@@ -311,6 +323,18 @@ def _load_compute_pools() -> tuple[
     with no `type` falls back to the legacy `model_affinity` key (default
     true) for configs written before `type` existed — `type` wins when
     both are present.
+
+    `provider: llama_cpp` (e.g. a llama-swap-backed pool) skips the live
+    Ollama `/api/ps` query entirely — llama-swap has no equivalent live
+    resident-VRAM introspection endpoint, and doesn't need one here: its own
+    `swap: false` groups are configured to never evict each other, so
+    "what's really resident right now" is just whatever this pool's active
+    leases already say. `ResourceManager.acquire()` sums active leases'
+    configured `vram_mb` directly for these pools instead of asking an
+    external API — the same arithmetic the Ollama path falls back to when
+    `/api/ps` is unreachable, just as the *normal* path here rather than a
+    degraded fallback. `provider: ollama` (the default) keeps the live
+    `/api/ps` behavior described above.
 
     Each `models` entry is either a plain string (uses the pool's own
     `max_concurrent`, no `vram_mb`/`background_max_concurrent`) or a
@@ -353,6 +377,7 @@ def _load_compute_pools() -> tuple[
             pool_vram_budget: dict[str, int | None] = {}
             model_vram: dict[str, dict[str, int]] = {}
             model_background_limit: dict[str, dict[str, int]] = {}
+            pool_provider: dict[str, str] = {p["name"]: p.get("provider", "ollama") for p in pools}
             for p in pools:
                 names: set[str] = set()
                 overrides: dict[str, int] = {}
@@ -374,10 +399,16 @@ def _load_compute_pools() -> tuple[
                 pool_vram_budget[p["name"]] = int(p["vram_budget_mb"]) if "vram_budget_mb" in p else None
                 model_vram[p["name"]] = vram
                 model_background_limit[p["name"]] = background
-            return capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram, model_background_limit
+            return (
+                capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram,
+                model_background_limit, pool_provider,
+            )
     except Exception:
         pass
-    return {"default": 1}, {"default"}, {"default": set()}, {"default": {}}, {"default": None}, {"default": {}}, {"default": {}}
+    return (
+        {"default": 1}, {"default"}, {"default": set()}, {"default": {}}, {"default": None}, {"default": {}},
+        {"default": {}}, {"default": "ollama"},
+    )
 
 
 def _die_with_parent() -> None:
@@ -558,6 +589,7 @@ class ResourceManager:
         model_vram: dict[str, dict[str, int]] | None = None,
         model_background_limit: dict[str, dict[str, int]] | None = None,
         ollama_base_url: str = "http://localhost:11434",
+        pool_provider: dict[str, str] | None = None,
     ) -> None:
         self._lock = threading.Lock()
         self._capacity = dict(pools)
@@ -585,6 +617,10 @@ class ResourceManager:
         # has at least one free slot rather than queueing behind bulk work.
         self._model_background_limit = {name: dict(m) for name, m in (model_background_limit or {}).items()}
         self._ollama_base_url = ollama_base_url
+        # pool -> "ollama" | "llama_cpp" — see acquire()'s vram_aware branch.
+        # Pools not in this dict (e.g. reload_config called from an older
+        # config shape) default to "ollama", the historical-only behavior.
+        self._pool_provider = dict(pool_provider or {})
         # pool -> {request_id: {holder, pid, model, acquired_at, timeout, priority}}
         self._leases: dict[str, dict[str, dict]] = {name: {} for name in pools}
         self._active_model: dict[str, str | None] = {name: None for name in pools}
@@ -671,21 +707,32 @@ class ResourceManager:
                         )
                         continue  # busy with a different model — must drain first
                 elif vram_aware and model is not None:
-                    resident = _query_ollama_resident_mb(self._ollama_base_url)
+                    # llama_cpp pools (e.g. llama-swap) have no live
+                    # /api/ps-equivalent to query — and don't need one, since
+                    # their groups are configured (swap: false) to never evict
+                    # each other. Skip straight to deriving "what's resident"
+                    # from this pool's own active leases, the same computation
+                    # the ollama path only falls back to when /api/ps itself
+                    # is unreachable.
+                    is_llama_cpp = self._pool_provider.get(name, "ollama") == "llama_cpp"
+                    resident = None if is_llama_cpp else _query_ollama_resident_mb(self._ollama_base_url)
                     if resident is None:
-                        # Can't verify Ollama's real state — fail safe to the
-                        # strict single-resident-model rule rather than guess.
-                        # vram-aware pools don't maintain _active_model (it'd
-                        # be ambiguous with several models resident at once),
-                        # so derive "busy with a different model" from actual
-                        # lease data instead.
+                        # Can't verify live resident state (llama_cpp: by
+                        # design; ollama: /api/ps unreachable) — fail safe to
+                        # the strict single-resident-model rule rather than
+                        # guess. vram-aware pools don't maintain _active_model
+                        # (it'd be ambiguous with several models resident at
+                        # once), so derive "busy with a different model" from
+                        # actual lease data instead.
                         other_models = {l["model"] for l in self._leases[name].values() if l["model"] != model}
                         if other_models:
                             self._stats[name]["denied_model_busy"] += 1
                             log.info(
                                 "acquire denied: pool=%s holder=%s pid=%d model=%s priority=%s "
-                                "reason=model_busy (ollama unreachable, other resident models=%s)",
-                                name, holder, pid, model, priority, sorted(other_models),
+                                "reason=model_busy (%s, other resident models=%s)",
+                                name, holder, pid, model, priority,
+                                "leases-derived" if is_llama_cpp else "ollama unreachable",
+                                sorted(other_models),
                             )
                             continue
                     elif model not in resident:
@@ -833,6 +880,7 @@ class ResourceManager:
         vram_budget: dict[str, int | None] | None = None,
         model_vram: dict[str, dict[str, int]] | None = None,
         model_background_limit: dict[str, dict[str, int]] | None = None,
+        pool_provider: dict[str, str] | None = None,
     ) -> None:
         """Re-read compute_pools from config.yaml into a *running*
         ResourceManager, without restarting the supervisor or touching
@@ -855,6 +903,7 @@ class ResourceManager:
             self._vram_budget = dict(vram_budget or {})
             self._model_vram = {name: dict(m) for name, m in (model_vram or {}).items()}
             self._model_background_limit = {name: dict(m) for name, m in (model_background_limit or {}).items()}
+            self._pool_provider = dict(pool_provider or {})
             for name in pools:
                 self._leases.setdefault(name, {})
                 self._active_model.setdefault(name, None)
@@ -1026,10 +1075,10 @@ def _make_handler(supervisor: Supervisor):
                 self._json(200, {"status": "released"})
             elif self.path == "/supervisor/resources/reload":
                 (capacity, affinity, pool_models, model_concurrency,
-                 vram_budget, model_vram, model_background_limit) = _load_compute_pools()
+                 vram_budget, model_vram, model_background_limit, pool_provider) = _load_compute_pools()
                 supervisor.resources.reload_config(
                     capacity, affinity, pool_models, model_concurrency,
-                    vram_budget, model_vram, model_background_limit,
+                    vram_budget, model_vram, model_background_limit, pool_provider,
                 )
                 self._json(200, {"status": "reloaded", "pools": list(capacity)})
             else:
@@ -1082,12 +1131,11 @@ def main(
         "kg": Worker("kg", [_venv_bin("uvicorn"), "prisma.server.kg_app:app", "--host", host, "--port", str(kg_port)],
                      stop_timeout=15.0, env={"PRISMA_SUPERVISOR_PORT": str(supervisor_port)}),
     }
-    capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram, model_background_limit = (
-        _load_compute_pools()
-    )
+    (capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram,
+     model_background_limit, pool_provider) = _load_compute_pools()
     resources = ResourceManager(
         capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram,
-        model_background_limit, ollama_base_url=_ollama_base_url(),
+        model_background_limit, ollama_base_url=_ollama_base_url(), pool_provider=pool_provider,
     )
     # Best-effort check with whatever's already known (config + previously
     # saved profiles) — don't wait for the profiling thread below, which can
@@ -1096,7 +1144,7 @@ def main(
     _check_pool_vram_fit(pool_models, pool_vram_budget, affinity, model_vram)
     threading.Thread(
         target=_profile_missing_models,
-        args=(resources, pool_models, pool_vram_budget, affinity, model_vram, _ollama_base_url()),
+        args=(resources, pool_models, pool_vram_budget, affinity, model_vram, _ollama_base_url(), pool_provider),
         daemon=True, name="vram-profiler",
     ).start()
 

--- a/prisma/server/sync_routes.py
+++ b/prisma/server/sync_routes.py
@@ -1,0 +1,118 @@
+"""Vault file sync endpoints (/sync/*) for the desktop (Tauri) client.
+
+Whole-file, path-based (not slug-based) — the desktop mirrors the vault's
+`.md` files 1:1 onto local disk (see the vault-sync plan / TODO.md's
+"Deferred feature: desktop<->server sync"). KG/Chroma stay server-side only;
+desktop never touches them — this router is the entire surface desktop
+needs.
+
+Built via a factory (`build_sync_router`) taking getter callables rather
+than raw objects: app.py's `/reload`-style endpoints rebind its module
+globals (`global _vault; _vault = VaultService(...)`) at runtime, so a
+router that captured `_vault` by value at include_router() time would keep
+talking to a stale, replaced instance after a reload. Getters re-read the
+current global on every request, same as every other endpoint in app.py
+already does implicitly by referencing the module-level name directly.
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from prisma.services.vault import VaultService
+
+_CLIENT_ID_HEADER = "x-sync-client-id"
+
+
+class SyncManifestEntry(BaseModel):
+    path: str
+    mtime: float
+    size: int
+
+
+class SyncFileResponse(BaseModel):
+    path: str
+    body: str
+    mtime: float
+
+
+class SyncFileWriteRequest(BaseModel):
+    path: str
+    body: str
+    expected_mtime: Optional[float] = None
+
+
+def build_sync_router(
+    get_vault: Callable[[], VaultService],
+    broadcast_fn: Callable[..., None],
+    mark_stale_fn: Callable[[], None],
+) -> APIRouter:
+    router = APIRouter(prefix="/sync", tags=["sync"])
+
+    @router.get("/manifest", response_model=list[SyncManifestEntry])
+    def manifest():
+        return [
+            SyncManifestEntry(path=path, mtime=mtime, size=size)
+            for path, mtime, size in get_vault().list_md_manifest()
+        ]
+
+    @router.get("/file", response_model=SyncFileResponse)
+    def get_file(path: str = Query(...)):
+        try:
+            result = get_vault().read_by_path(path)
+        except ValueError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"not found: {path!r}")
+        body, mtime = result
+        return SyncFileResponse(path=path, body=body, mtime=mtime)
+
+    @router.put("/file", response_model=SyncFileResponse)
+    def put_file(req: SyncFileWriteRequest, request: Request):
+        vault = get_vault()
+        try:
+            current = vault.read_by_path(req.path)
+        except ValueError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+
+        if current is not None:
+            body, mtime = current
+            # Either an explicit mtime mismatch, or the client believed
+            # this path was brand new (expected_mtime is None) but the
+            # server already has a file there — same ambiguity either way,
+            # resolved identically client-side (compare mtimes, keep newer).
+            if req.expected_mtime is None or mtime != req.expected_mtime:
+                raise HTTPException(
+                    status_code=409,
+                    detail={"path": req.path, "body": body, "mtime": mtime},
+                )
+
+        try:
+            new_mtime = vault.write_by_path(req.path, req.body)
+        except ValueError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+
+        mark_stale_fn()
+        broadcast_fn(
+            {"type": "vault_change", "action": "sync_write", "path": req.path},
+            exclude_client_id=request.headers.get(_CLIENT_ID_HEADER),
+        )
+        return SyncFileResponse(path=req.path, body=req.body, mtime=new_mtime)
+
+    @router.delete("/file")
+    def delete_file(request: Request, path: str = Query(...)):
+        try:
+            get_vault().delete_by_path(path)
+        except ValueError as exc:
+            raise HTTPException(status_code=403, detail=str(exc))
+
+        mark_stale_fn()
+        broadcast_fn(
+            {"type": "vault_change", "action": "sync_delete", "path": path},
+            exclude_client_id=request.headers.get(_CLIENT_ID_HEADER),
+        )
+        return {"status": "deleted", "path": path}
+
+    return router

--- a/prisma/services/chat_llm.py
+++ b/prisma/services/chat_llm.py
@@ -1,10 +1,10 @@
 """Backend-agnostic LLM interface for the chat module (ADR-014: openai SDK,
 multi-base_url — not litellm, not hand-rolled requests).
 
-Ollama and OpenRouter are both OpenAI-API-compatible, so the same `openai`
-client works for either with just a base_url/api_key change. Anthropic
-would need its own adapter when that backend is actually built (see
-ADR-014) — not needed yet, chat is Ollama-only today.
+Ollama, llama.cpp (llama-server/llama-swap), and OpenRouter are all
+OpenAI-API-compatible, so the same `openai` client works for any of them with
+just a base_url/api_key change. Anthropic would need its own adapter when that
+backend is actually built (see ADR-014).
 
 Every call goes through resource_lock.lease(), same as the knowledge
 graph's and ChromaDB's Ollama calls — one shared arbitration point for
@@ -63,7 +63,9 @@ class ChatLLM:
     def _resolve_base_url(self) -> str:
         if self._config.base_url:
             return self._config.base_url
-        if self._config.provider == "ollama":
+        if self._config.provider in ("ollama", "llama_cpp"):
+            # Both are OpenAI-API-compatible on their /v1 path — same client,
+            # just a different local backend host:port (llm.host in config).
             return f"http://{self._ollama_host}/v1"
         if self._config.provider == "openrouter":
             return "https://openrouter.ai/api/v1"
@@ -79,7 +81,7 @@ class ChatLLM:
                     f"chat.api_key_env={self._config.api_key_env!r} is set but not present in the environment"
                 )
             return key
-        return "ollama"  # Ollama's OpenAI-compat endpoint ignores the key but the SDK requires a non-empty string
+        return "ollama"  # placeholder — Ollama/llama.cpp's OpenAI-compat endpoints ignore the key, but the SDK requires a non-empty string
 
     def complete(self, messages: list[dict], temperature: float = 0.1) -> str | None:
         """One resource_lock-gated chat completion call. Returns None if the

--- a/prisma/services/chroma_service.py
+++ b/prisma/services/chroma_service.py
@@ -15,8 +15,26 @@ _log = logging.getLogger("prisma.chroma")
 _RESOURCE_HOLDER = "api"  # must match the worker name supervisor.py restarts, so a crash releases our leases
 
 
-def _embed_texts(texts: list[str], model: str, base_url: str = "http://localhost:11434") -> list[list[float]] | None:
+def _embed_texts(
+    texts: list[str], model: str, base_url: str = "http://localhost:11434", provider: str = "ollama",
+) -> list[list[float]] | None:
+    """provider="ollama" uses Ollama's native /api/embed (its own request/
+    response shape). provider="llama_cpp" uses the OpenAI-compatible
+    /v1/embeddings endpoint that llama-server/llama-swap expose (e.g. served
+    from a bge-m3-style embedding model) — same idea, different wire format,
+    so this is a real branch, not just a base_url swap like chat_llm.py's."""
     try:
+        if provider == "llama_cpp":
+            resp = requests.post(
+                f"{base_url}/v1/embeddings",
+                json={"model": model, "input": texts},
+                timeout=60,
+            )
+            if resp.status_code != 200:
+                _log.warning("embed failed: status=%d", resp.status_code)
+                return None
+            data = sorted(resp.json().get("data", []), key=lambda item: item.get("index", 0))
+            return [item["embedding"] for item in data]
         resp = requests.post(
             f"{base_url}/api/embed",
             json={"model": model, "input": texts},
@@ -45,6 +63,7 @@ class ChromaIndexer:
         vault: VaultService,
         embedding_model: str = "nomic-embed-text",
         ollama_base_url: str = "http://localhost:11434",
+        provider: str = "ollama",
         chroma_host: str = "127.0.0.1",
         chroma_port: int = 8767,
         supervisor_host: str = "127.0.0.1",
@@ -53,6 +72,7 @@ class ChromaIndexer:
         self._vault = vault
         self._model = embedding_model
         self._base_url = ollama_base_url
+        self._provider = provider
         # ChromaDB runs as its own supervised server process (ADR-012), not
         # embedded — a crash there no longer takes down this process's threads.
         self._chroma_host = chroma_host
@@ -162,7 +182,7 @@ class ChromaIndexer:
         except Exception:
             return []
         with resource_lock.lease(self._supervisor_host, self._supervisor_port, holder=_RESOURCE_HOLDER, model=self._model) as granted:
-            embeddings = _embed_texts([question], self._model, self._base_url) if granted else None
+            embeddings = _embed_texts([question], self._model, self._base_url, self._provider) if granted else None
         if not embeddings:
             _log.warning("chroma query: embedding failed for question, skipping")
             return []
@@ -271,12 +291,10 @@ class ChromaIndexer:
 
     def _probe_model(self) -> bool:
         """Return False and log an actionable warning if the embedding model is not available."""
-        result = _embed_texts(["test"], self._model, self._base_url)
+        result = _embed_texts(["test"], self._model, self._base_url, self._provider)
         if result is None:
-            _log.error(
-                "chroma: embedding model %r not available — run: ollama pull %s",
-                self._model, self._model,
-            )
+            hint = f"ollama pull {self._model}" if self._provider == "ollama" else f"check {self._model!r} is loaded in llama-swap"
+            _log.error("chroma: embedding model %r not available — %s", self._model, hint)
             return False
         return True
 
@@ -329,7 +347,7 @@ class ChromaIndexer:
         except OSError:
             return False
         chunks = _chunk_markdown(text)
-        embeddings = _embed_texts(chunks, self._model, self._base_url)
+        embeddings = _embed_texts(chunks, self._model, self._base_url, self._provider)
         if embeddings is None or len(embeddings) != len(chunks):
             _log.warning("chroma: embedding failed for %s — skipping", rel)
             return False

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Literal
 
 import instructor
+import requests
 from instructor.core.exceptions import IncompleteOutputException, InstructorRetryException
 from instructor.core.hooks import Hooks
 from openai import OpenAI
@@ -297,6 +298,10 @@ class KnowledgeGraphService:
         interval_minutes: int = 10,
         ollama_model: str = "qwen2.5:7b-32k",
         ollama_base_url: str = "http://localhost:11434",
+        provider: str = "ollama",
+        api_key: str = "ollama",
+        context_window_override: int | None = None,
+        max_output_fraction: float = 0.25,
         token_budget: int = 1000,
         index_extensions: tuple[str, ...] = DEFAULT_INDEX_EXTENSIONS,
         supervisor_host: str = "127.0.0.1",
@@ -308,6 +313,29 @@ class KnowledgeGraphService:
         self._interval = interval_minutes * 60
         self._ollama_model = ollama_model
         self._base_url = ollama_base_url
+        self._provider = provider
+        # Fraction of the model's real context window max_tokens may use,
+        # even when more technically fits — quality degrades well before
+        # the context ceiling (docs/kg-extraction-context-length.md), and
+        # different models degrade at different rates, so this is a
+        # per-deployment config knob (kg.max_output_fraction), not a single
+        # hardcoded global constant.
+        self._max_output_fraction = max_output_fraction
+        # Resolved lazily (first extraction call) rather than at construction
+        # time — the model may not be loaded yet (llama-swap loads on
+        # demand), and querying too early would just get "not found". None
+        # until resolved; a resolution failure permanently falls back to a
+        # conservative hardcoded assumption rather than retrying every call.
+        # A static override (openrouter — no local endpoint to query at all)
+        # counts as already-resolved, skipping the live-query attempt.
+        self._context_window: int | None = context_window_override
+        self._context_window_resolved = context_window_override is not None
+        # ollama/llama_cpp's local OpenAI-compat servers live at {host}/v1;
+        # openrouter's base_url (from LLMConfig.base_url, via kg_app.py's
+        # _llm_base_url()) is already the complete
+        # "https://openrouter.ai/api/v1" — appending /v1 again would be
+        # wrong, so only the local providers get it appended here.
+        resolved_base_url = ollama_base_url if provider == "openrouter" else f"{ollama_base_url}/v1"
         # Instructor validates the extraction response against `Extraction`
         # and retries on validation failure, replacing the old markdown-fence
         # regex + manual dict parsing. Mode.JSON (not the default Mode.TOOLS)
@@ -316,7 +344,7 @@ class KnowledgeGraphService:
         # unreliable for this local model (qwen2.5:7b class), so JSON mode is
         # the consistent choice here too.
         self._instructor_client = instructor.from_openai(
-            OpenAI(base_url=f"{ollama_base_url}/v1", api_key="ollama", timeout=300.0),
+            OpenAI(base_url=resolved_base_url, api_key=api_key, timeout=300.0),
             mode=instructor.Mode.JSON,
         )
         # Per-section token budget, not per-file — this is the actual fix for
@@ -375,6 +403,13 @@ class KnowledgeGraphService:
         # Kùzu query or get told "busy," which a partial/lazy cache would
         # need to handle.
         self._indexed_cache: dict[str, str] = {}
+        # Parallel to _indexed_cache — which model actually produced this
+        # file's current graph entries. Not used for the re-extract-or-not
+        # decision (content_hash alone still drives that); this is purely
+        # provenance, for comparing extraction quality across models on the
+        # same content (e.g. NuExtract vs qwen2.5 vs a future cloud model)
+        # without losing track of which model produced what.
+        self._indexed_model_cache: dict[str, str | None] = {}
 
         self._state: IndexState = "stale"
         self._last_indexed: datetime | None = None
@@ -471,6 +506,7 @@ class KnowledgeGraphService:
                         "MATCH (f:IndexedFile {source_file: $rel}) DETACH DELETE f", {"rel": rel_path},
                     )
                     self._indexed_cache.pop(rel_path, None)
+                    self._indexed_model_cache.pop(rel_path, None)
                 except Exception as exc:
                     _log.warning("taint_file: failed to clear tracking node for %s: %s", rel_path, exc)
             self._pending.add(path)
@@ -508,6 +544,7 @@ class KnowledgeGraphService:
                     self._conn.execute("MATCH (e:Entity) DETACH DELETE e")
                     self._conn.execute("MATCH (f:IndexedFile) DETACH DELETE f")
                     self._indexed_cache.clear()
+                    self._indexed_model_cache.clear()
                 except Exception as exc:
                     _log.warning("drop_index failed: %s", exc)
             self._state = "stale"
@@ -547,6 +584,76 @@ class KnowledgeGraphService:
                 return True
         except OSError:
             return False
+
+    def _resolve_context_window(self) -> int | None:
+        """The model's real *loaded* context window (not a claimed/configured
+        value — see ADR-013's follow-up section on why that distinction
+        matters, and docs/kg-extraction-context-length.md Round 3 for a
+        concrete case of it mattering). Queried once and cached — a
+        resolution failure (model not loaded yet, backend unreachable) is
+        remembered as "give up," not retried every call, so a persistently
+        unreachable backend doesn't add a query's worth of latency to every
+        single extraction."""
+        if self._context_window_resolved:
+            return self._context_window
+        self._context_window_resolved = True
+        try:
+            if self._provider == "openrouter":
+                # No live-queryable endpoint — this path is only reached
+                # when llm.context_window wasn't set for an openrouter
+                # deployment. Falls through to the except/None below,
+                # which _compute_max_tokens treats as "use the hardcoded
+                # 4000 ceiling only" — degraded, not broken, but
+                # llm.context_window should really be set for this provider.
+                _log.warning(
+                    "provider=openrouter but llm.context_window is unset — "
+                    "max_output_fraction won't apply, only the hardcoded ceiling will"
+                )
+            elif self._provider == "llama_cpp":
+                resp = requests.get(f"{self._base_url}/v1/models", timeout=5)
+                resp.raise_for_status()
+                for entry in resp.json().get("data", []):
+                    if entry.get("id") == self._ollama_model:
+                        n_ctx = entry.get("meta", {}).get("n_ctx")
+                        if n_ctx:
+                            self._context_window = int(n_ctx)
+                            return self._context_window
+            else:  # ollama
+                resp = requests.get(f"{self._base_url}/api/ps", timeout=5)
+                resp.raise_for_status()
+                for entry in resp.json().get("models", []):
+                    if entry.get("name") == self._ollama_model:
+                        n_ctx = entry.get("context_length")
+                        if n_ctx:
+                            self._context_window = int(n_ctx)
+                            return self._context_window
+        except Exception as exc:
+            _log.warning("could not resolve %s's real context window: %s", self._ollama_model, exc)
+        return self._context_window
+
+    def _compute_max_tokens(self, prompt_tokens_estimate: int) -> int:
+        """How many output tokens to actually allow for one extraction call.
+        Three independent ceilings, take the smallest:
+        1. A hardcoded sane ceiling (4000 — see the call site's own history:
+           raised from 2000 after a real entity-dense paper needed more).
+        2. `max_output_fraction` (config.yaml's kg.max_output_fraction,
+           default 0.25) of the model's real context window — even if more
+           technically fits, quality degrades well before the context limit
+           (see kg-extraction-context-length.md), and this fraction is
+           deliberately per-model-tunable in config rather than a single
+           global constant, since different models degrade at different
+           rates (cservinl, 2026-07-24).
+        3. Whatever headroom is actually left in the context window after
+           the prompt itself (system prompt + section content) — a hard
+           technical ceiling, not a quality one.
+        Floors at 500 regardless (a lower cap than that risks truncating
+        even a well-behaved extraction on real content)."""
+        ceilings = [4000]
+        context_window = self._resolve_context_window()
+        if context_window:
+            ceilings.append(int(context_window * self._max_output_fraction))
+            ceilings.append(max(0, context_window - prompt_tokens_estimate - 200))
+        return max(500, min(ceilings))
 
     def status(self) -> dict:
         with self._lock:
@@ -609,12 +716,27 @@ class KnowledgeGraphService:
         # restarting kg lost track of files it had already durably graphed).
         self._conn.execute(
             "CREATE NODE TABLE IF NOT EXISTS IndexedFile("
-            "source_file STRING, content_hash STRING, PRIMARY KEY(source_file))"
+            "source_file STRING, content_hash STRING, extracted_by STRING, "
+            "PRIMARY KEY(source_file))"
         )
-        result = self._conn.execute("MATCH (f:IndexedFile) RETURN f.source_file, f.content_hash")
+        # Migration: CREATE TABLE IF NOT EXISTS is a no-op against a Kùzu DB
+        # that already has an IndexedFile table from before extracted_by
+        # existed (true for any pre-2026-07-24 database, including whatever
+        # ends up on forge) — the column never gets added for those without
+        # this explicit ALTER. Kùzu has no "ADD COLUMN IF NOT EXISTS", so
+        # just swallow the one error it raises when the column is already
+        # there (a fresh DB created by the statement above already has it).
+        try:
+            self._conn.execute("ALTER TABLE IndexedFile ADD extracted_by STRING")
+        except RuntimeError:
+            pass
+        result = self._conn.execute(
+            "MATCH (f:IndexedFile) RETURN f.source_file, f.content_hash, f.extracted_by"
+        )
         while result.has_next():
-            source_file, content_hash = result.get_next()
+            source_file, content_hash, extracted_by = result.get_next()
             self._indexed_cache[source_file] = content_hash
+            self._indexed_model_cache[source_file] = extracted_by
 
     # ── Extraction ────────────────────────────────────────────────────────────
 
@@ -675,6 +797,11 @@ class KnowledgeGraphService:
 
                 hooks = Hooks()
                 hooks.on("parse:error", _on_parse_error)
+                # Rough token estimate (chars // 4, same heuristic
+                # _chunk_markdown's own chunker uses) of system prompt +
+                # section content — just enough to compute real remaining
+                # headroom in _compute_max_tokens, not meant to be exact.
+                prompt_tokens_estimate = (len(_EXTRACTION_SYSTEM) + len(prompt)) // 4
                 try:
                     extraction = self._instructor_client.chat.completions.create(
                         model=self._ollama_model,
@@ -694,21 +821,14 @@ class KnowledgeGraphService:
                         # compute/GPU-bound (single-stream decode is
                         # memory-bound, so low GPU% during a long
                         # generation is normal, not a sign of throttling).
-                        # Originally set to 2000 (== token_budget) on the
-                        # assumption that a structured JSON extraction
-                        # shouldn't need to be longer than the section it's
-                        # summarizing — wrong in practice: a dense paper's
-                        # entity/relationship list can legitimately exceed
-                        # its own input length as JSON, and Instructor
+                        # Originally a flat 4000 (raised from 2000 after a
+                        # real entity-dense paper needed more — Instructor
                         # treats a length-truncated response as immediately
-                        # fatal (IncompleteOutputException, not retryable —
-                        # retrying would just truncate at the same cap
-                        # again). Confirmed live: a Chinchilla-scaling-laws
-                        # chunk was dropped for exactly this reason. 4000
-                        # gives real headroom while still bounding the
-                        # runaway-generation failure mode this cap exists
-                        # for in the first place.
-                        max_tokens=4000,
+                        # fatal, not retryable at the same cap). Now computed
+                        # per-call/per-model instead of hardcoded — see
+                        # _compute_max_tokens's own docstring for the three
+                        # ceilings it takes the smallest of.
+                        max_tokens=self._compute_max_tokens(prompt_tokens_estimate),
                         # Instructor re-prompts on validation failure — each
                         # retry is a real Ollama call, so it must happen
                         # inside this lease, not after releasing it.
@@ -922,16 +1042,28 @@ class KnowledgeGraphService:
         IndexedFile table, kept in sync on every write."""
         return self._indexed_cache.get(rel)
 
+    def indexed_model(self, rel: str) -> str | None:
+        """Which model produced this file's current graph entries, or None
+        if never indexed. Public (no leading underscore, no lock required)
+        — pure provenance lookup for comparing extraction quality across
+        models on the same content, safe to call from the API layer."""
+        return self._indexed_model_cache.get(rel)
+
     def _set_indexed_hash(self, rel: str, content_hash: str) -> None:
         """Caller must hold self._lock. Write-through: Kùzu first (the
         durable store), then the cache — if the Kùzu write fails, the
-        cache must not silently disagree with what's actually persisted."""
+        cache must not silently disagree with what's actually persisted.
+        Also stamps which model produced this file's current graph entries
+        (self._ollama_model) — pure provenance, doesn't affect the
+        re-extract-or-not decision (content_hash alone still drives that)."""
         try:
             self._conn.execute(
-                "MERGE (f:IndexedFile {source_file: $rel}) SET f.content_hash = $hash",
-                {"rel": rel, "hash": content_hash},
+                "MERGE (f:IndexedFile {source_file: $rel}) "
+                "SET f.content_hash = $hash, f.extracted_by = $model",
+                {"rel": rel, "hash": content_hash, "model": self._ollama_model},
             )
             self._indexed_cache[rel] = content_hash
+            self._indexed_model_cache[rel] = self._ollama_model
         except Exception as exc:
             _log.warning("failed to record indexed hash for %s: %s", rel, exc)
 
@@ -983,6 +1115,7 @@ class KnowledgeGraphService:
                 self._conn.execute("MATCH (e:Entity {source_file: $rel}) DETACH DELETE e", {"rel": rel})
                 self._conn.execute("MATCH (f:IndexedFile {source_file: $rel}) DETACH DELETE f", {"rel": rel})
                 self._indexed_cache.pop(rel, None)
+                self._indexed_model_cache.pop(rel, None)
             return True
         except Exception as exc:
             _log.warning("delete failed for %s: %s", rel, exc)
@@ -1198,7 +1331,7 @@ class KnowledgeGraphService:
                 })
         except Exception as exc:
             _log.warning("entities_for_file edges failed for %s: %s", rel_path, exc)
-        return {"entities": entities, "edges": edges}
+        return {"entities": entities, "edges": edges, "extracted_by": self.indexed_model(rel_path)}
 
     def search(self, question: str, top_k: int = 20) -> list[dict]:
         terms = [t.lower() for t in re.findall(r"[a-zA-Z0-9_]+", question) if len(t) > 2]

--- a/prisma/services/vault.py
+++ b/prisma/services/vault.py
@@ -182,6 +182,8 @@ class VaultService:
         # change. Chat writes are low-frequency; one process-wide lock is
         # simple and sufficient — no need for per-slug lock management.
         self._chat_write_lock = threading.Lock()
+        # Same rationale as _chat_write_lock, for /sync/file's writes.
+        self._path_write_lock = threading.Lock()
 
     def ensure_dirs(self) -> None:
         for d in self.default_dirs.values():
@@ -901,6 +903,50 @@ class VaultService:
         if ".." in Path(rel_path).parts:
             raise ValueError("path outside vault")
         (self.root / rel_path).mkdir(parents=True, exist_ok=True)
+
+    # ── Path-based access (sync) ─────────────────────────────────────────────
+    # Used by /sync/* — unlike the rest of this class, the desktop client
+    # addresses files by their vault-relative path directly (it mirrors the
+    # vault's on-disk layout 1:1), not by slug. Kept narrow (.md only,
+    # explicit path) rather than extending the slug-resolution machinery.
+
+    def _safe_sync_path(self, rel_path: str) -> Path:
+        if not rel_path.endswith(".md"):
+            raise ValueError("sync only supports .md files")
+        p = Path(rel_path)
+        if p.is_absolute() or ".." in p.parts:
+            raise ValueError("path outside vault")
+        if any(part in _SKIP_DIRS or part.startswith(".") for part in p.parts[:-1]):
+            raise ValueError("path inside a reserved or hidden directory")
+        return self.root / p
+
+    def read_by_path(self, rel_path: str) -> tuple[str, float] | None:
+        path = self._safe_sync_path(rel_path)
+        if not path.is_file():
+            return None
+        return path.read_text(encoding="utf-8"), path.stat().st_mtime
+
+    def write_by_path(self, rel_path: str, body: str) -> float:
+        """Create-or-overwrite. Returns the new mtime."""
+        path = self._safe_sync_path(rel_path)
+        with self._path_write_lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+            return path.stat().st_mtime
+
+    def delete_by_path(self, rel_path: str) -> None:
+        path = self._safe_sync_path(rel_path)
+        with self._path_write_lock:
+            path.unlink(missing_ok=True)
+
+    def list_md_manifest(self) -> list[tuple[str, float, int]]:
+        """(rel_path, mtime, size) for every .md file — the desktop
+        client's input for initial-reconciliation diffing."""
+        manifest = []
+        for path in self._all_md_files():
+            stat = path.stat()
+            manifest.append((path.relative_to(self.root).as_posix(), stat.st_mtime, stat.st_size))
+        return manifest
 
     def delete_stream(self, slug: str) -> None:
         path = self._find_stream_path(slug)

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -48,15 +48,43 @@ class ZoteroConfig(BaseModel):
 
 
 class LLMConfig(BaseModel):
-    """LLM configuration"""
-    provider: str = Field("ollama", description="LLM provider")
+    """LLM configuration — used for KG extraction (see kg_app.py). Cloud
+    routing (openrouter) mirrors ChatConfig's own pattern (ADR-014): api_key
+    comes from an env var, never this file, and there's no local endpoint to
+    live-query for context window, so it's an explicit config value instead."""
+    provider: str = Field("ollama", description="ollama | llama_cpp | openrouter")
     model: str = Field("qwen2.5:7b-32k", description="Model name")
-    host: str = Field("localhost:11434", description="Host and port")
-    max_concurrent_inferences: int = Field(1, ge=1, le=16, description="Max simultaneous Ollama requests")
+    host: str = Field("localhost:11434", description="Host and port — ignored for openrouter")
+    max_concurrent_inferences: int = Field(1, ge=1, le=16, description="Max simultaneous requests")
+    api_key_env: Optional[str] = Field(
+        None, description="Env var holding the API key — only used/required when provider=openrouter"
+    )
+    base_url_override: Optional[str] = Field(
+        None, description="Override the provider's default base_url; None derives it from provider"
+    )
+    context_window: Optional[int] = Field(
+        None,
+        description=(
+            "Static context window for providers with no live-queryable endpoint "
+            "(openrouter) — ollama/llama_cpp instead resolve this live per-call "
+            "(see KnowledgeGraphService._resolve_context_window) and ignore this field."
+        ),
+    )
+
+    @field_validator('provider')
+    @classmethod
+    def validate_provider(cls, v):
+        if v not in ('ollama', 'llama_cpp', 'openrouter'):
+            raise ValueError('provider must be "ollama", "llama_cpp", or "openrouter"')
+        return v
 
     @property
     def base_url(self) -> str:
         """Generate base URL for API calls"""
+        if self.base_url_override:
+            return self.base_url_override
+        if self.provider == "openrouter":
+            return "https://openrouter.ai/api/v1"
         return f"http://{self.host}"
 
 
@@ -97,8 +125,8 @@ class ChatConfig(BaseModel):
     @field_validator('provider')
     @classmethod
     def validate_provider(cls, v):
-        if v not in ('ollama', 'openrouter', 'anthropic'):
-            raise ValueError('provider must be "ollama", "openrouter", or "anthropic"')
+        if v not in ('ollama', 'llama_cpp', 'openrouter', 'anthropic'):
+            raise ValueError('provider must be "ollama", "llama_cpp", "openrouter", or "anthropic"')
         return v
 
 
@@ -187,9 +215,48 @@ class SourcesConfig(BaseModel):
 
 
 class RetrievalConfig(BaseModel):
-    embedding_model: str = Field("nomic-embed-text", description="Ollama embedding model for ChromaDB semantic search")
-    ollama_base_url: str = Field("http://localhost:11434", description="Ollama base URL for embeddings")
+    provider: str = Field("ollama", description="ollama | llama_cpp — embedding backend for ChromaDB")
+    embedding_model: str = Field("nomic-embed-text", description="Embedding model name for ChromaDB semantic search")
+    ollama_base_url: str = Field(
+        "http://localhost:11434",
+        description="Embedding backend base URL — name kept for backward compat, used regardless of provider",
+    )
     chroma_port: int = Field(8767, description="Port of the supervised ChromaDB server process (see ADR-012)")
+
+    @field_validator('provider')
+    @classmethod
+    def validate_provider(cls, v):
+        if v not in ('ollama', 'llama_cpp'):
+            raise ValueError('provider must be "ollama" or "llama_cpp"')
+        return v
+
+
+class AuthConfig(BaseModel):
+    """Server auth (ADR-011) — password mode only; oidc is reserved for a
+    future WAN-facing implementation and rejected at load time if set."""
+    mode: str = Field("none", description="none | password | oidc")
+    password_hash: str = Field("", description="bcrypt hash — generate with: prisma auth hash-password")
+    session_ttl_hours: int = Field(720, description="JWT session lifetime (default 30 days)")
+
+    @field_validator('mode')
+    @classmethod
+    def validate_mode(cls, v):
+        if v not in ('none', 'password', 'oidc'):
+            raise ValueError('mode must be "none", "password", or "oidc"')
+        return v
+
+
+class ServerConfig(BaseModel):
+    """Zone-based auth gating (ADR-011 / deployment-models.md). host/port
+    here are for schema parity with the documented YAML — the actual bind
+    address/port are still CLI flags on `prisma serve`, unrelated to auth."""
+    host: str = Field("127.0.0.1", description="Documented for parity; --host on `prisma serve` is authoritative")
+    port: int = Field(8765, description="Documented for parity; --port on `prisma serve` is authoritative")
+    trusted_proxies: List[str] = Field(
+        default_factory=lambda: ["127.0.0.1", "::1"],
+        description="IPs allowed to set X-Forwarded-For — trusted only when the direct connection is loopback",
+    )
+    auth: AuthConfig = Field(default_factory=lambda: AuthConfig())
 
 
 class PrismaConfig(BaseModel):
@@ -204,6 +271,17 @@ class PrismaConfig(BaseModel):
     analysis: AnalysisConfig = Field(default_factory=lambda: AnalysisConfig())
     logging: LoggingConfig = Field(default_factory=lambda: LoggingConfig())
     retrieval: RetrievalConfig = Field(default_factory=lambda: RetrievalConfig())
+    server: ServerConfig = Field(default_factory=lambda: ServerConfig())
+
+    @field_validator('server')
+    @classmethod
+    def validate_server_auth_mode(cls, v):
+        if v.auth.mode == 'oidc':
+            raise ValueError(
+                'server.auth.mode "oidc" is not implemented yet (ADR-011 WAN tier) — '
+                'use "none" or "password"'
+            )
+        return v
 
 
 class ConfigLoader:
@@ -301,6 +379,9 @@ class ConfigLoader:
 
     def get_chat_config(self) -> ChatConfig:
         return self.config.chat
+
+    def get_server_config(self) -> ServerConfig:
+        return self.config.server
 
     def has_zotero_credentials(self) -> bool:
         """Check if Zotero API credentials are configured."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "semchunk>=4.1",
     "openai>=1.0",
     "instructor>=1.15",
+    "bcrypt>=4.0",
+    "PyJWT>=2.9",
 ]
 
 [project.optional-dependencies]

--- a/tests-sets/mocked/config/test_config_loader.py
+++ b/tests-sets/mocked/config/test_config_loader.py
@@ -32,10 +32,16 @@ sources:
 
 
 def test_defaults_when_no_config_file(tmp_path, monkeypatch):
+    # Also isolate from whatever real ~/.config/prisma/config.yaml exists on
+    # the machine running this test — PRISMA_CONFIG pointing at a nonexistent
+    # path isn't enough on its own, since _get_config_path() falls back to
+    # checking default_locations (including the real one) when the env var's
+    # path doesn't exist.
+    monkeypatch.setattr("prisma.utils.config.Path.exists", lambda self: False)
     monkeypatch.setenv("PRISMA_CONFIG", str(tmp_path / "nonexistent.yaml"))
     loader = ConfigLoader()
     assert loader.config.llm.provider == "ollama"
-    assert loader.config.llm.model == "llama3.1:8b"
+    assert loader.config.llm.model == "qwen2.5:7b-32k"
     assert loader.config.search.default_limit == 10
 
 
@@ -53,12 +59,15 @@ def test_yaml_merged_into_config(tmp_path, monkeypatch):
 
 
 def test_get_dot_notation_existing_key(tmp_path, monkeypatch):
+    # See test_defaults_when_no_config_file for why this patch is needed too.
+    monkeypatch.setattr("prisma.utils.config.Path.exists", lambda self: False)
     monkeypatch.setenv("PRISMA_CONFIG", str(tmp_path / "nonexistent.yaml"))
     loader = ConfigLoader()
     assert loader.get("llm.provider") == "ollama"
 
 
 def test_get_dot_notation_missing_key_returns_default(tmp_path, monkeypatch):
+    monkeypatch.setattr("prisma.utils.config.Path.exists", lambda self: False)
     monkeypatch.setenv("PRISMA_CONFIG", str(tmp_path / "nonexistent.yaml"))
     loader = ConfigLoader()
     assert loader.get("nonexistent.key", "fallback") == "fallback"

--- a/tests-sets/mocked/test_analysis_agent.py
+++ b/tests-sets/mocked/test_analysis_agent.py
@@ -21,6 +21,13 @@ class TestAnalysisAgent(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.analysis_agent = AnalysisAgent()
+        # AnalysisAgent() reads prisma.utils.config's module-level `config`
+        # singleton (built once, at first import of that module) — these
+        # tests assume the Ollama-native code path regardless of whatever
+        # real ~/.config/prisma/config.yaml the machine running this test
+        # happens to have, so force it directly (see the sibling copy of
+        # this file in tests/unit/agents/ for the same fix).
+        self.analysis_agent.llm_config.provider = 'ollama'
         self.sample_paper = PaperMetadata(
             title='Test Paper Title',
             authors=['Author One', 'Author Two'],

--- a/tests/unit/agents/test_analysis_agent.py
+++ b/tests/unit/agents/test_analysis_agent.py
@@ -21,6 +21,13 @@ class TestAnalysisAgent(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.analysis_agent = AnalysisAgent()
+        # AnalysisAgent() reads prisma.utils.config's module-level `config`
+        # singleton (built once, at first import of that module, long before
+        # this test runs) — patching Path.exists here wouldn't retroactively
+        # change it. These tests assume the Ollama-native code path
+        # regardless of whatever real ~/.config/prisma/config.yaml the
+        # machine running this test happens to have, so force it directly.
+        self.analysis_agent.llm_config.provider = 'ollama'
         self.sample_paper = PaperMetadata(
             title='Test Paper Title',
             authors=['Author One', 'Author Two'],

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -39,20 +39,27 @@ sources:
     
     def test_default_config_loading(self):
         """Test that default configuration loads when no config file exists."""
-        # Create ConfigLoader without any config file
-        with tempfile.TemporaryDirectory() as temp_dir:
+        # Create ConfigLoader without any config file. Also patches Path.exists
+        # to False (not just PRISMA_CONFIG to a nonexistent path) — otherwise
+        # _get_config_path()'s fallback to default_locations (which includes
+        # the real ~/.config/prisma/config.yaml) would pick up whatever real
+        # config the machine running this test happens to have, defeating the
+        # "no config file" isolation this test is actually after. Same
+        # pattern as test_zotero_credentials_check below.
+        with tempfile.TemporaryDirectory() as temp_dir, \
+                patch('prisma.utils.config.Path.exists', return_value=False):
             old_env = os.environ.get('PRISMA_CONFIG')
             os.environ['PRISMA_CONFIG'] = str(Path(temp_dir) / 'nonexistent.yaml')
-            
+
             config_loader = ConfigLoader()
-            
+
             # Should have defaults and be Pydantic model
             self.assertIsInstance(config_loader.config, PrismaConfig)
             self.assertEqual(config_loader.config.llm.provider, 'ollama')
             self.assertIsInstance(config_loader.config.llm.model, str)
             self.assertTrue(len(config_loader.config.llm.model) > 0)
             self.assertEqual(config_loader.config.search.default_limit, 10)
-            
+
             # Restore environment
             if old_env:
                 os.environ['PRISMA_CONFIG'] = old_env
@@ -93,27 +100,53 @@ sources:
     
     def test_get_method_with_dot_notation(self):
         """Test the get method with dot notation for backward compatibility."""
-        config_loader = ConfigLoader()
-        
-        # Test existing key
-        result = config_loader.get('llm.provider')
-        self.assertEqual(result, 'ollama')
-        
-        # Test non-existing key with default
-        result = config_loader.get('nonexistent.key', 'default_value')
-        self.assertEqual(result, 'default_value')
-    
+        # Isolated from whatever real ~/.config/prisma/config.yaml exists on
+        # the machine running this test — see test_default_config_loading.
+        with patch('prisma.utils.config.Path.exists', return_value=False):
+            config_loader = ConfigLoader()
+
+            # Test existing key
+            result = config_loader.get('llm.provider')
+            self.assertEqual(result, 'ollama')
+
+            # Test non-existing key with default
+            result = config_loader.get('nonexistent.key', 'default_value')
+            self.assertEqual(result, 'default_value')
+
     def test_llm_config_helper(self):
         """Test LLM configuration helper method."""
-        config_loader = ConfigLoader()
-        llm_config = config_loader.get_llm_config()
-        
-        # Test that we get a Pydantic model with proper attributes
-        self.assertTrue(hasattr(llm_config, 'provider'))
-        self.assertTrue(hasattr(llm_config, 'model'))
-        self.assertTrue(hasattr(llm_config, 'host'))
-        self.assertEqual(llm_config.provider, 'ollama')
+        # Isolated from whatever real ~/.config/prisma/config.yaml exists on
+        # the machine running this test — see test_default_config_loading.
+        with patch('prisma.utils.config.Path.exists', return_value=False):
+            config_loader = ConfigLoader()
+            llm_config = config_loader.get_llm_config()
+
+            # Test that we get a Pydantic model with proper attributes
+            self.assertTrue(hasattr(llm_config, 'provider'))
+            self.assertTrue(hasattr(llm_config, 'model'))
+            self.assertTrue(hasattr(llm_config, 'host'))
+            self.assertEqual(llm_config.provider, 'ollama')
     
+    def test_llm_config_openrouter_provider_accepted(self):
+        cfg = LLMConfig(provider='openrouter', model='openai/gpt-4o-mini', api_key_env='OPENROUTER_API_KEY')
+        self.assertEqual(cfg.provider, 'openrouter')
+
+    def test_llm_config_openrouter_base_url(self):
+        cfg = LLMConfig(provider='openrouter')
+        self.assertEqual(cfg.base_url, 'https://openrouter.ai/api/v1')
+
+    def test_llm_config_base_url_override_wins(self):
+        cfg = LLMConfig(provider='openrouter', base_url_override='https://custom.example/v1')
+        self.assertEqual(cfg.base_url, 'https://custom.example/v1')
+
+    def test_llm_config_ollama_base_url_unchanged(self):
+        cfg = LLMConfig(provider='ollama', host='localhost:11434')
+        self.assertEqual(cfg.base_url, 'http://localhost:11434')
+
+    def test_llm_config_invalid_provider_still_rejected(self):
+        with self.assertRaises(ValidationError):
+            LLMConfig(provider='anthropic')
+
     def test_validation_errors(self):
         """Test that Pydantic validation catches invalid configurations."""
         # Test invalid output format

--- a/tests/unit/server/test_auth.py
+++ b/tests/unit/server/test_auth.py
@@ -1,0 +1,180 @@
+"""Unit tests for prisma.server.auth — zone classification, password hashing,
+session tokens, and the AuthMiddleware's zone/mode gating (ADR-011).
+"""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from prisma.server.auth import (
+    classify_zone,
+    decode_token,
+    hash_password,
+    issue_token,
+    verify_password,
+)
+
+_TRUSTED = ["127.0.0.1", "::1"]
+
+
+# ── classify_zone (pure function) ─────────────────────────────────────────────
+
+def test_classify_zone_loopback():
+    assert classify_zone("127.0.0.1", None, _TRUSTED) == "local"
+    assert classify_zone("::1", None, _TRUSTED) == "local"
+    assert classify_zone("localhost", None, _TRUSTED) == "local"
+
+
+def test_classify_zone_lan():
+    assert classify_zone("192.168.1.50", None, _TRUSTED) == "lan"
+    assert classify_zone("10.0.0.5", None, _TRUSTED) == "lan"
+    assert classify_zone("172.16.0.5", None, _TRUSTED) == "lan"
+
+
+def test_classify_zone_wan():
+    assert classify_zone("8.8.8.8", None, _TRUSTED) == "wan"
+
+
+def test_classify_zone_trusts_forwarded_for_only_from_trusted_proxy():
+    # Direct connection from the trusted proxy (loopback) — header honored.
+    assert classify_zone("127.0.0.1", "192.168.1.50", _TRUSTED) == "lan"
+    # Direct connection NOT from a trusted proxy — header must be ignored,
+    # otherwise a WAN client could spoof a local/LAN origin by setting it.
+    assert classify_zone("8.8.8.8", "127.0.0.1", _TRUSTED) == "wan"
+
+
+# ── password hashing ──────────────────────────────────────────────────────────
+
+def test_hash_and_verify_password_roundtrip():
+    h = hash_password("correct horse battery staple")
+    assert verify_password("correct horse battery staple", h)
+    assert not verify_password("wrong password", h)
+
+
+def test_verify_password_empty_hash_always_fails():
+    assert not verify_password("anything", "")
+
+
+# ── session tokens ────────────────────────────────────────────────────────────
+
+def test_issue_and_decode_token_roundtrip():
+    pw_hash = hash_password("hunter2")
+    token, expires_at = issue_token(pw_hash, ttl_hours=1)
+    payload = decode_token(token, pw_hash)
+    assert payload is not None
+    assert payload["exp"] == pytest.approx(expires_at)
+
+
+def test_decode_token_rejects_wrong_password_hash():
+    pw_hash = hash_password("hunter2")
+    other_hash = hash_password("different password")
+    token, _ = issue_token(pw_hash, ttl_hours=1)
+    assert decode_token(token, other_hash) is None
+
+
+def test_decode_token_rejects_expired_token():
+    pw_hash = hash_password("hunter2")
+    token, _ = issue_token(pw_hash, ttl_hours=-1)  # already expired
+    assert decode_token(token, pw_hash) is None
+
+
+def test_decode_token_rejects_garbage():
+    pw_hash = hash_password("hunter2")
+    assert decode_token("not-a-jwt", pw_hash) is None
+
+
+# ── AuthMiddleware, end-to-end via TestClient ─────────────────────────────────
+
+@pytest.fixture
+def password_mode_config(tmp_path, monkeypatch):
+    pw_hash = hash_password("s3cret")
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "server:\n"
+        "  auth:\n"
+        "    mode: password\n"
+        f"    password_hash: '{pw_hash}'\n"
+    )
+    monkeypatch.setenv("PRISMA_CONFIG", str(cfg_path))
+    return pw_hash
+
+
+def _client_from(host: str) -> TestClient:
+    # `client` is a TestClient *constructor* kwarg (the simulated TCP peer
+    # address for scope['client']) — it can't be mutated on an existing
+    # instance, a fresh TestClient is needed per simulated source zone.
+    from prisma.server.app import app
+    return TestClient(app, client=(host, 12345))
+
+
+def test_local_zone_bypasses_auth_even_in_password_mode(password_mode_config):
+    r = _client_from("127.0.0.1").get("/status")
+    assert r.status_code == 200
+
+
+def test_lan_zone_requires_token_in_password_mode(password_mode_config):
+    r = _client_from("192.168.1.50").get("/status")
+    assert r.status_code == 401
+
+
+def test_lan_zone_passes_with_valid_token(password_mode_config):
+    client = _client_from("192.168.1.50")
+    r = client.post("/auth/login", json={"password": "s3cret"})
+    assert r.status_code == 200
+    token = r.json()["token"]
+
+    r2 = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+    assert r2.status_code == 200
+
+
+def test_login_rejects_wrong_password(password_mode_config):
+    r = _client_from("192.168.1.50").post("/auth/login", json={"password": "wrong"})
+    assert r.status_code == 401
+
+
+def test_wan_zone_always_rejected(password_mode_config):
+    r = _client_from("8.8.8.8").get("/status")
+    assert r.status_code == 403
+
+
+def test_login_rejected_from_wan_zone(password_mode_config):
+    r = _client_from("8.8.8.8").post("/auth/login", json={"password": "s3cret"})
+    assert r.status_code == 403
+
+
+def test_health_always_reachable_regardless_of_zone(password_mode_config):
+    r = _client_from("8.8.8.8").get("/health")
+    assert r.status_code == 200
+
+
+# ── /ws upgrade gating ─────────────────────────────────────────────────────────
+
+def test_ws_lan_zone_rejected_without_token(password_mode_config):
+    client = _client_from("192.168.1.50")
+    with pytest.raises(Exception):
+        with client.websocket_connect("/ws"):
+            pass
+
+
+def test_ws_lan_zone_accepted_with_valid_subprotocol_token(password_mode_config):
+    client = _client_from("192.168.1.50")
+    login = client.post("/auth/login", json={"password": "s3cret"})
+    token = login.json()["token"]
+    with client.websocket_connect("/ws", subprotocols=["bearer", token]):
+        pass  # connecting without raising is the assertion
+
+
+def test_ws_local_zone_accepted_without_token_even_in_password_mode(password_mode_config):
+    client = _client_from("127.0.0.1")
+    with client.websocket_connect("/ws"):
+        pass
+
+
+def test_mode_none_bypasses_auth_from_any_zone(monkeypatch, tmp_path):
+    # Point at a nonexistent path rather than just delenv — a real
+    # ~/.config/prisma/config.yaml on the machine running this test would
+    # otherwise be picked up by ConfigLoader's default-locations fallback
+    # (a real footgun found earlier in this project: see test_config.py).
+    monkeypatch.setenv("PRISMA_CONFIG", str(tmp_path / "does-not-exist.yaml"))
+    r = _client_from("192.168.1.50").get("/status")
+    assert r.status_code == 200

--- a/tests/unit/server/test_supervisor_resources.py
+++ b/tests/unit/server/test_supervisor_resources.py
@@ -189,7 +189,7 @@ def test_load_compute_pools_reads_model_affinity_flag(tmp_path, monkeypatch):
         "    model_affinity: false\n"
     )
 
-    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit = _load_compute_pools()
+    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit, pool_provider = _load_compute_pools()
 
     assert capacity == {"local-ollama": 3, "cloud_api": 4}
     assert affinity == {"local-ollama"}
@@ -199,7 +199,7 @@ def test_load_compute_pools_reads_model_affinity_flag(tmp_path, monkeypatch):
 def test_load_compute_pools_defaults_when_config_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit = _load_compute_pools()
+    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit, pool_provider = _load_compute_pools()
 
     assert capacity == {"default": 1}
     assert affinity == {"default"}  # zero-config default assumes one local GPU
@@ -219,7 +219,7 @@ def test_load_compute_pools_model_affinity_defaults_true_unless_disabled(tmp_pat
         "    model_affinity: false\n"   # explicitly opted out — auto-scaled/auto-routed
     )
 
-    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit = _load_compute_pools()
+    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit, pool_provider = _load_compute_pools()
 
     assert affinity == {"local-ollama"}
 
@@ -242,7 +242,7 @@ def test_load_compute_pools_type_field_is_authoritative_over_model_affinity(tmp_
         "    max_concurrent: 8\n"
     )
 
-    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit = _load_compute_pools()
+    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit, pool_provider = _load_compute_pools()
 
     assert capacity == {"local-ollama": 3, "cloud_api": 8}
     assert affinity == {"local-ollama"}
@@ -461,7 +461,7 @@ def test_load_compute_pools_parses_per_model_concurrency_overrides(tmp_path, mon
         "      - nomic-embed-text\n"  # plain string form
     )
 
-    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit = _load_compute_pools()
+    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit, pool_provider = _load_compute_pools()
 
     assert pool_models["local-ollama"] == {"prisma-kg:7b", "prisma-chat:7b", "nomic-embed-text"}
     assert model_concurrency["local-ollama"] == {"prisma-kg:7b": 1, "prisma-chat:7b": 3}
@@ -487,7 +487,7 @@ def test_load_compute_pools_parses_vram_budget_and_model_vram(tmp_path, monkeypa
         "    max_concurrent: 8\n"
     )
 
-    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit = _load_compute_pools()
+    capacity, affinity, pool_models, model_concurrency, vram_budget, model_vram, model_background_limit, pool_provider = _load_compute_pools()
 
     assert vram_budget == {"local-ollama": 14000, "cloud_api": None}
     assert model_vram["local-ollama"] == {"qwen2.5:7b-32k": 7500, "nomic-embed-text": 1000}

--- a/tests/unit/server/test_sync_routes.py
+++ b/tests/unit/server/test_sync_routes.py
@@ -1,0 +1,137 @@
+"""Unit tests for prisma.server.sync_routes — built in isolation (a bare
+FastAPI app wrapping just build_sync_router + a tmp_path VaultService), not
+the full prisma.server.app singleton, so these don't depend on auth/CORS/the
+real vault_root and stay independently testable per the vault-sync plan.
+"""
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from prisma.server.sync_routes import build_sync_router
+from prisma.services.vault import VaultService
+
+
+class _Recorder:
+    """Fake broadcast_fn/mark_stale_fn that just records calls."""
+
+    def __init__(self):
+        self.broadcasts = []
+        self.mark_stale_calls = 0
+
+    def broadcast(self, event, exclude_client_id=None):
+        self.broadcasts.append((event, exclude_client_id))
+
+    def mark_stale(self):
+        self.mark_stale_calls += 1
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> VaultService:
+    v = VaultService(tmp_path)
+    v.ensure_dirs()
+    return v
+
+
+@pytest.fixture
+def recorder() -> _Recorder:
+    return _Recorder()
+
+
+@pytest.fixture
+def client(vault, recorder) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_sync_router(
+        get_vault=lambda: vault,
+        broadcast_fn=recorder.broadcast,
+        mark_stale_fn=recorder.mark_stale,
+    ))
+    return TestClient(app)
+
+
+def test_manifest_empty_vault(client):
+    r = client.get("/sync/manifest")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_put_new_file_creates_and_broadcasts(client, vault, recorder):
+    r = client.put("/sync/file", json={"path": "notes/a.md", "body": "hello", "expected_mtime": None})
+    assert r.status_code == 200
+    assert r.json()["body"] == "hello"
+    assert vault.read_by_path("notes/a.md")[0] == "hello"
+    assert recorder.mark_stale_calls == 1
+    assert len(recorder.broadcasts) == 1
+    event, exclude = recorder.broadcasts[0]
+    assert event == {"type": "vault_change", "action": "sync_write", "path": "notes/a.md"}
+    assert exclude is None  # no X-Sync-Client-Id header sent
+
+
+def test_put_echoes_exclude_client_id_from_header(client, recorder):
+    r = client.put(
+        "/sync/file",
+        json={"path": "notes/a.md", "body": "hello", "expected_mtime": None},
+        headers={"X-Sync-Client-Id": "desktop-123"},
+    )
+    assert r.status_code == 200
+    _, exclude = recorder.broadcasts[0]
+    assert exclude == "desktop-123"
+
+
+def test_get_file_roundtrip(client, vault):
+    vault.write_by_path("notes/a.md", "content")
+    r = client.get("/sync/file", params={"path": "notes/a.md"})
+    assert r.status_code == 200
+    assert r.json()["body"] == "content"
+
+
+def test_get_missing_file_404(client):
+    r = client.get("/sync/file", params={"path": "notes/missing.md"})
+    assert r.status_code == 404
+
+
+def test_put_conflicting_mtime_returns_409_with_server_state(client, vault):
+    vault.write_by_path("notes/a.md", "server version")
+    r = client.put("/sync/file", json={"path": "notes/a.md", "body": "client version", "expected_mtime": 1.0})
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    assert detail["body"] == "server version"
+    # server-side content must be untouched by the rejected write
+    assert vault.read_by_path("notes/a.md")[0] == "server version"
+
+
+def test_put_new_but_server_already_has_file_conflicts(client, vault):
+    vault.write_by_path("notes/a.md", "server version")
+    r = client.put("/sync/file", json={"path": "notes/a.md", "body": "client version", "expected_mtime": None})
+    assert r.status_code == 409
+
+
+def test_put_matching_expected_mtime_succeeds(client, vault):
+    mtime = vault.write_by_path("notes/a.md", "v1")
+    r = client.put("/sync/file", json={"path": "notes/a.md", "body": "v2", "expected_mtime": mtime})
+    assert r.status_code == 200
+    assert vault.read_by_path("notes/a.md")[0] == "v2"
+
+
+def test_delete_file_removes_and_broadcasts(client, vault, recorder):
+    vault.write_by_path("notes/a.md", "content")
+    r = client.delete("/sync/file", params={"path": "notes/a.md"})
+    assert r.status_code == 200
+    assert vault.read_by_path("notes/a.md") is None
+    assert recorder.mark_stale_calls == 1
+    event, _ = recorder.broadcasts[0]
+    assert event["action"] == "sync_delete"
+
+
+def test_put_path_traversal_rejected(client):
+    r = client.put("/sync/file", json={"path": "../outside.md", "body": "x", "expected_mtime": None})
+    assert r.status_code == 403
+
+
+def test_manifest_lists_written_files(client, vault):
+    vault.write_by_path("notes/a.md", "aa")
+    vault.write_by_path("notes/b.md", "b")
+    r = client.get("/sync/manifest")
+    paths = {entry["path"] for entry in r.json()}
+    assert paths == {"notes/a.md", "notes/b.md"}

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -48,6 +48,45 @@ def _patch_create(kg, **kwargs):
     return patch.object(kg._instructor_client.chat.completions, "create", **kwargs)
 
 
+# ── openrouter provider support ───────────────────────────────────────────────
+
+def test_openrouter_base_url_not_double_suffixed(vault, tmp_path):
+    # kg_app.py's _llm_base_url() delegates to LLMConfig.base_url, which for
+    # openrouter already returns the complete ".../api/v1" — the client
+    # construction must not append /v1 a second time (unlike the
+    # ollama/llama_cpp case, where ollama_base_url is host-only).
+    service = KnowledgeGraphService(
+        vault, kg_dir=tmp_path / "kg-out",
+        provider="openrouter", ollama_base_url="https://openrouter.ai/api/v1",
+        api_key="sk-or-test",
+    )
+    assert str(service._instructor_client.client.base_url) == "https://openrouter.ai/api/v1/"
+
+
+def test_ollama_base_url_still_gets_v1_appended(vault, tmp_path):
+    service = KnowledgeGraphService(
+        vault, kg_dir=tmp_path / "kg-out",
+        provider="ollama", ollama_base_url="http://localhost:11434",
+    )
+    assert str(service._instructor_client.client.base_url) == "http://localhost:11434/v1/"
+
+
+def test_context_window_override_skips_live_resolution(vault, tmp_path):
+    service = KnowledgeGraphService(
+        vault, kg_dir=tmp_path / "kg-out",
+        provider="openrouter", ollama_base_url="https://openrouter.ai/api/v1",
+        api_key="sk-or-test", context_window_override=128000,
+    )
+    # No network call should happen — already marked resolved at construction.
+    assert service._context_window_resolved is True
+    assert service._resolve_context_window() == 128000
+
+
+def test_no_context_window_override_defaults_to_unresolved(vault, tmp_path):
+    service = KnowledgeGraphService(vault, kg_dir=tmp_path / "kg-out")
+    assert service._context_window_resolved is False
+
+
 # ── Escape-sequence sanitization ──────────────────────────────────────────────
 # Confirmed live 2026-07-07 (docs/kg-dead-letter-triage-2026-07-07.md): a real
 # paper's appendix of raw byte-sequence descriptions (e.g. `Hebrew: "\xd6"?`)

--- a/tests/unit/services/test_vault_sync.py
+++ b/tests/unit/services/test_vault_sync.py
@@ -1,0 +1,84 @@
+"""Unit tests for VaultService's path-based access methods (read_by_path /
+write_by_path / delete_by_path / list_md_manifest) — used by /sync/*.
+Uses a real tmp_path, no mocks (same convention as test_vault_streams.py).
+"""
+from pathlib import Path
+
+import pytest
+
+from prisma.services.vault import VaultService
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> VaultService:
+    v = VaultService(tmp_path)
+    v.ensure_dirs()
+    return v
+
+
+def test_write_then_read_by_path_roundtrip(vault):
+    mtime = vault.write_by_path("notes/foo.md", "# Foo\nhello")
+    assert isinstance(mtime, float)
+    body, read_mtime = vault.read_by_path("notes/foo.md")
+    assert body == "# Foo\nhello"
+    assert read_mtime == mtime
+
+
+def test_write_by_path_creates_parent_dirs(vault):
+    vault.write_by_path("deeply/nested/dir/note.md", "content")
+    assert (vault.root / "deeply" / "nested" / "dir" / "note.md").is_file()
+
+
+def test_write_by_path_overwrites_existing(vault):
+    vault.write_by_path("notes/foo.md", "v1")
+    vault.write_by_path("notes/foo.md", "v2")
+    body, _ = vault.read_by_path("notes/foo.md")
+    assert body == "v2"
+
+
+def test_read_by_path_missing_file_returns_none(vault):
+    assert vault.read_by_path("notes/does-not-exist.md") is None
+
+
+def test_delete_by_path_removes_file(vault):
+    vault.write_by_path("notes/foo.md", "content")
+    vault.delete_by_path("notes/foo.md")
+    assert vault.read_by_path("notes/foo.md") is None
+
+
+def test_delete_by_path_missing_file_is_noop(vault):
+    vault.delete_by_path("notes/never-existed.md")  # must not raise
+
+
+def test_list_md_manifest_reflects_written_files(vault):
+    vault.write_by_path("notes/a.md", "a")
+    vault.write_by_path("notes/b.md", "bb")
+    manifest = {path: (mtime, size) for path, mtime, size in vault.list_md_manifest()}
+    assert set(manifest) == {"notes/a.md", "notes/b.md"}
+    assert manifest["notes/b.md"][1] == 2
+
+
+@pytest.mark.parametrize("bad_path", [
+    "../outside.md",
+    "notes/../../outside.md",
+    "/etc/passwd.md",
+])
+def test_path_traversal_rejected(vault, bad_path):
+    with pytest.raises(ValueError):
+        vault.write_by_path(bad_path, "x")
+    with pytest.raises(ValueError):
+        vault.read_by_path(bad_path)
+    with pytest.raises(ValueError):
+        vault.delete_by_path(bad_path)
+
+
+def test_non_md_extension_rejected(vault):
+    with pytest.raises(ValueError):
+        vault.write_by_path("notes/foo.txt", "x")
+
+
+def test_reserved_dir_rejected(vault):
+    with pytest.raises(ValueError):
+        vault.write_by_path(".git/foo.md", "x")
+    with pytest.raises(ValueError):
+        vault.write_by_path("node_modules/foo.md", "x")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2315,9 +2315,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2332,9 +2329,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2349,9 +2343,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2366,9 +2357,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2383,9 +2371,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2400,9 +2385,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2417,9 +2399,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2434,9 +2413,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,9 +2427,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2468,9 +2441,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2485,9 +2455,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2502,9 +2469,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2519,9 +2483,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,0 +1,98 @@
+// ADR-011 password-mode auth, client side. Isolated here for the same
+// reason as platform.ts: +page.svelte shouldn't branch on isTauri for
+// every network call. Under Tauri, login goes through the `sync_login`
+// command so a single password prompt covers both this app's own
+// authFetch calls AND the Rust sync engine's session (see
+// prisma-desktop's src-tauri/src/auth/mod.rs) — pure-browser/PWA use
+// falls back to calling POST /auth/login directly.
+//
+// Reactive UI state (whether to show the login screen) intentionally
+// lives in +page.svelte itself, not here — this module only holds a
+// plain, non-reactive token so apiFetch can read the current value
+// without every call site threading it through by hand, matching how
+// platform.ts stays a plain utility module with no component state of
+// its own.
+import { invoke } from "@tauri-apps/api/core";
+import { isTauri } from "./platform";
+
+let token: string | null = null;
+let onAuthRequired: (() => void) | null = null;
+
+export function setAuthRequiredHandler(cb: () => void): void {
+  onAuthRequired = cb;
+}
+
+/// Called once at startup: on Tauri, picks up a session already stored in
+/// auth.json (from a previous run) without reprompting for a password.
+/// Returns true if a session was restored.
+export async function restoreSession(serverUrl: string): Promise<boolean> {
+  if (!isTauri) return false;
+  try {
+    const status = await invoke<{ logged_in: boolean; token: string | null }>("sync_status", {
+      serverUrl,
+    });
+    if (status.logged_in && status.token) {
+      token = status.token;
+      return true;
+    }
+  } catch {
+    // sync_status unreachable — treat as "no stored session".
+  }
+  return false;
+}
+
+export async function login(serverUrl: string, password: string): Promise<void> {
+  if (isTauri) {
+    const result = await invoke<{ token: string; expires_at: string }>("sync_login", {
+      serverUrl,
+      password,
+    });
+    token = result.token;
+  } else {
+    const resp = await fetch(`${serverUrl.replace(/\/$/, "")}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    });
+    if (!resp.ok) {
+      const detail = await resp.text().catch(() => "");
+      throw new Error(`login failed (${resp.status}): ${detail}`);
+    }
+    const body = await resp.json();
+    token = body.token;
+  }
+}
+
+export function logout(serverUrl: string): void {
+  token = null;
+  if (isTauri) void invoke("sync_logout", { serverUrl }).catch(() => {});
+}
+
+export function hasSession(): boolean {
+  return token !== null;
+}
+
+/// For the one call site that can't go through apiFetch: the browser's
+/// native WebSocket API takes subprotocols, not headers — see connectWS()
+/// in +page.svelte, which mirrors prisma-desktop's own pull.rs handshake
+/// (["bearer", "<jwt>"]).
+export function getToken(): string | null {
+  return token;
+}
+
+/// Drop-in replacement for `fetch()` against apiBase-rooted URLs: attaches
+/// `Authorization: Bearer` when a token is held, and invokes the
+/// registered handler on a 401 so the UI can show the login screen
+/// instead of silently failing every subsequent call. Not used for
+/// webBase (static UI assets) or the loopback-only supervisor port — see
+/// the vault-sync plan for why those two are out of scope for this
+/// gating.
+export async function apiFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  if (token) headers.set("Authorization", `Bearer ${token}`);
+  const resp = await fetch(url, { ...init, headers });
+  if (resp.status === 401) {
+    onAuthRequired?.();
+  }
+  return resp;
+}

--- a/ui/src/lib/components/LoginScreen.svelte
+++ b/ui/src/lib/components/LoginScreen.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import { login } from "../auth";
+
+  let { serverUrl, onLoggedIn }: { serverUrl: string; onLoggedIn: () => void } = $props();
+
+  let password = $state("");
+  let error = $state<string | null>(null);
+  let submitting = $state(false);
+
+  function autofocus(el: HTMLInputElement) {
+    el.focus();
+  }
+
+  async function submit(e: SubmitEvent) {
+    e.preventDefault();
+    if (!password || submitting) return;
+    submitting = true;
+    error = null;
+    try {
+      await login(serverUrl, password);
+      password = "";
+      onLoggedIn();
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      submitting = false;
+    }
+  }
+</script>
+
+<div class="login-overlay">
+  <form class="login-box" onsubmit={submit}>
+    <h1>Prisma</h1>
+    <p class="hint">This server requires a password to connect from this network (ADR-011).</p>
+    <input
+      type="password"
+      bind:value={password}
+      placeholder="Password"
+      use:autofocus
+      disabled={submitting}
+    />
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+    <button type="submit" disabled={submitting || !password}>
+      {submitting ? "Connecting…" : "Connect"}
+    </button>
+  </form>
+</div>
+
+<style>
+  .login-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #0a1420;
+    z-index: 10000;
+  }
+  .login-box {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 280px;
+    padding: 24px;
+    background: #111f2e;
+    border: 1px solid #24384a;
+    border-radius: 8px;
+  }
+  h1 {
+    margin: 0 0 4px;
+    font-size: 20px;
+    color: #c8ddf0;
+    text-align: center;
+  }
+  .hint {
+    margin: 0 0 8px;
+    font-size: 12px;
+    color: #6a8aa8;
+    text-align: center;
+  }
+  input {
+    padding: 8px 10px;
+    background: #0d1926;
+    border: 1px solid #24384a;
+    border-radius: 4px;
+    color: #e0ecf5;
+    font-size: 14px;
+  }
+  input:focus { outline: none; border-color: #4a90d9; }
+  button {
+    padding: 8px 10px;
+    background: #1a5a9a;
+    border: none;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 14px;
+    cursor: pointer;
+  }
+  button:disabled { opacity: 0.6; cursor: default; }
+  button:not(:disabled):hover { background: #2a6ab0; }
+  .error {
+    margin: 0;
+    font-size: 12px;
+    color: #e07a7a;
+  }
+</style>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { isTauri, DEFAULT_SCALE, applyScale, loadSettings as loadPlatformSettings, saveSettings as savePlatformSettings, shellOpen, winDrag, type AppSettings } from "$lib/platform";
+  import { apiFetch, restoreSession, setAuthRequiredHandler, getToken } from "$lib/auth";
   import TauriResizeGrips from "$lib/components/TauriResizeGrips.svelte";
   import TauriWindowControls from "$lib/components/TauriWindowControls.svelte";
+  import LoginScreen from "$lib/components/LoginScreen.svelte";
 
   type NodeType = "note" | "source" | "chat" | "stream";
   type GState = "idle" | "indexing" | "stale";
@@ -187,6 +189,18 @@
       : (localStorage.getItem("prisma.server") ?? _defaultApiBase())
   );
 
+  // ── Auth (ADR-011 password mode) ──────────────────────────────────────────
+  // Shown whenever apiFetch (or the /ws connection below) hits a 401 —
+  // i.e. this server is in the LAN zone with server.auth.mode: password
+  // and we don't hold a valid session yet.
+  let showLoginScreen = $state(false);
+  setAuthRequiredHandler(() => { showLoginScreen = true; });
+  // Tauri only: picks up a session already stored in auth.json from a
+  // previous run so a restart doesn't force a re-login every time. Reruns
+  // whenever apiBase changes too (e.g. the user points Settings at a
+  // different server) so that server's own stored session gets checked.
+  $effect(() => { restoreSession(apiBase); });
+
   // ── WebSocket — API-process push events (vault_change, stream_progress) ──────
   // Hot-reload is handled separately below, by polling the Web process directly —
   // it's a dev-only, self-contained concern local to that process (see ADR-012),
@@ -195,7 +209,13 @@
 
   function connectWS() {
     const wsBase = apiBase.replace(/^http/, "ws");
-    const ws = new WebSocket(`${wsBase}/ws`);
+    // Same subprotocol scheme as prisma-desktop's own pull.rs — the
+    // browser WebSocket API can't set an Authorization header, only
+    // subprotocols. Connecting with no token when auth is required just
+    // fails and falls into the existing reconnect-with-backoff below,
+    // which naturally retries once a token exists post-login.
+    const token = getToken();
+    const ws = token ? new WebSocket(`${wsBase}/ws`, ["bearer", token]) : new WebSocket(`${wsBase}/ws`);
 
     ws.onopen = () => { _wsConnected = true; };
 
@@ -290,6 +310,33 @@
   let dragOverKey = $state<string | null>(null);
   let hoverExpandTimer: ReturnType<typeof setTimeout> | null = null;
   let activeNode = $state<RenderedNode | null>(null);
+  // <iframe src="..."> can't carry an Authorization header, so once
+  // server.auth.mode is "password" a direct apiBase URL there would just
+  // 401 — loaded as a blob URL via apiFetch instead. See the vault-sync
+  // plan's note on this being the one real gap authFetch alone can't close.
+  let htmlFrameSrc = $state<string | null>(null);
+  $effect(() => {
+    const node = activeNode;
+    if (!node || node.original_ext !== ".html") {
+      htmlFrameSrc = null;
+      return;
+    }
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    (async () => {
+      try {
+        const r = await apiFetch(`${apiBase}/notes/${node.slug}/view`);
+        if (!r.ok || cancelled) return;
+        const blob = await r.blob();
+        objectUrl = URL.createObjectURL(blob);
+        if (!cancelled) htmlFrameSrc = objectUrl;
+      } catch {}
+    })();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  });
   let activeChat = $state<ChatDetail | null>(null);
   let excerptPollInterval: ReturnType<typeof setInterval> | undefined;
   let chatInput = $state("");
@@ -363,7 +410,7 @@
 
   async function ping(): Promise<boolean> {
     try {
-      const r = await fetch(`${apiBase}/health`, { signal: AbortSignal.timeout(2000) });
+      const r = await apiFetch(`${apiBase}/health`, { signal: AbortSignal.timeout(2000) });
       return r.ok;
     } catch { return false; }
   }
@@ -393,7 +440,7 @@
 
   async function loadTree() {
     try {
-      const r = await fetch(`${apiBase}/tree`);
+      const r = await apiFetch(`${apiBase}/tree`);
       if (r.ok) {
         tree = await r.json();
         if (!treeLoaded) { collapsedDirs = initCollapsed(tree); treeLoaded = true; }
@@ -403,7 +450,7 @@
 
   async function moveNode(slug: string, destDir: string) {
     ctxMenu = null; ctxMovePicker = false;
-    const r = await fetch(`${apiBase}/nodes/${encodeURIComponent(slug)}/move`, {
+    const r = await apiFetch(`${apiBase}/nodes/${encodeURIComponent(slug)}/move`, {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ dest_dir: destDir }),
     });
@@ -418,7 +465,7 @@
     if (!renameTarget) return;
     const { slug, value } = renameTarget;
     renameTarget = null;
-    const r = await fetch(`${apiBase}/nodes/${encodeURIComponent(slug)}/rename`, {
+    const r = await apiFetch(`${apiBase}/nodes/${encodeURIComponent(slug)}/rename`, {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title: value }),
     });
@@ -438,7 +485,7 @@
   async function doDelete(slug: string) {
     ctxMenu = null;
     if (!confirm("Delete this item permanently?")) return;
-    await fetch(`${apiBase}/nodes/${encodeURIComponent(slug)}`, { method: "DELETE" });
+    await apiFetch(`${apiBase}/nodes/${encodeURIComponent(slug)}`, { method: "DELETE" });
     await loadTree();
     await loadChats();
     if (activeNode?.slug === slug) activeNode = null;
@@ -450,7 +497,7 @@
     const name = prompt("New folder name:");
     if (!name?.trim()) return;
     const rel = (parentKey.startsWith("/") ? parentKey.slice(1) : parentKey) + "/" + name.trim();
-    await fetch(`${apiBase}/dirs`, {
+    await apiFetch(`${apiBase}/dirs`, {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ path: rel }),
     });
@@ -499,14 +546,14 @@
 
   async function loadStreams() {
     try {
-      const r = await fetch(`${apiBase}/streams`);
+      const r = await apiFetch(`${apiBase}/streams`);
       if (r.ok) streams = await r.json();
     } catch {}
   }
 
   async function loadChats() {
     try {
-      const r = await fetch(`${apiBase}/notes?node_type=chat`);
+      const r = await apiFetch(`${apiBase}/notes?node_type=chat`);
       if (r.ok) {
         const listing = await r.json();
         chats = listing.chats ?? [];
@@ -521,7 +568,7 @@
     showKgProgressPage = false;
     loadingNode = true;
     try {
-      const r = await fetch(`${apiBase}/chats/${encodeURIComponent(slug)}`);
+      const r = await apiFetch(`${apiBase}/chats/${encodeURIComponent(slug)}`);
       if (r.ok) activeChat = await r.json();
     } finally {
       loadingNode = false;
@@ -529,7 +576,7 @@
   }
 
   async function createChat() {
-    const r = await fetch(`${apiBase}/chats`, {
+    const r = await apiFetch(`${apiBase}/chats`, {
       method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({}),
     });
     if (r.ok) {
@@ -550,7 +597,7 @@
       { role: "user", content: text, timestamp: new Date().toISOString(), sources_cited: [], tool_calls: [] },
     ];
     try {
-      const r = await fetch(`${apiBase}/chat`, {
+      const r = await apiFetch(`${apiBase}/chat`, {
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: text, chat_slug: slug }),
       });
@@ -569,7 +616,7 @@
   async function deleteChatMessage(index: number) {
     if (!activeChat) return;
     if (!confirm("Remove this turn from the conversation?")) return;
-    const r = await fetch(`${apiBase}/chats/${encodeURIComponent(activeChat.slug)}/messages/${index}`, { method: "DELETE" });
+    const r = await apiFetch(`${apiBase}/chats/${encodeURIComponent(activeChat.slug)}/messages/${index}`, { method: "DELETE" });
     if (r.ok) activeChat = await r.json();
   }
 
@@ -577,7 +624,7 @@
     if (!activeChat) return;
     const slug = activeChat.slug;
     const pinned = !activeChat.pinned_turns.includes(index);
-    const r = await fetch(`${apiBase}/chats/${encodeURIComponent(slug)}/turns/${index}/pin`, {
+    const r = await apiFetch(`${apiBase}/chats/${encodeURIComponent(slug)}/turns/${index}/pin`, {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ pinned }),
     });
@@ -600,7 +647,7 @@
     clearInterval(excerptPollInterval);
     excerptPollInterval = setInterval(async () => {
       if (!activeChat || activeChat.slug !== slug) { clearInterval(excerptPollInterval); return; }
-      const r = await fetch(`${apiBase}/chats/${encodeURIComponent(slug)}`);
+      const r = await apiFetch(`${apiBase}/chats/${encodeURIComponent(slug)}`);
       if (!r.ok) { clearInterval(excerptPollInterval); return; }
       const fresh = await r.json();
       // Merge only the Excerpt-related fields — never replace the whole
@@ -639,7 +686,7 @@
 
   async function loadZoteroStatus() {
     try {
-      const r = await fetch(`${apiBase}/zotero/status`);
+      const r = await apiFetch(`${apiBase}/zotero/status`);
       if (r.ok) zoteroStatus = await r.json();
     } catch {}
   }
@@ -647,7 +694,7 @@
   async function loadZoteroCollections() {
     zoteroLoading = true;
     try {
-      const r = await fetch(`${apiBase}/zotero/collections`);
+      const r = await apiFetch(`${apiBase}/zotero/collections`);
       if (r.ok) {
         zoteroCollections = await r.json();
         if (zoteroCollection && !zoteroCollections.find(c => c.key === zoteroCollection)) {
@@ -664,7 +711,7 @@
     if (coll) params.set("collection", coll);
     if (zoteroQ.trim()) params.set("q", zoteroQ.trim());
     try {
-      const r = await fetch(`${apiBase}/zotero/items?${params}`);
+      const r = await apiFetch(`${apiBase}/zotero/items?${params}`);
       if (r.ok) zoteroItems = await r.json();
     } catch {} finally { zoteroLoading = false; }
   }
@@ -677,7 +724,7 @@
   async function importZoteroItem(key: string) {
     importingKey = key;
     try {
-      const r = await fetch(`${apiBase}/zotero/import/${key}`, { method: "POST" });
+      const r = await apiFetch(`${apiBase}/zotero/import/${key}`, { method: "POST" });
       if (r.ok) {
         const node = await r.json();
         activeNode = node;
@@ -692,7 +739,7 @@
     showKgProgressPage = false;
     loadingNode = true;
     try {
-      const r = await fetch(`${apiBase}/home`);
+      const r = await apiFetch(`${apiBase}/home`);
       if (r.ok) activeNode = await r.json();
     } catch {} finally { loadingNode = false; }
   }
@@ -707,7 +754,7 @@
   async function fetchStatus() {
     const wasOnline = serverOnline;
     try {
-      const r = await fetch(`${apiBase}/status`, { signal: AbortSignal.timeout(3000) });
+      const r = await apiFetch(`${apiBase}/status`, { signal: AbortSignal.timeout(3000) });
       if (!r.ok) { serverOnline = false; serverStatus = null; return; }
       const s: ServerStatus = await r.json();
       serverOnline = true;
@@ -770,7 +817,7 @@
     if (name === "api") {
       await fetch(`${supervisorBase()}/supervisor/restart/api`, { method: "POST" });
     } else {
-      await fetch(`${apiBase}/supervisor/restart/${name}`, { method: "POST" });
+      await apiFetch(`${apiBase}/supervisor/restart/${name}`, { method: "POST" });
     }
   }
 
@@ -800,7 +847,7 @@
     try {
       const f = fmt ?? viewFormat;
       const url = f === "md" ? `${apiBase}/notes/${slug}?format=md` : `${apiBase}/notes/${slug}`;
-      const r = await fetch(url);
+      const r = await apiFetch(url);
       if (r.ok) activeNode = await r.json();
     } catch {} finally { loadingNode = false; }
   }
@@ -811,7 +858,7 @@
     showKgProgressPage = false;
     loadingNode = true;
     try {
-      const r = await fetch(`${apiBase}/streams/${slug}/view`);
+      const r = await apiFetch(`${apiBase}/streams/${slug}/view`);
       if (r.ok) {
         activeNode = await r.json();
         if (activeNode?.collection_key) {
@@ -820,11 +867,11 @@
             zoteroLoading = true;
             try {
               if (zoteroCollections.length === 0) {
-                const rc = await fetch(`${apiBase}/zotero/collections`);
+                const rc = await apiFetch(`${apiBase}/zotero/collections`);
                 if (rc.ok) zoteroCollections = await rc.json();
               }
               const params = new URLSearchParams({ collection: activeNode.collection_key });
-              const ri = await fetch(`${apiBase}/zotero/items?${params}`);
+              const ri = await apiFetch(`${apiBase}/zotero/items?${params}`);
               if (ri.ok) zoteroItems = await ri.json();
             } finally { zoteroLoading = false; }
             sectionOpen = { ...sectionOpen, zotero: true };
@@ -841,7 +888,7 @@
     if (next === "md" && activeNode?.original_ext === ".html" && !activeNode.has_md) {
       generatingMd = true;
       try {
-        await fetch(`${apiBase}/notes/${activeNode.slug}/md`, { method: "POST" });
+        await apiFetch(`${apiBase}/notes/${activeNode.slug}/md`, { method: "POST" });
       } finally {
         generatingMd = false;
       }
@@ -892,7 +939,7 @@
   async function runSearch() {
     searching = true;
     try {
-      const r = await fetch(`${apiBase}/search?q=${encodeURIComponent(searchQuery)}`);
+      const r = await apiFetch(`${apiBase}/search?q=${encodeURIComponent(searchQuery)}`);
       if (r.ok) searchResults = await r.json();
     } catch {} finally { searching = false; }
   }
@@ -915,7 +962,7 @@
       deepPhase = (deepPhase + 1) % DEEP_PHASES.length;
     }, 3500);
     try {
-      const r = await fetch(`${apiBase}/search/deep?q=${encodeURIComponent(deepQuery)}`);
+      const r = await apiFetch(`${apiBase}/search/deep?q=${encodeURIComponent(deepQuery)}`);
       if (r.ok) deepResults = await r.json();
     } catch {} finally {
       deepSearching = false;
@@ -998,7 +1045,7 @@
     streamFormSaving = true;
     streamFormError = "";
     try {
-      const r = await fetch(`${apiBase}/streams`, {
+      const r = await apiFetch(`${apiBase}/streams`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(streamForm),
@@ -1019,13 +1066,13 @@
 
   async function deleteStream(slug: string) {
     if (!confirm(`Delete stream "${slug}"?`)) return;
-    await fetch(`${apiBase}/streams/${slug}`, { method: "DELETE" });
+    await apiFetch(`${apiBase}/streams/${slug}`, { method: "DELETE" });
     if (activeNode?.slug === slug) activeNode = null;
     await Promise.all([loadTree(), loadStreams()]);
   }
 
   async function patchStreamStatus(slug: string, status: string) {
-    await fetch(`${apiBase}/streams/${slug}`, {
+    await apiFetch(`${apiBase}/streams/${slug}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ status }),
@@ -1038,6 +1085,10 @@
 
   loadSettings().then(() => bootstrap());
 </script>
+
+{#if showLoginScreen}
+  <LoginScreen serverUrl={apiBase} onLoggedIn={() => { showLoginScreen = false; loadTree(); connectWS(); }} />
+{/if}
 
 {#if isTauri}
   <!-- Sibling of .shell, not a descendant — see TauriResizeGrips.svelte. -->
@@ -1522,7 +1573,7 @@
             onclick={async () => {
               if (!activeNode || activeNode.node_type === "stream" || activeNode.node_type === "chat") return;
               const next = activeNode.node_type === "note" ? "source" : "note";
-              const r = await fetch(`${apiBase}/notes/${activeNode.slug}/type`, {
+              const r = await apiFetch(`${apiBase}/notes/${activeNode.slug}/type`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ node_type: next }),
@@ -1592,11 +1643,13 @@
         {/if}
         {#if activeNode.original_ext === ".html"}
           {#key activeNode.slug}
+          {#if htmlFrameSrc}
           <iframe
             class="html-frame"
-            src="{apiBase}/notes/{activeNode.slug}/view"
+            src={htmlFrameSrc}
             title={activeNode.title}
           ></iframe>
+          {/if}
           {/key}
         {:else}
         <div class="rendered" use:contentClickDelegate>


### PR DESCRIPTION
## Summary
- llama_cpp provider alongside Ollama for chat, KG extraction, chroma embeddings, and analysis_agent; supervisor compute-pool awareness for llama-swap-backed pools.
- KG extraction: model-provenance tracking, dynamic max_tokens from the model's real context window, and an openrouter provider option for deployments where local hardware can't run extraction-quality models fast enough.
- Vault-sync server surface (`/sync/manifest`, `/sync/file`), path-based VaultService accessors, WS broadcast() echo-loop prevention.
- ADR-011 password-mode auth: zone-classifying middleware, `POST /auth/login`, JWT sessions, WS auth via Sec-WebSocket-Protocol, `prisma auth hash-password` CLI.
- UI: login screen + apiFetch auth wrapper.
- Docs: llama.cpp Vulkan benchmark (forge vs anvil), NuExtract-2.0 KG-extraction evaluation (negative result), TODO.md updates.

The desktop-side implementation (Rust: fs-watcher push, WS pull, conflict resolution) lives in the sibling `prisma-desktop` repo, not part of this PR.

## Test plan
- [x] 480 passed, 24 skipped (`pytest tests/`) - no regressions
- [x] Verified live against a real running server (temp instance, isolated ports): login, push/pull/409-conflict/delete over REST, WS subprotocol handshake, both directions of echo-loop suppression
- [x] Verified live on Forge (prisma-dev Helm chart): KG extraction correctly routes to openai/gpt-4o-mini via OpenRouter after this branch deploys
