### PR TITLE
Redesign sync: server orchestrates, desktop responds (fixes push loop)

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -10,6 +10,7 @@ def _ep_safe(**kw):
 _imeta.entry_points = _ep_safe
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -72,6 +73,10 @@ _t("importing zotero")
 from prisma.services.zotero import ZoteroMode, ZoteroService
 _t("zotero ok")
 
+_t("importing sync_orchestrator")
+from prisma.services.sync_orchestrator import SyncDecision, diff_manifest
+_t("sync_orchestrator ok")
+
 _t("importing vault_models")
 from prisma.storage.models.vault_models import (
     Chat, ChatMessage, ChatRole, NodeType, RenderedNode, StreamRunResult, ToolCallRecord,
@@ -121,6 +126,123 @@ def broadcast(event: dict, exclude_client_id: str | None = None) -> None:
     incoming server-side change."""
     if _ws_loop is not None and _ws_loop.is_running():
         asyncio.run_coroutine_threadsafe(_ws_broadcast(event, exclude_client_id), _ws_loop)
+
+
+# ── Sync orchestration (2026-07-26 redesign) ──────────────────────────────────
+# The server is the sole authority deciding push/pull/conflict for the
+# desktop's local vault mirror — see prisma-desktop's sync/pull.rs and
+# services/sync_orchestrator.py's own module doc comments for the full
+# rationale. _client_baseline is the server-side equivalent of the
+# desktop's sync_state.json: the last-known-agreed (hash, mtime) per path,
+# per client_id — rebuilt from scratch each connection via a full
+# request_manifest/manifest_response exchange rather than persisted, since
+# a fresh full diff on every connect is cheap for a personal vault and
+# means there's nothing to get out of sync across a restart.
+
+_client_baseline: dict[str, dict[str, tuple[str, float]]] = {}
+_client_baseline_lock = threading.Lock()
+
+
+def _hash_body(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _server_manifest() -> dict[str, tuple[str, float]]:
+    """Every synced file's (content_hash, mtime), read fresh from the vault."""
+    manifest: dict[str, tuple[str, float]] = {}
+    for path, mtime, _size in _vault.list_md_manifest():
+        result = _vault.read_by_path(path)
+        if result is None:
+            continue
+        body, _mtime = result
+        manifest[path] = (_hash_body(body), mtime)
+    return manifest
+
+
+def _server_file_entry(path: str) -> tuple[str, float] | None:
+    """Single-path version of _server_manifest — used for the live
+    file_changed/file_deleted notifications, where re-hashing the entire
+    vault on every keystroke-adjacent edit would be wasteful."""
+    try:
+        result = _vault.read_by_path(path)
+    except ValueError:
+        return None
+    if result is None:
+        return None
+    body, mtime = result
+    return (_hash_body(body), mtime)
+
+
+async def _dispatch_sync_decisions(ws: WebSocket, client_id: str, decisions: dict[str, "SyncDecision"]) -> None:
+    for path, decision in decisions.items():
+        if decision == SyncDecision.ASK_CLIENT_TO_PUSH:
+            await ws.send_text(json.dumps({"type": "request_file", "path": path}))
+        elif decision == SyncDecision.PUSH_TO_CLIENT:
+            await ws.send_text(json.dumps({"type": "vault_change", "action": "sync_write", "path": path}))
+        elif decision == SyncDecision.TELL_CLIENT_TO_DELETE:
+            await ws.send_text(json.dumps({"type": "vault_change", "action": "sync_delete", "path": path}))
+            with _client_baseline_lock:
+                _client_baseline.setdefault(client_id, {}).pop(path, None)
+        elif decision == SyncDecision.DELETE_ON_SERVER:
+            try:
+                _vault.delete_by_path(path)
+            except ValueError:
+                continue
+            _indexer.mark_stale(path)
+            broadcast({"type": "vault_change", "action": "sync_delete", "path": path}, exclude_client_id=client_id)
+            with _client_baseline_lock:
+                _client_baseline.setdefault(client_id, {}).pop(path, None)
+
+
+async def _handle_sync_message(ws: WebSocket, client_id: str, msg: dict) -> None:
+    kind = msg.get("type")
+    with _client_baseline_lock:
+        baseline = dict(_client_baseline.get(client_id, {}))
+
+    if kind == "manifest_response":
+        client_files = {
+            f["path"]: (f["hash"], f["mtime"]) for f in msg.get("files", []) if "path" in f and "hash" in f
+        }
+        server_files = _server_manifest()
+        decisions = diff_manifest(server_files, client_files, baseline)
+        await _dispatch_sync_decisions(ws, client_id, decisions)
+        # Confirm the baseline for everything that's already in sync (not
+        # flagged above) — self-heals cases the ack-based updates below
+        # can't see directly, e.g. a client-side conflict resolution that
+        # overwrote its own copy to match the server without any PUT.
+        with _client_baseline_lock:
+            bl = _client_baseline.setdefault(client_id, {})
+            for path, entry in client_files.items():
+                if path not in decisions and server_files.get(path) == entry:
+                    bl[path] = entry
+
+    elif kind in ("file_changed", "file_deleted"):
+        path = msg.get("path")
+        if not path:
+            return
+        client_entry = None if kind == "file_deleted" else (msg.get("hash", ""), msg.get("mtime", 0.0))
+        server_entry = _server_file_entry(path)
+        decisions = diff_manifest(
+            {path: server_entry} if server_entry else {},
+            {path: client_entry} if client_entry else {},
+            {path: baseline[path]} if path in baseline else {},
+        )
+        if path in decisions:
+            await _dispatch_sync_decisions(ws, client_id, decisions)
+        else:
+            with _client_baseline_lock:
+                bl = _client_baseline.setdefault(client_id, {})
+                if client_entry:
+                    bl[path] = client_entry
+                else:
+                    bl.pop(path, None)
+            await ws.send_text(json.dumps({"type": "ack", "path": path}))
+
+    elif kind == "file_synced":
+        path = msg.get("path")
+        if path:
+            with _client_baseline_lock:
+                _client_baseline.setdefault(client_id, {})[path] = (msg.get("hash", ""), msg.get("mtime", 0.0))
 
 
 # ── Vault root / config helpers ───────────────────────────────────────────────
@@ -318,10 +440,22 @@ app.add_middleware(AccessLogMiddleware)
 # value at include_router() time would keep talking to a stale, replaced
 # instance after a reload.
 from prisma.server.sync_routes import build_sync_router  # noqa: E402
+def _update_client_baseline(client_id: str, path: str, content_hash: str, mtime: float) -> None:
+    with _client_baseline_lock:
+        _client_baseline.setdefault(client_id, {})[path] = (content_hash, mtime)
+
+
+def _clear_client_baseline(client_id: str, path: str) -> None:
+    with _client_baseline_lock:
+        _client_baseline.setdefault(client_id, {}).pop(path, None)
+
+
 app.include_router(build_sync_router(
     get_vault=lambda: _vault,
     broadcast_fn=broadcast,
     mark_stale_fn=lambda path: _indexer.mark_stale(path),
+    update_baseline_fn=_update_client_baseline,
+    clear_baseline_fn=_clear_client_baseline,
 ))
 
 _executor = ThreadPoolExecutor(max_workers=2)
@@ -519,16 +653,39 @@ async def websocket_endpoint(ws: WebSocket, client_id: str | None = Query(None))
     # reject a handshake response that doesn't confirm one of the
     # subprotocols they offered. `client_id` (desktop sends a persisted
     # UUID) lets broadcast() skip echoing a sync push back to its own
-    # sender — see _ws_broadcast/exclude_client_id.
+    # sender — see _ws_broadcast/exclude_client_id — and is what makes
+    # this connection a sync-orchestration participant at all (see
+    # _handle_sync_message): a browser/PWA tab connects with no client_id
+    # and just receives ordinary vault_change broadcasts as before.
     if "bearer" in ws.scope.get("subprotocols", []):
         await ws.accept(subprotocol="bearer")
     else:
         await ws.accept()
     with _ws_clients_lock:
         _ws_clients[ws] = client_id
+
+    if client_id:
+        # Kick off a full sync as soon as this client connects — see
+        # sync_orchestrator's module doc comment for why the server (not
+        # the client) now always initiates this.
+        try:
+            await ws.send_text(json.dumps({"type": "request_manifest"}))
+        except Exception:
+            pass
+
     try:
         while True:
-            await ws.receive_text()  # keeps connection alive; client sends nothing
+            text = await ws.receive_text()
+            if not client_id:
+                continue  # not a sync participant — nothing to parse/act on
+            try:
+                msg = json.loads(text)
+            except ValueError:
+                continue
+            try:
+                await _handle_sync_message(ws, client_id, msg)
+            except Exception:
+                _log.exception("error handling sync message from client_id=%s: %r", client_id, msg)
     except WebSocketDisconnect:
         pass
     finally:

--- a/prisma/server/sync_routes.py
+++ b/prisma/server/sync_routes.py
@@ -16,6 +16,7 @@ already does implicitly by referencing the module-level name directly.
 """
 from __future__ import annotations
 
+import hashlib
 from typing import Callable, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -58,7 +59,17 @@ def build_sync_router(
     get_vault: Callable[[], VaultService],
     broadcast_fn: Callable[..., None],
     mark_stale_fn: Callable[[str], None],
+    update_baseline_fn: Callable[[str, str, str, float], None],
+    clear_baseline_fn: Callable[[str, str], None],
 ) -> APIRouter:
+    """`update_baseline_fn(client_id, path, hash, mtime)` / `clear_baseline_fn(client_id, path)`
+    keep app.py's server-side sync_orchestrator baseline (the per-client
+    "last known agreed state") in sync with what actually landed here — a
+    successful PUT/DELETE is itself the ACK for an ASK_CLIENT_TO_PUSH
+    decision (the HTTP response already proves it completed), unlike a
+    PUSH_TO_CLIENT decision, which needs an explicit `file_synced` message
+    back over the WS since there's no request/response round trip for that
+    direction. See sync_orchestrator.py's own module doc comment."""
     router = APIRouter(prefix="/sync", tags=["sync"])
 
     @router.get("/manifest", response_model=list[SyncManifestEntry])
@@ -111,9 +122,16 @@ def build_sync_router(
         # nothing ever able to clear it (confirmed live 2026-07-25 on Forge,
         # right after the vault-sync engine pushed a stream file).
         mark_stale_fn(req.path)
+        client_id = request.headers.get(_CLIENT_ID_HEADER)
+        if client_id:
+            # This PUT succeeding is itself the ACK for an
+            # ASK_CLIENT_TO_PUSH decision -- see build_sync_router's own
+            # docstring for why this direction doesn't need a separate
+            # WS message the way a server-initiated push-down does.
+            update_baseline_fn(client_id, req.path, hashlib.sha256(req.body.encode("utf-8")).hexdigest(), new_mtime)
         broadcast_fn(
             {"type": "vault_change", "action": "sync_write", "path": req.path},
-            exclude_client_id=request.headers.get(_CLIENT_ID_HEADER),
+            exclude_client_id=client_id,
         )
         return SyncFileResponse(path=req.path, body=req.body, mtime=new_mtime)
 
@@ -125,9 +143,12 @@ def build_sync_router(
             raise HTTPException(status_code=403, detail=str(exc))
 
         mark_stale_fn(path)
+        client_id = request.headers.get(_CLIENT_ID_HEADER)
+        if client_id:
+            clear_baseline_fn(client_id, path)
         broadcast_fn(
             {"type": "vault_change", "action": "sync_delete", "path": path},
-            exclude_client_id=request.headers.get(_CLIENT_ID_HEADER),
+            exclude_client_id=client_id,
         )
         return {"status": "deleted", "path": path}
 

--- a/prisma/services/sync_orchestrator.py
+++ b/prisma/services/sync_orchestrator.py
@@ -1,0 +1,87 @@
+"""Server-side sync orchestration (2026-07-26 redesign): the server is now
+the sole authority deciding push vs. pull vs. conflict for the desktop's
+local vault mirror. See prisma-desktop's sync/pull.rs module doc comment
+for the full rationale -- the previous design let the desktop's own fs
+watcher decide unilaterally when to push, which caused a real, sustained
+bug: the watcher firing was never proof content actually changed, and with
+two independent sides each free to act, nothing arbitrated a spurious or
+duplicate event, and it looped hundreds of times against unchanged content.
+
+`diff_manifest` is pure, allocation-only logic (no I/O, no locks) so it's
+unit-testable on its own -- the actual WebSocket message dispatch lives in
+app.py's websocket_endpoint, the thin I/O shell around it. Same split as
+prisma-desktop's manifest.rs (reconcile vs. the code that used to call it).
+
+Comparisons are by content hash (SHA256, matching prisma-desktop's
+content_hash()), not mtime. mtime alone isn't safe for this: see prisma#40,
+where two mtimes one float64 ULP apart (a real, reproducible case at
+today's Unix-timestamp magnitude) compared unequal forever. Hashes have no
+such precision-boundary failure mode.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class SyncDecision(Enum):
+    ASK_CLIENT_TO_PUSH = "ask_client_to_push"
+    PUSH_TO_CLIENT = "push_to_client"
+    TELL_CLIENT_TO_DELETE = "tell_client_to_delete"
+    DELETE_ON_SERVER = "delete_on_server"
+
+
+def diff_manifest(
+    server_files: dict[str, tuple[str, float]],
+    client_files: dict[str, tuple[str, float]],
+    baseline: dict[str, tuple[str, float]],
+) -> dict[str, SyncDecision]:
+    """`server_files`/`client_files`/`baseline` map vault-relative path to
+    (content_hash, mtime). `baseline` is the last-known-agreed state for
+    this specific client (per-client, see app.py's _client_baseline) --
+    what both sides had the last time they were confirmed in sync, used to
+    tell "who changed since then" apart from "who's just behind."
+
+    Mirrors prisma-desktop's manifest::reconcile's tracked/untracked
+    lifecycle table exactly, just from the server's point of view: what
+    Rust's client called "push" (local -> remote) is ASK_CLIENT_TO_PUSH
+    here, and what it called "pull" (remote -> local) is PUSH_TO_CLIENT.
+    """
+    decisions: dict[str, SyncDecision] = {}
+    for path in set(server_files) | set(client_files) | set(baseline):
+        s = server_files.get(path)
+        c = client_files.get(path)
+        b = baseline.get(path)
+
+        if s and c:
+            if s[0] == c[0]:
+                continue  # already in sync
+            if b and b[0] == s[0]:
+                # Server unchanged since baseline, client differs -> client has a new edit.
+                decisions[path] = SyncDecision.ASK_CLIENT_TO_PUSH
+            elif b and b[0] == c[0]:
+                # Client unchanged since baseline, server differs -> server has a new edit.
+                decisions[path] = SyncDecision.PUSH_TO_CLIENT
+            else:
+                # Both changed since baseline (or no baseline at all) --
+                # ambiguous. Ask the client to push rather than guess a
+                # winner here: its own expected_mtime/409 conflict
+                # machinery (PUT /sync/file) already safely resolves this,
+                # preserving the losing side as a .conflict-<ts> copy.
+                decisions[path] = SyncDecision.ASK_CLIENT_TO_PUSH
+        elif s and not c:
+            if b and b[0] == s[0]:
+                # Client deleted it; server hasn't changed since -> propagate the delete.
+                decisions[path] = SyncDecision.DELETE_ON_SERVER
+            else:
+                # No baseline, or server changed since -> don't lose data, recreate on client.
+                decisions[path] = SyncDecision.PUSH_TO_CLIENT
+        elif c and not s:
+            if b and b[0] == c[0]:
+                # Server deleted it; client hasn't changed since -> propagate the delete.
+                decisions[path] = SyncDecision.TELL_CLIENT_TO_DELETE
+            else:
+                # No baseline, or client changed since -> don't lose data, recreate on server.
+                decisions[path] = SyncDecision.ASK_CLIENT_TO_PUSH
+        # else: neither side has it -- nothing to do (and it naturally
+        # falls out of baseline on the next confirmed-in-sync update).
+    return decisions

--- a/tests/unit/server/test_sync_routes.py
+++ b/tests/unit/server/test_sync_routes.py
@@ -15,12 +15,14 @@ from prisma.services.vault import VaultService
 
 
 class _Recorder:
-    """Fake broadcast_fn/mark_stale_fn that just records calls."""
+    """Fake broadcast_fn/mark_stale_fn/baseline callbacks that just record calls."""
 
     def __init__(self):
         self.broadcasts = []
         self.mark_stale_calls = 0
         self.mark_stale_paths = []
+        self.baseline_updates = []  # (client_id, path, hash, mtime)
+        self.baseline_clears = []  # (client_id, path)
 
     def broadcast(self, event, exclude_client_id=None):
         self.broadcasts.append((event, exclude_client_id))
@@ -28,6 +30,12 @@ class _Recorder:
     def mark_stale(self, path):
         self.mark_stale_calls += 1
         self.mark_stale_paths.append(path)
+
+    def update_baseline(self, client_id, path, content_hash, mtime):
+        self.baseline_updates.append((client_id, path, content_hash, mtime))
+
+    def clear_baseline(self, client_id, path):
+        self.baseline_clears.append((client_id, path))
 
 
 @pytest.fixture
@@ -49,6 +57,8 @@ def client(vault, recorder) -> TestClient:
         get_vault=lambda: vault,
         broadcast_fn=recorder.broadcast,
         mark_stale_fn=recorder.mark_stale,
+        update_baseline_fn=recorder.update_baseline,
+        clear_baseline_fn=recorder.clear_baseline,
     ))
     return TestClient(app)
 
@@ -81,6 +91,30 @@ def test_put_echoes_exclude_client_id_from_header(client, recorder):
     assert r.status_code == 200
     _, exclude = recorder.broadcasts[0]
     assert exclude == "desktop-123"
+
+
+def test_put_with_client_id_updates_baseline(client, recorder):
+    r = client.put(
+        "/sync/file",
+        json={"path": "notes/a.md", "body": "hello", "expected_mtime": None},
+        headers={"X-Sync-Client-Id": "desktop-123"},
+    )
+    mtime = r.json()["mtime"]
+    import hashlib
+    assert recorder.baseline_updates == [
+        ("desktop-123", "notes/a.md", hashlib.sha256(b"hello").hexdigest(), mtime)
+    ]
+
+
+def test_put_without_client_id_does_not_touch_baseline(client, recorder):
+    client.put("/sync/file", json={"path": "notes/a.md", "body": "hello", "expected_mtime": None})
+    assert recorder.baseline_updates == []
+
+
+def test_delete_with_client_id_clears_baseline(client, recorder, vault):
+    vault.write_by_path("notes/a.md", "content")
+    client.delete("/sync/file", params={"path": "notes/a.md"}, headers={"X-Sync-Client-Id": "desktop-123"})
+    assert recorder.baseline_clears == [("desktop-123", "notes/a.md")]
 
 
 def test_get_file_roundtrip(client, vault):

--- a/tests/unit/services/test_sync_orchestrator.py
+++ b/tests/unit/services/test_sync_orchestrator.py
@@ -1,0 +1,100 @@
+"""Unit tests for sync_orchestrator.diff_manifest -- pure logic, no I/O.
+Mirrors prisma-desktop's manifest::reconcile test suite (same
+tracked/untracked lifecycle table, server's point of view instead of the
+client's).
+"""
+from prisma.services.sync_orchestrator import SyncDecision, diff_manifest
+
+
+def test_new_client_file_asks_client_to_push():
+    client = {"notes/a.md": ("h1", 100.0)}
+    decisions = diff_manifest({}, client, {})
+    assert decisions == {"notes/a.md": SyncDecision.ASK_CLIENT_TO_PUSH}
+
+
+def test_new_server_file_pushes_to_client():
+    server = {"notes/a.md": ("h1", 100.0)}
+    decisions = diff_manifest(server, {}, {})
+    assert decisions == {"notes/a.md": SyncDecision.PUSH_TO_CLIENT}
+
+
+def test_matching_hash_is_a_noop():
+    server = {"notes/a.md": ("h1", 100.0)}
+    client = {"notes/a.md": ("h1", 200.0)}  # mtime differs, hash doesn't -- still in sync
+    decisions = diff_manifest(server, client, {})
+    assert decisions == {}
+
+
+def test_differing_hash_with_server_unchanged_since_baseline_asks_client_to_push():
+    baseline = {"notes/a.md": ("h1", 100.0)}
+    server = {"notes/a.md": ("h1", 100.0)}  # unchanged since baseline
+    client = {"notes/a.md": ("h2", 150.0)}  # client edited
+    decisions = diff_manifest(server, client, baseline)
+    assert decisions == {"notes/a.md": SyncDecision.ASK_CLIENT_TO_PUSH}
+
+
+def test_differing_hash_with_client_unchanged_since_baseline_pushes_to_client():
+    baseline = {"notes/a.md": ("h1", 100.0)}
+    server = {"notes/a.md": ("h2", 150.0)}  # server edited
+    client = {"notes/a.md": ("h1", 100.0)}  # unchanged since baseline
+    decisions = diff_manifest(server, client, baseline)
+    assert decisions == {"notes/a.md": SyncDecision.PUSH_TO_CLIENT}
+
+
+def test_both_changed_since_baseline_asks_client_to_push_letting_409_resolve_it():
+    baseline = {"notes/a.md": ("h1", 100.0)}
+    server = {"notes/a.md": ("h2", 150.0)}
+    client = {"notes/a.md": ("h3", 160.0)}
+    decisions = diff_manifest(server, client, baseline)
+    assert decisions == {"notes/a.md": SyncDecision.ASK_CLIENT_TO_PUSH}
+
+
+def test_no_baseline_but_both_present_and_differ_asks_client_to_push():
+    server = {"notes/a.md": ("h1", 100.0)}
+    client = {"notes/a.md": ("h2", 100.0)}
+    decisions = diff_manifest(server, client, {})
+    assert decisions == {"notes/a.md": SyncDecision.ASK_CLIENT_TO_PUSH}
+
+
+def test_client_deleted_file_server_unchanged_deletes_on_server():
+    baseline = {"notes/a.md": ("h1", 100.0)}
+    server = {"notes/a.md": ("h1", 100.0)}  # server unchanged since baseline
+    decisions = diff_manifest(server, {}, baseline)
+    assert decisions == {"notes/a.md": SyncDecision.DELETE_ON_SERVER}
+
+
+def test_client_deleted_file_but_server_changed_recreates_on_client():
+    baseline = {"notes/a.md": ("h1", 100.0)}
+    server = {"notes/a.md": ("h2", 150.0)}  # server changed since baseline
+    decisions = diff_manifest(server, {}, baseline)
+    assert decisions == {"notes/a.md": SyncDecision.PUSH_TO_CLIENT}
+
+
+def test_server_deleted_file_client_unchanged_tells_client_to_delete():
+    baseline = {"notes/a.md": ("h1", 100.0)}
+    client = {"notes/a.md": ("h1", 100.0)}  # client unchanged since baseline
+    decisions = diff_manifest({}, client, baseline)
+    assert decisions == {"notes/a.md": SyncDecision.TELL_CLIENT_TO_DELETE}
+
+
+def test_server_deleted_file_but_client_changed_recreates_on_server():
+    baseline = {"notes/a.md": ("h1", 100.0)}
+    client = {"notes/a.md": ("h2", 150.0)}  # client changed since baseline
+    decisions = diff_manifest({}, client, baseline)
+    assert decisions == {"notes/a.md": SyncDecision.ASK_CLIENT_TO_PUSH}
+
+
+def test_absent_everywhere_is_a_noop():
+    baseline = {"notes/ghost.md": ("h1", 100.0)}
+    decisions = diff_manifest({}, {}, baseline)
+    assert decisions == {}
+
+
+def test_multiple_paths_are_each_diffed_independently():
+    server = {"notes/server-only.md": ("h1", 100.0), "notes/both.md": ("h2", 100.0)}
+    client = {"notes/client-only.md": ("h3", 100.0), "notes/both.md": ("h2", 100.0)}
+    decisions = diff_manifest(server, client, {})
+    assert decisions == {
+        "notes/server-only.md": SyncDecision.PUSH_TO_CLIENT,
+        "notes/client-only.md": SyncDecision.ASK_CLIENT_TO_PUSH,
+    }


### PR DESCRIPTION
## Summary
Companion to prisma-desktop#7 -- see that PR for the full rationale (a real, sustained bug: the desktop's fs-watcher decided unilaterally when to push, looping 443 identical pushes for unchanged content in one observed run).

- New `sync_orchestrator.py`: `diff_manifest()`, pure logic mirroring prisma-desktop's `manifest::reconcile` (same tracked/untracked lifecycle table), hash-based not mtime-based.
- `/ws` sends `request_manifest` to every sync-capable client on connect, dispatches `manifest_response`/`file_changed`/`file_deleted`/`file_synced` via `_handle_sync_message`, tracked per-client in `_client_baseline`.
- `sync_routes.py`'s `put_file`/`delete_file` update that baseline after a successful write/delete (the HTTP response is itself the ACK for a pull-up decision).

## Test plan
- [x] New `test_sync_orchestrator.py`: 13 tests covering the full diff decision table
- [x] `test_sync_routes.py` updated for the new baseline callbacks
- [x] Full suite: 510 passed, 24 skipped
- [ ] Live retest against real Anvil<->Forge sync