### PR TITLE
Fix eternal 409 conflict loop from exact float64 mtime equality

### DIFF
--- a/prisma/server/sync_routes.py
+++ b/prisma/server/sync_routes.py
@@ -25,6 +25,16 @@ from prisma.services.vault import VaultService
 
 _CLIENT_ID_HEADER = "x-sync-client-id"
 
+# mtime equality tolerance for the optimistic-concurrency check below. Unix
+# timestamps at today's magnitude (~1.78e9) leave float64 only ~238ns of
+# resolution (confirmed live 2026-07-25: two mtimes one ULP apart --
+# 1785018422.3829463 vs .3829465 -- compared unequal forever after a round
+# trip through JSON serialization, Python -> Rust -> Python, causing an
+# eternal single-file 409 loop that never resolved on its own). Exact `==`
+# is fundamentally unsafe here; 1ms is orders of magnitude looser than the
+# ULP-scale noise while still far tighter than any real edit-timing window.
+_MTIME_TOLERANCE_SECONDS = 1e-3
+
 
 class SyncManifestEntry(BaseModel):
     path: str
@@ -83,7 +93,7 @@ def build_sync_router(
             # this path was brand new (expected_mtime is None) but the
             # server already has a file there — same ambiguity either way,
             # resolved identically client-side (compare mtimes, keep newer).
-            if req.expected_mtime is None or mtime != req.expected_mtime:
+            if req.expected_mtime is None or abs(mtime - req.expected_mtime) > _MTIME_TOLERANCE_SECONDS:
                 raise HTTPException(
                     status_code=409,
                     detail={"path": req.path, "body": body, "mtime": mtime},

--- a/tests/unit/server/test_sync_routes.py
+++ b/tests/unit/server/test_sync_routes.py
@@ -3,6 +3,7 @@ FastAPI app wrapping just build_sync_router + a tmp_path VaultService), not
 the full prisma.server.app singleton, so these don't depend on auth/CORS/the
 real vault_root and stay independently testable per the vault-sync plan.
 """
+import math
 from pathlib import Path
 
 import pytest
@@ -112,6 +113,29 @@ def test_put_matching_expected_mtime_succeeds(client, vault):
     r = client.put("/sync/file", json={"path": "notes/a.md", "body": "v2", "expected_mtime": mtime})
     assert r.status_code == 200
     assert vault.read_by_path("notes/a.md")[0] == "v2"
+
+
+def test_put_one_ulp_off_expected_mtime_still_succeeds(client, vault):
+    # Regression test for a real 2026-07-25 bug: a Unix timestamp at today's
+    # magnitude (~1.78e9) leaves float64 only ~238ns of resolution, so a
+    # value round-tripped through JSON across languages (Python -> Rust ->
+    # Python) can land one ULP off from the server's freshly-read mtime.
+    # Exact equality treated this as a real conflict forever, with no way
+    # for the client to ever converge -- confirmed live: expected_mtime one
+    # ULP away from the true mtime 409'd endlessly, in an infinite loop the
+    # client could never resolve (see sync_routes.py's _MTIME_TOLERANCE_SECONDS).
+    mtime = vault.write_by_path("notes/a.md", "v1")
+    off_by_one_ulp = math.nextafter(mtime, math.inf)
+    assert off_by_one_ulp != mtime  # sanity check this is a real distinct float
+    r = client.put("/sync/file", json={"path": "notes/a.md", "body": "v2", "expected_mtime": off_by_one_ulp})
+    assert r.status_code == 200
+    assert vault.read_by_path("notes/a.md")[0] == "v2"
+
+
+def test_put_genuinely_stale_expected_mtime_still_conflicts(client, vault):
+    vault.write_by_path("notes/a.md", "v1")
+    r = client.put("/sync/file", json={"path": "notes/a.md", "body": "v2", "expected_mtime": 1.0})
+    assert r.status_code == 409
 
 
 def test_delete_file_removes_and_broadcasts(client, vault, recorder):


### PR DESCRIPTION
## Summary
- \`/sync/file\`'s optimistic-concurrency check compared mtimes with exact float equality. At today's Unix-timestamp magnitude (~1.78e9), float64 only has ~238ns of resolution -- confirmed live: a value round-tripped through JSON across languages (Python's `stat().st_mtime` -> Rust client -> back to Python) landed exactly one ULP off, and exact equality treated the same instant as a permanent conflict.
- The desktop client had no way to ever converge: each retry re-read the same one-ULP-off value from the previous conflict response and got the same 409 again, forever.
- Not the earlier (now-fixed) exponential conflict-copy duplication bug -- this one never grew, it just never resolved. Single-level conflict copies kept regenerating identically every fs-watcher cycle.
- Switches to a 1ms tolerance in the comparison.

## Test plan
- [x] New regression test: expected_mtime one ULP off (via `math.nextafter`) now succeeds
- [x] New regression test: a genuinely stale expected_mtime still correctly 409s
- [x] Full suite: 490 passed, 24 skipped
- [ ] Live retest against real Anvil<->Forge sync once deployed