### PR TITLE
Add ZoteroConfig.api_key_env, matching LLMConfig/ChatConfig's pattern

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -24,6 +24,7 @@ enabled = true
 api_key = ""            # Your Zotero API key (get from zotero.org/settings/keys)
 # api_key_env = "ZOTERO_API_KEY"  # or: name of an env var holding it instead (takes priority over api_key — keeps the real key out of this file, e.g. sourced from a K8s Secret)
 library_id = ""          # Your library ID (user ID or group ID)
+# library_id_env = "ZOTERO_LIBRARY_ID"  # or: name of an env var holding it instead (takes priority over library_id)
 library_type = "user"    # "user" or "group"
 
 # Optional: Default collections to search (leave empty to search all)

--- a/config.example.toml
+++ b/config.example.toml
@@ -22,6 +22,7 @@ enabled = true
 
 # Web API — required for both reads and writes
 api_key = ""            # Your Zotero API key (get from zotero.org/settings/keys)
+# api_key_env = "ZOTERO_API_KEY"  # or: name of an env var holding it instead (takes priority over api_key — keeps the real key out of this file, e.g. sourced from a K8s Secret)
 library_id = ""          # Your library ID (user ID or group ID)
 library_type = "user"    # "user" or "group"
 

--- a/docs/wiki/configuration.md
+++ b/docs/wiki/configuration.md
@@ -24,6 +24,7 @@ enabled = true
 api_key = ""                           # from zotero.org/settings/keys
 # api_key_env = "ZOTERO_API_KEY"       # or: env var holding it instead — takes priority over api_key, keeps the real key out of this file
 library_id = ""                        # your numeric user ID
+# library_id_env = "ZOTERO_LIBRARY_ID" # or: env var holding it instead — takes priority over library_id
 library_type = "user"                  # "user" | "group"
 
 # Search behavior

--- a/docs/wiki/configuration.md
+++ b/docs/wiki/configuration.md
@@ -22,6 +22,7 @@ enabled = true
 # Reads and writes: Zotero Web API only (no local Zotero Desktop
 # integration — see ADR-008's follow-up)
 api_key = ""                           # from zotero.org/settings/keys
+# api_key_env = "ZOTERO_API_KEY"       # or: env var holding it instead — takes priority over api_key, keeps the real key out of this file
 library_id = ""                        # your numeric user ID
 library_type = "user"                  # "user" | "group"
 

--- a/docs/wiki/zotero.md
+++ b/docs/wiki/zotero.md
@@ -17,19 +17,20 @@ library_type = "user"           # "user" | "group"
 ```
 
 For a deployment where config.toml itself isn't a safe place for a real secret
-(e.g. rendered into a Kubernetes ConfigMap, which isn't encrypted at rest),
-use `api_key_env` instead — same pattern as `llm.api_key_env`/`chat.api_key_env`:
+or identifying info (e.g. rendered into a Kubernetes ConfigMap, which isn't
+encrypted at rest), use `api_key_env`/`library_id_env` instead — same pattern
+as `llm.api_key_env`/`chat.api_key_env`:
 
 ```toml
 [sources.zotero]
 enabled = true
-api_key_env = "ZOTERO_API_KEY"  # takes priority over api_key when set
-library_id = "YOUR_USER_ID"
+api_key_env = "ZOTERO_API_KEY"        # takes priority over api_key when set
+library_id_env = "ZOTERO_LIBRARY_ID"  # takes priority over library_id when set
 library_type = "user"
 ```
 
-The real key then only needs to exist as an environment variable — sourced
-from a K8s Secret, for example — and never touches the config file at all.
+Both then only need to exist as environment variables — sourced from a K8s
+Secret, for example — and never touch the config file at all.
 
 ## Connectivity
 

--- a/docs/wiki/zotero.md
+++ b/docs/wiki/zotero.md
@@ -16,6 +16,21 @@ library_id = "YOUR_USER_ID"     # https://www.zotero.org/settings/keys
 library_type = "user"           # "user" | "group"
 ```
 
+For a deployment where config.toml itself isn't a safe place for a real secret
+(e.g. rendered into a Kubernetes ConfigMap, which isn't encrypted at rest),
+use `api_key_env` instead — same pattern as `llm.api_key_env`/`chat.api_key_env`:
+
+```toml
+[sources.zotero]
+enabled = true
+api_key_env = "ZOTERO_API_KEY"  # takes priority over api_key when set
+library_id = "YOUR_USER_ID"
+library_type = "user"
+```
+
+The real key then only needs to exist as an environment variable — sourced
+from a K8s Secret, for example — and never touches the config file at all.
+
 ## Connectivity
 
 `services/zotero.py::check_web_api_reachable()` is the canonical live-reachability

--- a/prisma/cli/prisma_cli.py
+++ b/prisma/cli/prisma_cli.py
@@ -133,16 +133,22 @@ def status(verbose: bool):
     if config is None:
         click.echo("  ⚠️  Skipped — fix config first")
     else:
+        zconf = config.config.sources.zotero
+        env_errors = []
         try:
-            api_key = config.config.sources.zotero.resolve_api_key() or ''
-            api_key_env_error = None
+            api_key = zconf.resolve_api_key() or ''
         except RuntimeError as exc:
             api_key = ''
-            api_key_env_error = str(exc)
-        library_id = config.get('sources.zotero.library_id', '')
+            env_errors.append(str(exc))
+        try:
+            library_id = zconf.resolve_library_id() or ''
+        except RuntimeError as exc:
+            library_id = ''
+            env_errors.append(str(exc))
 
-        if api_key_env_error:
-            click.echo(f"  Web API: ❌ {api_key_env_error}")
+        if env_errors:
+            for err in env_errors:
+                click.echo(f"  Web API: ❌ {err}")
             all_good = False
         elif api_key and library_id:
             click.echo(f"  Web API: library_id={library_id} ✅ credentials configured")

--- a/prisma/cli/prisma_cli.py
+++ b/prisma/cli/prisma_cli.py
@@ -133,10 +133,18 @@ def status(verbose: bool):
     if config is None:
         click.echo("  ⚠️  Skipped — fix config first")
     else:
-        api_key = config.get('sources.zotero.api_key', '')
+        try:
+            api_key = config.config.sources.zotero.resolve_api_key() or ''
+            api_key_env_error = None
+        except RuntimeError as exc:
+            api_key = ''
+            api_key_env_error = str(exc)
         library_id = config.get('sources.zotero.library_id', '')
 
-        if api_key and library_id:
+        if api_key_env_error:
+            click.echo(f"  Web API: ❌ {api_key_env_error}")
+            all_good = False
+        elif api_key and library_id:
             click.echo(f"  Web API: library_id={library_id} ✅ credentials configured")
             from ..services.zotero import check_web_api_reachable
             if check_web_api_reachable(api_key, library_id):

--- a/prisma/integrations/zotero/unified_client.py
+++ b/prisma/integrations/zotero/unified_client.py
@@ -89,7 +89,7 @@ class ZoteroClient:
         zotero_config = self.config.sources.zotero
 
         web_config = ZoteroAPIConfig(
-            api_key=getattr(zotero_config, 'api_key', ''),
+            api_key=zotero_config.resolve_api_key() or '',
             library_id=getattr(zotero_config, 'library_id', ''),
             library_type=getattr(zotero_config, 'library_type', 'user')
         )

--- a/prisma/integrations/zotero/unified_client.py
+++ b/prisma/integrations/zotero/unified_client.py
@@ -90,7 +90,7 @@ class ZoteroClient:
 
         web_config = ZoteroAPIConfig(
             api_key=zotero_config.resolve_api_key() or '',
-            library_id=getattr(zotero_config, 'library_id', ''),
+            library_id=zotero_config.resolve_library_id() or '',
             library_type=getattr(zotero_config, 'library_type', 'user')
         )
         return ZoteroWebAPIClient(web_config)

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -303,7 +303,7 @@ def _build_zotero() -> ZoteroService:
     from prisma.utils.config import ConfigLoader
     try:
         zconf = ConfigLoader().get_zotero_config()
-        api_key = zconf.api_key or None
+        api_key = zconf.resolve_api_key() or None
         user_id = zconf.library_id or None
         mode = ZoteroMode.web_api if api_key else ZoteroMode.offline
         return ZoteroService(mode=mode, api_key=api_key, user_id=user_id)

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -304,7 +304,7 @@ def _build_zotero() -> ZoteroService:
     try:
         zconf = ConfigLoader().get_zotero_config()
         api_key = zconf.resolve_api_key() or None
-        user_id = zconf.library_id or None
+        user_id = zconf.resolve_library_id() or None
         mode = ZoteroMode.web_api if api_key else ZoteroMode.offline
         return ZoteroService(mode=mode, api_key=api_key, user_id=user_id)
     except Exception:

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -18,7 +18,15 @@ class ZoteroConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     
     enabled: bool = Field(False, description="Whether Zotero integration is enabled")
-    api_key: Optional[str] = Field(None, description="Zotero API key")
+    api_key: Optional[str] = Field(None, description="Zotero API key — prefer api_key_env instead")
+    api_key_env: Optional[str] = Field(
+        None,
+        description=(
+            "Env var holding the API key — takes priority over api_key when set, "
+            "same pattern as LLMConfig/ChatConfig's api_key_env. Lets the real "
+            "secret live in an env var (e.g. a K8s Secret) instead of this file."
+        ),
+    )
     library_id: Optional[str] = Field(None, description="Zotero library ID")
     library_type: str = Field("user", description="Library type: 'user' or 'group'")
     default_collections: List[str] = Field(default_factory=list, description="Default collections to search")
@@ -34,13 +42,27 @@ class ZoteroConfig(BaseModel):
         default_factory=lambda: str(Path.home() / "Zotero"),
         description="Path to Zotero data directory"
     )
-    
+
     @field_validator('library_type')
     @classmethod
     def validate_library_type(cls, v):
         if v not in ('user', 'group'):
             raise ValueError('library_type must be "user" or "group"')
         return v
+
+    def resolve_api_key(self) -> Optional[str]:
+        """Effective API key: api_key_env (if set) takes priority over the
+        literal api_key field. Raises if api_key_env is set but the env var
+        isn't — fail loud on a misconfigured indirection rather than silently
+        falling back to a (possibly stale) literal value or None."""
+        if self.api_key_env:
+            key = os.environ.get(self.api_key_env)
+            if not key:
+                raise RuntimeError(
+                    f"sources.zotero.api_key_env={self.api_key_env!r} is set but not present in the environment"
+                )
+            return key
+        return self.api_key
 
 
 class LLMConfig(BaseModel):
@@ -421,9 +443,13 @@ class ConfigLoader:
     def has_zotero_credentials(self) -> bool:
         """Check if Zotero API credentials are configured."""
         zotero_config = self.config.sources.zotero
+        try:
+            api_key = zotero_config.resolve_api_key()
+        except RuntimeError:
+            return False
         return (
             zotero_config.enabled and
-            zotero_config.api_key is not None and
+            api_key is not None and
             zotero_config.library_id is not None
         )
 

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -27,7 +27,15 @@ class ZoteroConfig(BaseModel):
             "secret live in an env var (e.g. a K8s Secret) instead of this file."
         ),
     )
-    library_id: Optional[str] = Field(None, description="Zotero library ID")
+    library_id: Optional[str] = Field(None, description="Zotero library ID — prefer library_id_env instead")
+    library_id_env: Optional[str] = Field(
+        None,
+        description=(
+            "Env var holding the library ID — takes priority over library_id "
+            "when set, same api_key_env pattern. Not a secret, but keeping it "
+            "alongside api_key_env avoids identifying info in a ConfigMap."
+        ),
+    )
     library_type: str = Field("user", description="Library type: 'user' or 'group'")
     default_collections: List[str] = Field(default_factory=list, description="Default collections to search")
     include_notes: bool = Field(False, description="Include notes in results")
@@ -63,6 +71,20 @@ class ZoteroConfig(BaseModel):
                 )
             return key
         return self.api_key
+
+    def resolve_library_id(self) -> Optional[str]:
+        """Effective library ID: library_id_env (if set) takes priority over
+        the literal library_id field. Same fail-loud contract as
+        resolve_api_key() — a misconfigured indirection should be obvious,
+        not silently fall through to None/offline mode."""
+        if self.library_id_env:
+            value = os.environ.get(self.library_id_env)
+            if not value:
+                raise RuntimeError(
+                    f"sources.zotero.library_id_env={self.library_id_env!r} is set but not present in the environment"
+                )
+            return value
+        return self.library_id
 
 
 class LLMConfig(BaseModel):
@@ -445,12 +467,13 @@ class ConfigLoader:
         zotero_config = self.config.sources.zotero
         try:
             api_key = zotero_config.resolve_api_key()
+            library_id = zotero_config.resolve_library_id()
         except RuntimeError:
             return False
         return (
             zotero_config.enabled and
             api_key is not None and
-            zotero_config.library_id is not None
+            library_id is not None
         )
 
 

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -250,8 +250,36 @@ index_extensions = ["md", ".yaml"]
         config_loader.config.sources.zotero.enabled = True
         config_loader.config.sources.zotero.api_key = 'test_key'
         config_loader.config.sources.zotero.library_id = '12345'
-        
+
         self.assertTrue(config_loader.has_zotero_credentials())
+
+    def test_zotero_resolve_api_key_falls_back_to_literal(self):
+        cfg = ZoteroConfig(api_key='literal-key')
+        self.assertEqual(cfg.resolve_api_key(), 'literal-key')
+
+    def test_zotero_resolve_api_key_env_takes_priority(self):
+        cfg = ZoteroConfig(api_key='literal-key', api_key_env='ZOTERO_TEST_KEY_VAR')
+        with patch.dict(os.environ, {'ZOTERO_TEST_KEY_VAR': 'from-env'}):
+            self.assertEqual(cfg.resolve_api_key(), 'from-env')
+
+    def test_zotero_resolve_api_key_env_missing_raises(self):
+        cfg = ZoteroConfig(api_key='literal-key', api_key_env='ZOTERO_TEST_KEY_VAR_UNSET')
+        os.environ.pop('ZOTERO_TEST_KEY_VAR_UNSET', None)
+        with self.assertRaises(RuntimeError):
+            cfg.resolve_api_key()
+
+    def test_has_zotero_credentials_false_when_api_key_env_missing(self):
+        # A misconfigured api_key_env must degrade to "no credentials",
+        # not crash the caller -- has_zotero_credentials() is a plain bool
+        # check used in several places with no exception handling of its own.
+        with patch('prisma.utils.config.Path.exists', return_value=False):
+            config_loader = ConfigLoader()
+        config_loader.config.sources.zotero.enabled = True
+        config_loader.config.sources.zotero.library_id = '12345'
+        config_loader.config.sources.zotero.api_key_env = 'ZOTERO_TEST_KEY_VAR_UNSET'
+        os.environ.pop('ZOTERO_TEST_KEY_VAR_UNSET', None)
+
+        self.assertFalse(config_loader.has_zotero_credentials())
 
 
 if __name__ == '__main__':

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -281,6 +281,31 @@ index_extensions = ["md", ".yaml"]
 
         self.assertFalse(config_loader.has_zotero_credentials())
 
+    def test_zotero_resolve_library_id_falls_back_to_literal(self):
+        cfg = ZoteroConfig(library_id='12345')
+        self.assertEqual(cfg.resolve_library_id(), '12345')
+
+    def test_zotero_resolve_library_id_env_takes_priority(self):
+        cfg = ZoteroConfig(library_id='12345', library_id_env='ZOTERO_TEST_LIBID_VAR')
+        with patch.dict(os.environ, {'ZOTERO_TEST_LIBID_VAR': '99999'}):
+            self.assertEqual(cfg.resolve_library_id(), '99999')
+
+    def test_zotero_resolve_library_id_env_missing_raises(self):
+        cfg = ZoteroConfig(library_id='12345', library_id_env='ZOTERO_TEST_LIBID_VAR_UNSET')
+        os.environ.pop('ZOTERO_TEST_LIBID_VAR_UNSET', None)
+        with self.assertRaises(RuntimeError):
+            cfg.resolve_library_id()
+
+    def test_has_zotero_credentials_false_when_library_id_env_missing(self):
+        with patch('prisma.utils.config.Path.exists', return_value=False):
+            config_loader = ConfigLoader()
+        config_loader.config.sources.zotero.enabled = True
+        config_loader.config.sources.zotero.api_key = 'test_key'
+        config_loader.config.sources.zotero.library_id_env = 'ZOTERO_TEST_LIBID_VAR_UNSET'
+        os.environ.pop('ZOTERO_TEST_LIBID_VAR_UNSET', None)
+
+        self.assertFalse(config_loader.has_zotero_credentials())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Prompted directly: setting Zotero credentials on forge surfaced that the real `api_key` had no safe place to live except literally in `config.toml` (rendered into a K8s ConfigMap, not encrypted at rest) — inconsistent with how OpenRouter's key is already handled (`LLMConfig`/`ChatConfig`'s `api_key_env`).
- Added `ZoteroConfig.api_key_env` (takes priority over the literal `api_key` field when set) + a `resolve_api_key()` helper, raising loudly if `api_key_env` is set but the env var isn't present — same fail-loud contract as `chat_llm.py`'s `_resolve_api_key()`.
- Wired into every call site that read `sources.zotero.api_key` directly: `app.py::_build_zotero()`, `unified_client.py::_create_web_api_client()`, `has_zotero_credentials()`, and the `prisma status` CLI command.

## Test plan
- [x] `pytest` — 644 passed, 37 skipped
- [x] New tests: literal fallback, env-var priority, missing-env-var raises, `has_zotero_credentials()` degrades gracefully (doesn't crash) when `api_key_env` is misconfigured

🤖 Generated with [Claude Code](https://claude.com/claude-code)