### PR TITLE
Log per-call token usage for chat and KG extraction (OpenRouter)

### DIFF
--- a/prisma/services/chat_llm.py
+++ b/prisma/services/chat_llm.py
@@ -104,4 +104,19 @@ class ChatLLM:
             except Exception as exc:
                 _log.warning("chat completion failed: %s", exc)
                 return None
+        # Cloud providers (openrouter) bill per-token — a real, per-call
+        # usage record here is what actually lets "how much are we
+        # spending" be answered from logs, rather than only from
+        # OpenRouter's own dashboard after the fact (found live 2026-07-25:
+        # a misconfigured deployment had already granted leases and hit
+        # OpenRouter for several calls before anyone noticed nothing was
+        # actually working — a per-call log line would have made that
+        # obvious immediately instead of needing to check OpenRouter's own
+        # /api/v1/key usage counter to even suspect it).
+        if resp.usage is not None:
+            _log.info(
+                "chat completion: provider=%s model=%s prompt_tokens=%d completion_tokens=%d total_tokens=%d",
+                self._config.provider, self._config.model,
+                resp.usage.prompt_tokens, resp.usage.completion_tokens, resp.usage.total_tokens,
+            )
         return resp.choices[0].message.content

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -856,6 +856,19 @@ class KnowledgeGraphService:
                     _log.warning("extraction call failed for %s: %s", rel_path, exc)
                     self._record_dropped_chunk(rel_path, section_text, str(exc), retry_count, reason)
                     return [], [], False
+                # Same rationale as ChatLLM.complete()'s own usage log —
+                # a real per-call token record for cloud providers
+                # (openrouter), directly from logs rather than only
+                # discoverable after the fact via OpenRouter's own
+                # /api/v1/key usage counter.
+                raw = getattr(extraction, "_raw_response", None)
+                usage = getattr(raw, "usage", None) if raw is not None else None
+                if usage is not None:
+                    _log.info(
+                        "kg extraction call: provider=%s model=%s prompt_tokens=%d completion_tokens=%d total_tokens=%d",
+                        self._provider, self._ollama_model,
+                        usage.prompt_tokens, usage.completion_tokens, usage.total_tokens,
+                    )
         with self._lock:
             self._chunk_durations.append((time.monotonic() - t0) * 1000)
             self._chunk_retries.append(retry_count)


### PR DESCRIPTION
## Summary
Cloud providers (openrouter) bill per-token — a real per-call usage record in logs (provider, model, prompt/completion/total tokens) lets "how much are we spending" be answered directly from logs, rather than only after the fact via OpenRouter's own `/api/v1/key` usage counter.

Context: found the need for this live while testing the vault-sync/auth deployment on Forge — a misconfigured deployment (chat.pool mismatch, then chat.api_key_env missing) had already been granted compute leases and reached OpenRouter's endpoint for several calls before anyone noticed nothing was actually working. A per-call log line at the point of the call would have made both failures obvious immediately instead of needing to check OpenRouter's own usage counter to even suspect it.

For KG extraction (routed through instructor's `response_model` validation), the raw completion's usage is available via instructor's own documented `_raw_response` attachment.

## Test plan
- [x] 480 passed, 24 skipped (`pytest tests/`) — no regressions