### PR TITLE
KG: mark_stale() checks path relevance instead of firing blindly

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -321,7 +321,7 @@ from prisma.server.sync_routes import build_sync_router  # noqa: E402
 app.include_router(build_sync_router(
     get_vault=lambda: _vault,
     broadcast_fn=broadcast,
-    mark_stale_fn=lambda: _indexer.mark_stale(),
+    mark_stale_fn=lambda path: _indexer.mark_stale(path),
 ))
 
 _executor = ThreadPoolExecutor(max_workers=2)
@@ -1453,7 +1453,9 @@ def create_stream(req: StreamCreateRequest):
         refresh_frequency=req.refresh_frequency,
         tags=req.tags,
     )
-    _indexer.mark_stale()
+    # No mark_stale() -- streams/*.yaml is never KG-indexable content (see
+    # KnowledgeGraphService.is_relevant_path), so it would just set "stale"
+    # with nothing ever able to clear it.
     _activity.info("action=create_stream slug=%s query=%r freq=%s", s.slug, req.query, req.refresh_frequency)
     return _stream_meta(s)
 
@@ -1483,7 +1485,7 @@ def delete_stream(slug: str):
         _vault.delete_stream(slug)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
-    _indexer.mark_stale()
+    # No mark_stale() -- see create_stream's comment above.
     _activity.info("action=delete_stream slug=%s", slug)
 
 

--- a/prisma/server/sync_routes.py
+++ b/prisma/server/sync_routes.py
@@ -57,7 +57,7 @@ class SyncFileWriteRequest(BaseModel):
 def build_sync_router(
     get_vault: Callable[[], VaultService],
     broadcast_fn: Callable[..., None],
-    mark_stale_fn: Callable[[], None],
+    mark_stale_fn: Callable[[str], None],
 ) -> APIRouter:
     router = APIRouter(prefix="/sync", tags=["sync"])
 
@@ -104,7 +104,13 @@ def build_sync_router(
         except ValueError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
 
-        mark_stale_fn()
+        # mark_stale_fn checks the path itself (KnowledgeGraphService.
+        # is_relevant_path) -- streams/*.yaml (the one other synced type,
+        # see _safe_sync_path) is excluded from the KG's own file watcher,
+        # so a bare unconditional mark_stale() here would set "stale" with
+        # nothing ever able to clear it (confirmed live 2026-07-25 on Forge,
+        # right after the vault-sync engine pushed a stream file).
+        mark_stale_fn(req.path)
         broadcast_fn(
             {"type": "vault_change", "action": "sync_write", "path": req.path},
             exclude_client_id=request.headers.get(_CLIENT_ID_HEADER),
@@ -118,7 +124,7 @@ def build_sync_router(
         except ValueError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
 
-        mark_stale_fn()
+        mark_stale_fn(path)
         broadcast_fn(
             {"type": "vault_change", "action": "sync_delete", "path": path},
             exclude_client_id=request.headers.get(_CLIENT_ID_HEADER),

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -497,7 +497,29 @@ class KnowledgeGraphService:
                 _log.warning("knowledge graph indexer thread did not exit within 5s — likely mid-extraction")
         _log.info("knowledge graph stopped")
 
-    def mark_stale(self) -> None:
+    def is_relevant_path(self, path: Path) -> bool:
+        """Whether `path` is something this service would ever actually
+        index — the single source of truth for both the fs watcher
+        (_VaultChangeHandler) and mark_stale()'s optional path check, so the
+        two can never drift apart the way they did before (a stream write
+        could set "stale" via mark_stale() while the watcher categorically
+        never adds streams/ to _pending, leaving "stale" stuck forever with
+        nothing left to process — confirmed live 2026-07-25)."""
+        if any(p in path.parts for p in (".vault-files", "streams")) or path.name.startswith("."):
+            return False
+        return path.suffix in self.index_extensions
+
+    def mark_stale(self, path: Path | str | None = None) -> None:
+        """Optimistically flags the index stale ahead of the watcher-driven
+        pass that actually decides whether re-extraction is needed — lets
+        /status reflect a change immediately rather than waiting up to 60s.
+        `path`, when known, is checked against is_relevant_path() first: a
+        write to something the watcher would never pick up (streams/*.yaml)
+        must not set "stale", since nothing would ever clear it. Callers
+        that don't know/care about a specific path (e.g. /knowledge-graph/taint)
+        keep the old unconditional behavior."""
+        if path is not None and not self.is_relevant_path(Path(path)):
+            return
         with self._lock:
             if self._state != "indexing":
                 self._state = "stale"

--- a/tests/unit/server/test_sync_routes.py
+++ b/tests/unit/server/test_sync_routes.py
@@ -20,12 +20,14 @@ class _Recorder:
     def __init__(self):
         self.broadcasts = []
         self.mark_stale_calls = 0
+        self.mark_stale_paths = []
 
     def broadcast(self, event, exclude_client_id=None):
         self.broadcasts.append((event, exclude_client_id))
 
-    def mark_stale(self):
+    def mark_stale(self, path):
         self.mark_stale_calls += 1
+        self.mark_stale_paths.append(path)
 
 
 @pytest.fixture
@@ -63,6 +65,7 @@ def test_put_new_file_creates_and_broadcasts(client, vault, recorder):
     assert r.json()["body"] == "hello"
     assert vault.read_by_path("notes/a.md")[0] == "hello"
     assert recorder.mark_stale_calls == 1
+    assert recorder.mark_stale_paths == ["notes/a.md"]
     assert len(recorder.broadcasts) == 1
     event, exclude = recorder.broadcasts[0]
     assert event == {"type": "vault_change", "action": "sync_write", "path": "notes/a.md"}
@@ -130,12 +133,6 @@ def test_put_one_ulp_off_expected_mtime_still_succeeds(client, vault):
     r = client.put("/sync/file", json={"path": "notes/a.md", "body": "v2", "expected_mtime": off_by_one_ulp})
     assert r.status_code == 200
     assert vault.read_by_path("notes/a.md")[0] == "v2"
-
-
-def test_put_genuinely_stale_expected_mtime_still_conflicts(client, vault):
-    vault.write_by_path("notes/a.md", "v1")
-    r = client.put("/sync/file", json={"path": "notes/a.md", "body": "v2", "expected_mtime": 1.0})
-    assert r.status_code == 409
 
 
 def test_delete_file_removes_and_broadcasts(client, vault, recorder):

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -641,6 +641,32 @@ def test_mark_stale_does_not_override_indexing_state(kg):
     assert kg.status()["state"] == "indexing"
 
 
+def test_mark_stale_ignores_stream_paths(kg, vault):
+    # Regression test for a real 2026-07-25 bug: streams/*.yaml is excluded
+    # from the KG's own file watcher (_VaultChangeHandler never adds it to
+    # _pending), so calling mark_stale() for a stream write set "stale" with
+    # nothing ever able to clear it -- stuck forever. Confirmed live on
+    # Forge right after the vault-sync engine pushed a stream file.
+    with kg._lock:
+        kg._state = "idle"
+    kg.mark_stale(vault.root / "streams" / "my-topic.yaml")
+    assert kg.status()["state"] == "idle"
+
+
+def test_mark_stale_still_applies_to_md_paths(kg, vault):
+    with kg._lock:
+        kg._state = "idle"
+    kg.mark_stale(vault.root / "notes" / "a.md")
+    assert kg.status()["state"] == "stale"
+
+
+def test_is_relevant_path_matches_watcher_exclusions(kg, vault):
+    assert kg.is_relevant_path(vault.root / "notes" / "a.md") is True
+    assert kg.is_relevant_path(vault.root / "streams" / "my-topic.yaml") is False
+    assert kg.is_relevant_path(vault.root / ".vault-files" / "chromadb" / "x.json") is False
+    assert kg.is_relevant_path(vault.root / ".hidden.md") is False
+
+
 def test_process_pending_clears_stale_even_with_no_real_change(kg, vault):
     # Regression test for a real 2026-07-25 bug: mark_stale() is called
     # optimistically from many API call sites ahead of this watcher-driven


### PR DESCRIPTION
## Summary
- Broader root cause behind #41: `mark_stale()` took no path argument, so ~10 call sites fired unconditionally regardless of whether the touched path was something the KG's own file watcher would ever pick up.
- `streams/*.yaml` is categorically excluded from that watcher -- any write there set "stale" with nothing ever able to clear it.
- `is_relevant_path()` is now the single source of truth for both the watcher and `mark_stale()`'s optional path check.
- `create_stream`/`delete_stream` never touch KG-relevant content -- removed their `mark_stale()` calls outright.
- `move_node`/`rename_node`/`delete_node` were checked and left alone: their slug lookups structurally can't resolve a stream.
- Removes a duplicate test introduced in the previous PR.

## Test plan
- [x] New tests: `is_relevant_path` correctness, `mark_stale` ignoring streams / still applying to notes, sync_routes path plumbing
- [x] Full suite: 493 passed, 24 skipped
- [ ] Live retest on Forge