### PR TITLE
KG: clear stale state even when watcher finds no real content change

### DIFF
--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -1224,20 +1224,32 @@ class KnowledgeGraphService:
                 pending = self._pending.copy()
                 self._pending.clear()
             if pending:
-                _log.info("knowledge graph incremental update: %d files flagged by watcher", len(pending))
-                existing = [path for path in pending if path.exists()]
-                for path in pending:
-                    if not path.exists():
-                        self._delete_file(path)
-                changed = self._extract_files_concurrently(existing)
-                if changed:
-                    with self._lock:
-                        self._last_indexed = datetime.now()
-                        self._state = "idle"
-                elif existing:
-                    _log.info("knowledge graph incremental update: no real content change — watcher false-positive")
-                self._set_activity(None)
+                self._process_pending(pending)
             self._stop_event.wait(timeout=60)
+
+    def _process_pending(self, pending: set[Path]) -> None:
+        _log.info("knowledge graph incremental update: %d files flagged by watcher", len(pending))
+        existing = [path for path in pending if path.exists()]
+        for path in pending:
+            if not path.exists():
+                self._delete_file(path)
+        changed = self._extract_files_concurrently(existing)
+        # mark_stale() is called optimistically from many API call sites
+        # (any vault write) before this watcher-driven pass ever runs, so
+        # /status reflects a change immediately rather than waiting up to
+        # 60s for this loop to catch up. But that means "stale" must always
+        # get resolved here once pending is actually processed -- even when
+        # the content hash didn't really change (confirmed live 2026-07-25:
+        # sync-engine conflict retries rewriting identical content left
+        # "stale" permanently stuck with nothing left to do, since only the
+        # `changed` branch used to clear it).
+        with self._lock:
+            if changed:
+                self._last_indexed = datetime.now()
+            self._state = "idle"
+        if not changed and existing:
+            _log.info("knowledge graph incremental update: no real content change — watcher false-positive")
+        self._set_activity(None)
 
     def _full_index(self) -> None:
         with self._lock:

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -641,6 +641,27 @@ def test_mark_stale_does_not_override_indexing_state(kg):
     assert kg.status()["state"] == "indexing"
 
 
+def test_process_pending_clears_stale_even_with_no_real_change(kg, vault):
+    # Regression test for a real 2026-07-25 bug: mark_stale() is called
+    # optimistically from many API call sites ahead of this watcher-driven
+    # pass, so if the flagged file's content hash turns out unchanged (e.g.
+    # a rewrite with identical content -- exactly what the vault-sync
+    # engine's conflict-retry path does), "stale" stayed stuck forever with
+    # nothing left to process, since only the real-change branch used to
+    # clear it.
+    f = vault.root / "notes" / "a.md"
+    content = "---\ntype: note\n---\ncontent"
+    f.write_text(content, encoding="utf-8")
+    with kg._lock:
+        kg._state = "stale"
+        rel = str(f.relative_to(vault.root))
+        kg._set_indexed_hash(rel, hashlib.sha256(content.encode("utf-8")).hexdigest())
+
+    kg._process_pending({f})
+
+    assert kg.status()["state"] == "idle"
+
+
 def test_full_index_sets_idle_and_last_indexed(kg, vault):
     f = vault.root / "notes" / "a.md"
     f.write_text("---\ntype: note\n---\ncontent", encoding="utf-8")


### PR DESCRIPTION
## Summary
- `mark_stale()` fires optimistically from many API call sites (any vault write) so `/status` shows "stale" immediately, ahead of the watcher-driven incremental pass that actually decides whether re-extraction is needed.
- That pass only cleared "stale" -> "idle" on a real content-hash change. If the flagged file's content turned out unchanged (confirmed live: the vault-sync engine's conflict-retry path rewrites identical content), "stale" stayed stuck forever with nothing left to process.
- Extracted the per-batch logic into `_process_pending()` (was inline in `_loop()`) so it's directly testable, and it now always resolves to "idle" once a batch is processed, changed or not.

## Test plan
- [x] New regression test: `_process_pending` on an unchanged file clears "stale" -> "idle"
- [x] Full suite: 491 passed, 24 skipped
- [ ] Live retest on Forge