### PR TITLE
Fix mark_stale() path not actually crossing the api<->kg process boundary

### DIFF
--- a/prisma/server/kg_app.py
+++ b/prisma/server/kg_app.py
@@ -219,9 +219,9 @@ def status():
 
 
 @app.post("/mark_stale")
-def mark_stale():
-    _kg.mark_stale()
-    return {"status": "stale"}
+def mark_stale(path: str | None = None):
+    _kg.mark_stale(path)
+    return {"status": _kg.status()["state"]}
 
 
 @app.post("/drop_index")

--- a/prisma/services/knowledge_graph_client.py
+++ b/prisma/services/knowledge_graph_client.py
@@ -37,8 +37,8 @@ class KnowledgeGraphClient:
     def stop(self) -> None:
         pass
 
-    def mark_stale(self) -> None:
-        self._post("/mark_stale")
+    def mark_stale(self, path: str | None = None) -> None:
+        self._post("/mark_stale", params={"path": path} if path is not None else None)
 
     def drop_index(self) -> None:
         self._post("/drop_index")

--- a/tests/unit/services/test_knowledge_graph_client.py
+++ b/tests/unit/services/test_knowledge_graph_client.py
@@ -50,6 +50,18 @@ def test_mark_stale_posts_to_kg():
     with patch("prisma.services.knowledge_graph_client.requests.post") as mock_post:
         client.mark_stale()
     assert mock_post.call_args[0][0].endswith("/mark_stale")
+    assert mock_post.call_args.kwargs["params"] is None
+
+
+def test_mark_stale_forwards_path_to_kg():
+    # The kg process runs in its own worker (see this module's docstring),
+    # so KnowledgeGraphService.mark_stale()'s path-relevance check (added
+    # alongside prisma#42) needs the path to actually cross the HTTP
+    # boundary, not just be accepted client-side and dropped.
+    client = KnowledgeGraphClient()
+    with patch("prisma.services.knowledge_graph_client.requests.post") as mock_post:
+        client.mark_stale("streams/my-topic.yaml")
+    assert mock_post.call_args.kwargs["params"] == {"path": "streams/my-topic.yaml"}
 
 
 def test_mark_stale_does_not_raise_when_unreachable():


### PR DESCRIPTION
## Summary
- #42's mark_stale(path=...) fix only changed the KG service and app.py's in-process call sites -- but `_indexer` in app.py is a `KnowledgeGraphClient` HTTP proxy to the separate "kg" worker process, and neither the client nor kg_app.py's `/mark_stale` endpoint were updated to actually carry the path across that boundary.
- Every real call site would have hit a TypeError (`KnowledgeGraphClient.mark_stale()` still took zero args) before ever reaching a real deployment.

## Test plan
- [x] New test: client forwards `path` as a query param
- [x] Full suite: 494 passed, 24 skipped
- [ ] Live retest on Forge