### PR TITLE
Rebuild search sources as independent quota-controlled modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Key Features
 
-- **🌐 Multi-Source Discovery**: Searches papers (arXiv, Semantic Scholar, Academia.edu) and books (OpenLibrary, Google Books) in parallel per stream query
+- **🌐 Multi-Source Discovery**: Searches papers (arXiv, Semantic Scholar, PubMed, IEEE Xplore\*) and books (OpenLibrary, Google Books) per stream query, each source independently quota-controlled (\*IEEE Xplore requires your own API key)
 - **🔗 Zotero Bookmarking**: Saves discovered papers into your existing Zotero library via its Web API — Zotero stays the library, Prisma adds to it
 - **🌊 Research Streams**: Persistent topic monitoring — scheduled searches automatically discover, deduplicate, and file new papers into a dedicated Zotero collection per stream
 - **⭐ Quality-Rated Sources**: Each search source is rated 1-5 stars by API reliability/structure, prioritizing curated academic APIs over scraping-dependent ones

--- a/config.example.toml
+++ b/config.example.toml
@@ -42,8 +42,6 @@ default_limit = 10
 # ⭐⭐⭐⭐⭐ (5-star): Premium APIs with curated content (semanticscholar, arxiv)
 # ⭐⭐⭐⭐ (4-star): Good APIs with structured data (openlibrary, googlebooks)
 # ⭐⭐⭐ (3-star): Basic APIs or reliable targets (zotero)
-# ⭐⭐ (2-star): HTML scraping with some structure (academia_rss)
-# ⭐ (1-star): Manual forms, requires LLM extraction (academia_search, researchgate)
 
 # Recommended high-quality sources (4-5 stars)
 sources = ["semanticscholar", "arxiv", "openlibrary", "googlebooks", "zotero"]
@@ -52,6 +50,29 @@ sources = ["semanticscholar", "arxiv", "openlibrary", "googlebooks", "zotero"]
 prefer_high_quality = true          # Prioritize 4-5 star sources
 min_confidence_score = 0.3          # Minimum academic confidence (0.0-1.0)
 require_academic_validation = true  # Apply academic content filters
+
+# Per-source quota/API-key overrides (optional). Every source ships a
+# sane, web-verified default rate limit and works with zero config below --
+# only add a [search.source_overrides.<name>] block once you have a real
+# API key for a source, or want to tune its rate limit yourself.
+#
+# [search.source_overrides.pubmed]
+# api_key_env = "PUBMED_API_KEY"   # NCBI account key: raises 3 req/s -> 10 req/s
+#
+# [search.source_overrides.ieee_xplore]
+# api_key_env = "IEEE_XPLORE_API_KEY"  # required -- IEEE has no anonymous mode
+# # requests_per_second / daily_cap: IEEE doesn't publish a rate limit or
+# # daily quota anywhere; the built-in default (0.5 req/s, no daily cap) is
+# # a conservative placeholder. Once you've registered a key and IEEE has
+# # sent their API user guide, override these here with the real numbers.
+# requests_per_second = 0.5
+#
+# [search.source_overrides.semanticscholar]
+# api_key_env = "SEMANTIC_SCHOLAR_API_KEY"  # moves you off the shared anonymous pool
+#
+# [search.source_overrides.googlebooks]
+# api_key_env = "GOOGLE_BOOKS_API_KEY"  # gives you your own 10,000 req/day quota
+# daily_cap = 10000
 
 # LLM Configuration for Analysis
 [llm]

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -29,14 +29,13 @@
 
 | Component | Status |
 |-----------|--------|
-| arXiv, Semantic Scholar, OpenLibrary, Google Books | ✅ Implemented |
+| arXiv, Semantic Scholar, PubMed, OpenLibrary, Google Books | ✅ Implemented |
+| Per-source quota control (rate limiting + daily caps) | ✅ Implemented |
+| IEEE Xplore search | ⚠️ Implemented, but real rate limit unverified (requires your own API key) |
 | Academic validation + confidence scoring | ✅ Implemented |
 | LLM relevance assessment (Ollama) | ✅ Implemented |
 | Duplicate detection | ✅ Implemented |
 | Literature review report generation | ✅ Implemented |
 | Research Streams | ✅ Implemented |
-| Zotero hybrid client (read local / write web) | ✅ Implemented |
+| Zotero Web API client | ✅ Implemented |
 | Offline write queue | ✅ Implemented |
-| Academia.edu search | ⚠️ Stub — HTTP request made, parsing not implemented |
-| PubMed search | ❌ Not started |
-| ResearchGate search | ❌ Not started |

--- a/docs/wiki/features.md
+++ b/docs/wiki/features.md
@@ -6,15 +6,16 @@ The core workflow: search → assess → deduplicate → analyze → report.
 
 ### 1. Multi-source Search
 
-Prisma queries multiple academic databases in parallel, sorted by source quality (highest first). Each result is validated against academic criteria before being accepted.
+Prisma queries multiple academic databases one at a time, in source-quality order (highest first). Each is a quota-controlled, independent module (`prisma/integrations/sources/`) — a slow or rate-limited source never blocks the others from being tried. Each paper result is validated against academic criteria before being accepted.
 
 Supported sources:
 - **Semantic Scholar** — 214M+ papers, full metadata, abstracts
 - **arXiv** — preprints with PDF links
+- **PubMed** — biomedical/life-sciences literature, via NCBI E-utilities
 - **OpenLibrary** — academic books via Internet Archive
 - **Google Books** — book catalog with publisher metadata
+- **IEEE Xplore** — engineering/CS papers (requires your own API key; real rate limit unverified as of 2026-07-29)
 - **Zotero** — your personal library (deduplication and discovery)
-- **Academia.edu** — framework exists, HTML parsing not yet implemented
 
 ### 2. Academic Validation
 
@@ -154,13 +155,11 @@ Status (chunk count, files indexed, model name) is exposed at `GET /status` unde
 
 Prisma detects network connectivity at startup and adapts:
 
-- **Online**: full pipeline available; Zotero writes go to the Web API
-- **Offline**: literature review is disabled (requires internet for APIs); research stream reads work via Zotero local HTTP; writes are queued to a local pending queue and flushed automatically on next online startup
+- **Online**: full pipeline available; Zotero reads and writes go through the Web API
+- **Offline**: literature review and research stream updates are both disabled (both need internet — source search APIs, and Zotero's Web API for reads too, since there is no local Zotero access path anymore); creating a *new* stream still works, with its Zotero collection creation queued and flushed automatically on next online startup
 
 ---
 
 ## What is NOT implemented yet
 
-- Academia.edu result parsing (the HTTP request is made but HTML parsing is absent)
-- PubMed source (referenced in docs but absent from `SearchAgent`)
-- ResearchGate source (referenced in docs, absent from code)
+- IEEE Xplore's real rate limit/daily quota — IEEE publishes none of this publicly; the current default is a conservative guess, unverified against a real API key as of 2026-07-29

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -60,12 +60,24 @@ active feature work, not "is this usable yet." Core pipeline:
 
 ## Phase 3 — Sources
 
-- **PubMed** — biomedical literature
-- **IEEE Xplore** — engineering and CS
-- **Academia.edu** — complete the HTML parsing stub
-- **ResearchGate** — scraping or API if available
-- **JSTOR, Web of Science** — subscription databases (institutional access)
-- **Grey literature** — theses, technical reports, government publications
+Done as of 2026-07-29: **PubMed** and **IEEE Xplore** are implemented (see
+`docs/wiki/sources.md`), alongside a real per-source quota-control system
+(`prisma.services.rate_limiter.RateLimiter`) and a source-module registry
+(`prisma/integrations/sources/`) that replaced the old monolithic
+`SearchAgent` dispatch. IEEE Xplore's rate limit is a conservative,
+unverified placeholder until the user has a registered key and IEEE's real
+API user guide — don't advertise it as fully reliable until that's
+confirmed.
+
+Not planned initially: Academia.edu, ResearchGate, JSTOR/Web of Science, and
+grey literature were all considered and dropped (2026-07-29) — no reliable
+API for any of them (HTML scraping / anti-bot measures / institutional-only
+access), not worth the maintenance burden versus the API-backed sources
+above. The half-implemented Academia.edu stub and the aspirational
+`academia_rss`/`academia_search`/`researchgate` `SOURCE_REGISTRY` entries
+were removed from the codebase the same day. Research Rabbit was also
+evaluated and dropped the same day — no public API and no viable
+integration path exists.
 
 ---
 

--- a/docs/wiki/sources.md
+++ b/docs/wiki/sources.md
@@ -8,12 +8,18 @@ Prisma uses a 1–5 star quality system to classify and prioritize academic sour
 |--------|-------|--------|---------|-------|
 | `semanticscholar` | ⭐⭐⭐⭐⭐ | REST API | Papers, abstracts, citations | 214M+ papers; no key needed (rate-limited) |
 | `arxiv` | ⭐⭐⭐⭐⭐ | REST API | Preprints, PDFs | Free; includes PDF links |
+| `pubmed` | ⭐⭐⭐⭐⭐ | REST API | Biomedical papers | Free NCBI E-utilities; no key needed (rate-limited) |
 | `openlibrary` | ⭐⭐⭐⭐ | REST API | Academic books | Internet Archive database |
 | `googlebooks` | ⭐⭐⭐⭐ | REST API | Books, monographs | Rich publisher metadata, cover images |
-| `zotero` | ⭐⭐⭐ | Local HTTP / Web API | Your library | Used for deduplication and stream discovery |
-| `academia_rss` | ⭐⭐ | RSS | Researcher feeds | Requires LLM extraction; not yet implemented |
-| `academia_search` | ⭐ | HTML scraping | Academia.edu results | Framework present, parsing not implemented |
-| `researchgate` | ⭐ | HTML scraping | ResearchGate results | Not implemented |
+| `ieee_xplore` | ⭐⭐⭐⭐ | REST API | Engineering/CS papers | **Requires an API key** (no anonymous mode); real rate limit unverified as of 2026-07-29, a conservative default is used until confirmed |
+| `zotero` | ⭐⭐⭐ | Web API | Your library | Used for deduplication and stream discovery |
+
+Each source (except `zotero`, which is the bookmark layer, not a discovery
+source) enforces its own quota via `prisma.services.rate_limiter.RateLimiter`
+-- a thread-safe token bucket, with defaults verified against each API's own
+published policy. Override a source's rate limit, daily cap, or API key from
+`config.toml` under `[search.source_overrides.<name>]` (see
+`config.example.toml`) without touching code.
 
 ## Academic Validation
 
@@ -60,7 +66,22 @@ Against Zotero, deduplication is done by exact title match via a Zotero search q
 
 ## Adding a New Source
 
-1. Add a `SourceMetadata` entry to `SOURCE_REGISTRY` in `prisma/storage/models/source_quality.py`
-2. Implement `_search_<source>(query, limit)` in `prisma/agents/search_agent.py`
-3. Add the source name to the `elif` dispatch in `SearchAgent.search()`
-4. Add it to `sources` in your config
+Sources are independent modules under `prisma/integrations/sources/`, each
+implementing the `Source` interface (`.../sources/base.py`) and owning its
+own `RateLimiter`. `SearchAgent` never needs to change:
+
+1. Create `prisma/integrations/sources/<name>.py` implementing `Source`
+   (`name`, `search()`, optionally `probe()`), using its own `RateLimiter`
+   instance for that API's real published rate limit.
+2. Register it in `build_sources()` in `prisma/integrations/sources/__init__.py`.
+3. Add a `SourceMetadata` entry to `SOURCE_REGISTRY` in
+   `prisma/storage/models/source_quality.py` (same key as `name`).
+4. Add the name to `valid_sources` in `SearchConfig`
+   (`prisma/utils/config.py`) and to `sources` in your config.
+
+`tests/unit/integrations/sources/test_registry.py` checks these three
+places (`build_sources()`, `SOURCE_REGISTRY`, `SearchConfig.valid_sources`)
+stay consistent -- a mismatch used to silently degrade a source to the
+lowest quality tier instead of raising (this happened for real with
+`semanticscholar`/`semantic_scholar` before it was caught and fixed
+2026-07-29).

--- a/prisma/agents/search_agent.py
+++ b/prisma/agents/search_agent.py
@@ -1,21 +1,25 @@
 """
 Search Agent - Academic papers and books search with quality-based source management
+
+Fetching/parsing/quota-control for each individual source lives in
+prisma/integrations/sources/ (one module per source, all implementing the
+Source interface in .../sources/base.py). This class only does
+cross-source orchestration: picking which sources to search and in what
+order, academic-content validation and confidence scoring (applied
+uniformly across every source's papers, using that source's real quality
+rating), deduplication, and result aggregation.
 """
 
-import requests
-import xml.etree.ElementTree as ET
-import time
 import logging
 from typing import Dict, List
-from urllib.parse import quote
 from datetime import datetime
 
+from ..integrations.sources import Source, build_sources
 from ..utils.text import significant_words
 
 from ..storage.models.agent_models import SearchResult, PaperMetadata, BookMetadata
-from ..storage.models.api_response_models import OpenLibraryResponse
 from ..storage.models.source_quality import (
-    SourceQuality, get_source_quality,
+    get_source_quality,
     validate_academic_content, get_academic_confidence_score,
     AcademicValidationCriteria
 )
@@ -23,26 +27,10 @@ from ..storage.models.source_quality import (
 logger = logging.getLogger(__name__)
 
 
-_SOURCE_PROBE_URLS: dict[str, str] = {
-    "arxiv": "http://export.arxiv.org/api/query?search_query=test&max_results=1",
-    "semanticscholar": "https://api.semanticscholar.org/graph/v1/paper/search?query=test&limit=1",
-    "openlibrary": "https://openlibrary.org/search.json?q=test&limit=1",
-    "googlebooks": "https://www.googleapis.com/books/v1/volumes?q=test&maxResults=1",
-    "academia": "https://www.academia.edu",
-    "zotero": "http://localhost:23119",
-}
-
-
 class SearchAgent:
     """Search for academic papers and books across multiple quality-rated sources."""
 
     def __init__(self):
-        self.arxiv_base_url = "http://export.arxiv.org/api/query"
-        self.openlibrary_base_url = "https://openlibrary.org"
-        self.googlebooks_base_url = "https://www.googleapis.com/books/v1/volumes"
-        self.academia_base_url = "https://www.academia.edu"
-        self.semantic_scholar_base_url = "https://api.semanticscholar.org/graph/v1"
-
         self.validation_criteria = AcademicValidationCriteria()
 
         try:
@@ -51,27 +39,40 @@ class SearchAgent:
             self.default_sources: List[str] = list(cfg.sources)
             self.min_confidence_score: float = cfg.min_confidence_score
             self.prefer_high_quality: bool = cfg.prefer_high_quality
+            self.require_academic_validation: bool = cfg.require_academic_validation
+            self._sources: Dict[str, Source] = build_sources(cfg)
         except Exception:
             self.default_sources = ["semanticscholar", "arxiv"]
             self.min_confidence_score = 0.5
             self.prefer_high_quality = True
+            self.require_academic_validation = True
+            self._sources = build_sources()
+
+    @property
+    def available_sources(self) -> set[str]:
+        """Names of every discovery source actually wired up (excludes
+        'zotero', which is handled separately, not a Source). Used by
+        callers that need to know which requested source names actually
+        require internet access, without hardcoding a second copy of this
+        list (see PrismaCoordinator.run_review's offline check)."""
+        return set(self._sources.keys())
 
     def preflight(self, sources: List[str], timeout: float = 5.0) -> List[str]:
         """Return only sources that respond within *timeout* seconds."""
         available: List[str] = []
         for source in sources:
-            probe = _SOURCE_PROBE_URLS.get(source.lower())
-            if probe is None:
-                logger.warning("preflight: unknown source %r — skipping", source)
+            src = self._sources.get(source.lower())
+            if src is None:
+                if source.lower() != "zotero":
+                    logger.warning("preflight: unknown source %r — skipping", source)
                 continue
             try:
-                r = requests.get(probe, timeout=timeout)
-                if r.status_code < 500:
+                if src.probe(timeout=timeout):
                     available.append(source)
                 else:
-                    logger.warning("preflight: %s returned %d — skipping", source, r.status_code)
+                    logger.warning("preflight: %s unreachable or over quota — skipping", source)
             except Exception as exc:
-                logger.warning("preflight: %s unreachable (%s) — skipping", source, exc)
+                logger.warning("preflight: %s probe raised (%s) — skipping", source, exc)
         return available
 
     def search(
@@ -118,40 +119,34 @@ class SearchAgent:
             papers_before = len(all_papers)
             books_before = len(all_books)
 
-            if source.lower() == 'arxiv':
-                papers = self._search_arxiv(query, limit, published_after=published_after)
-                all_papers.extend(papers)
-            elif source.lower() == 'openlibrary':
-                books = self._search_openlibrary(query, limit)
-                all_books.extend(books)
-            elif source.lower() == 'googlebooks':
-                books = self._search_googlebooks(query, limit)
-                all_books.extend(books)
-            elif source.lower() == 'academia':
-                papers = self._search_academia(query, limit)
-                all_papers.extend(papers)
-            elif source.lower() == 'semanticscholar':
-                papers = self._search_semantic_scholar(query, limit, published_after=published_after)
-                all_papers.extend(papers)
+            src = self._sources.get(source.lower())
+            if src is not None:
+                result = src.search(query, limit, published_after=published_after)
+                validated_papers, rejected = self._validate_papers(result.papers, source_quality)
+                all_papers.extend(validated_papers)
+                all_books.extend(result.books)
+                source_stats[source]['rejected'] = rejected
             elif source.lower() == 'zotero':
-                print(f"[INFO] Zotero local search - used for caching/deduplication")
-                # Note: Zotero search handled separately in research streams
+                # Zotero isn't a discovery Source (integrations/sources/) --
+                # it's the bookmark layer, searched separately in research
+                # streams via the Zotero Web API, not here.
+                print(f"[INFO] Zotero search - used for caching/deduplication")
             else:
                 print(f"[WARNING] Source '{source}' not yet implemented")
-            
+
             # Update statistics
             source_stats[source]['papers_found'] = len(all_papers) - papers_before
             source_stats[source]['books_found'] = len(all_books) - books_before
-        
+
         # Remove duplicates and limit results
         unique_papers = self._deduplicate_papers(all_papers)
         unique_books = self._deduplicate_books(all_books)
         limited_papers = unique_papers[:limit]
         limited_books = unique_books[:limit]
-        
+
         # Print quality summary
         self._print_quality_summary(source_stats, len(limited_papers), len(limited_books))
-        
+
         return SearchResult(
             papers=limited_papers,
             books=limited_books,
@@ -160,118 +155,51 @@ class SearchAgent:
             query=query,
             timestamp=datetime.now()
         )
-    
-    def _search_arxiv(
-        self, query: str, limit: int, published_after: datetime | None = None
-    ) -> List[PaperMetadata]:
-        """Search arXiv API for papers."""
-        try:
-            search_query = f"all:{quote(query)}"
-            if published_after is not None:
-                date_str = published_after.strftime("%Y%m%d%H%M%S")
-                search_query += f"+AND+submittedDate:[{date_str}+TO+99991231235959]"
 
-            url = (
-                f"{self.arxiv_base_url}?search_query={search_query}"
-                f"&start=0&max_results={limit}"
-                f"&sortBy=submittedDate&sortOrder=descending"
-            )
-            
-            # Make request
-            response = requests.get(url, timeout=30)
-            response.raise_for_status()
-            
-            # Parse XML response
-            root = ET.fromstring(response.content)
-            
-            papers = []
-            entries = root.findall('{http://www.w3.org/2005/Atom}entry')
-            
-            for entry in entries:
-                paper = self._parse_arxiv_entry(entry)
-                if paper:
-                    papers.append(paper)
-            
-            return papers
-            
-        except Exception as e:
-            print(f"[ERROR] ArXiv search failed: {e}")
-            return []
-    
-    def _parse_arxiv_entry(self, entry) -> PaperMetadata | None:
-        """Parse a single arXiv entry into paper metadata."""
-        try:
-            # Namespaces
-            atom_ns = '{http://www.w3.org/2005/Atom}'
-            arxiv_ns = '{http://arxiv.org/schemas/atom}'
-            
-            # Extract basic fields
-            title = entry.find(f'{atom_ns}title').text.strip().replace('\n', ' ')
-            summary = entry.find(f'{atom_ns}summary').text.strip().replace('\n', ' ')
-            
-            # Get arXiv ID from the ID field
-            arxiv_id = entry.find(f'{atom_ns}id').text.split('/')[-1]
-            
-            # Extract authors
-            authors = []
-            for author in entry.findall(f'{atom_ns}author'):
-                name = author.find(f'{atom_ns}name').text
-                authors.append(name)
-            
-            # Extract publication date
-            published = entry.find(f'{atom_ns}published').text[:10]  # YYYY-MM-DD
-            
-            # Build paper metadata using Pydantic model
-            paper = PaperMetadata(
-                title=title,
-                authors=authors,
-                abstract=summary,
-                source='arxiv',
-                arxiv_id=arxiv_id,
-                url=f"https://arxiv.org/abs/{arxiv_id}",
-                pdf_url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",
-                published_date=published,
-                connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(title)}",
-                doi=None,
-                journal=None,
-                volume=None,
-                issue=None,
-                pages=None
-            )
-            
-            # Validate academic quality
+    def _validate_papers(self, papers: List[PaperMetadata], source_quality) -> tuple[List[PaperMetadata], int]:
+        """Academic-content validation + confidence scoring, applied
+        uniformly to every source's papers (previously only arxiv and
+        semanticscholar did this inline, each with its own copy of the
+        same logic, and both hardcoded SourceQuality.FIVE_STAR regardless
+        of the real source -- centralizing it here fixes both: every
+        paper source is validated the same way, scored against its own
+        actual quality rating. Books are never validated -- this always
+        was, and still is, papers-only (BookMetadata has no venue/abstract
+        concept validate_academic_content checks)."""
+        if not self.require_academic_validation:
+            return list(papers), 0
+
+        accepted: List[PaperMetadata] = []
+        rejected = 0
+        for paper in papers:
             is_valid, reasons = validate_academic_content(
-                title=title,
-                authors=authors,
-                abstract=summary,
-                venue="arXiv",  # arXiv is a recognized academic venue
-                criteria=self.validation_criteria
+                title=paper.title,
+                authors=paper.authors,
+                abstract=paper.abstract,
+                venue=paper.journal or "",
+                criteria=self.validation_criteria,
             )
-            
             if not is_valid:
-                logger.debug(f"arXiv paper rejected: {'; '.join(reasons)}")
-                return None
-            
-            # Calculate confidence score
+                logger.debug("%s paper rejected: %s", paper.source, "; ".join(reasons))
+                rejected += 1
+                continue
+
             confidence = get_academic_confidence_score(
-                title=title,
-                authors=authors,
-                abstract=summary,
-                venue="arXiv",
-                source_quality=SourceQuality.FIVE_STAR
+                title=paper.title,
+                authors=paper.authors,
+                abstract=paper.abstract,
+                venue=paper.journal or "",
+                source_quality=source_quality,
             )
-            
             if confidence < self.min_confidence_score:
-                logger.debug(f"arXiv paper low confidence: {confidence:.2f}")
-                return None
-            
-            logger.debug(f"arXiv paper accepted with confidence: {confidence:.2f}")
-            return paper
-            
-        except Exception as e:
-            print(f"[ERROR] Failed to parse arXiv entry: {e}")
-            return None
-    
+                logger.debug("%s paper low confidence: %.2f", paper.source, confidence)
+                rejected += 1
+                continue
+
+            logger.debug("%s paper accepted with confidence: %.2f", paper.source, confidence)
+            accepted.append(paper)
+        return accepted, rejected
+
     # Within-run dedup: ≥5 shared stems → same paper (no LLM; sources are different APIs for same content)
     _STEM_DEDUP_THRESHOLD = 5
 
@@ -328,425 +256,33 @@ class SearchAgent:
             unique.append(paper)
 
         return unique
-    
+
     def _deduplicate_books(self, books: List[BookMetadata]) -> List[BookMetadata]:
         """Remove duplicate books based on title and ISBN similarity."""
         if not books:
             return []
-        
+
         unique_books = []
         seen_books = set()
-        
+
         for book in books:
             # Create a unique key from title and ISBN (if available)
             title_key = book.title.lower().strip()
             isbn_key = book.isbn_13 or book.isbn_10 or ""
             book_key = f"{title_key}|{isbn_key}"
-            
+
             if book_key not in seen_books:
                 seen_books.add(book_key)
                 unique_books.append(book)
-        
+
         return unique_books
-    
-    def _search_openlibrary(self, query: str, limit: int) -> List[BookMetadata]:
-        """Search Open Library API for books."""
-        try:
-            # Format query for Open Library search
-            search_query = quote(query)
-            
-            # Build request URL - using the subjects endpoint for better results
-            url = f"{self.openlibrary_base_url}/search.json?q={search_query}&limit={limit}"
-            
-            # Make request
-            response = requests.get(url, timeout=30)
-            response.raise_for_status()
-            
-            # Parse JSON response using Pydantic model
-            api_response = OpenLibraryResponse.model_validate(response.json())
-            
-            books = []
-            for doc in api_response.docs:
-                book = self._parse_openlibrary_doc(doc)
-                if book:
-                    books.append(book)
-
-            return books
-            
-        except Exception as e:
-            print(f"[ERROR] Open Library search failed: {e}")
-            return []
-    
-    def _parse_openlibrary_doc(self, doc) -> BookMetadata | None:
-        """Parse a single Open Library document into book metadata."""
-        try:
-            # Extract basic fields from validated Pydantic model
-            title = doc.title.strip()
-            if not title:
-                return None            # Extract authors from validated model
-            authors = []
-            if doc.author_name:
-                authors = [name.strip() for name in doc.author_name if name.strip()]
-            
-            # Extract description/summary
-            description = ""
-            # Note: first_sentence is not in our Pydantic model, so we'll skip this for now
-            
-            # Extract ISBNs from validated model
-            isbn_10 = None
-            isbn_13 = None
-            if doc.isbn:
-                for isbn in doc.isbn:
-                    isbn_clean = isbn.replace('-', '').replace(' ', '')
-                    if len(isbn_clean) == 10:
-                        isbn_10 = isbn_clean
-                    elif len(isbn_clean) == 13:
-                        isbn_13 = isbn_clean
-            
-            # Extract publication info
-            # Extract publisher from validated model
-            publisher = None
-            if doc.publisher:
-                if isinstance(doc.publisher, list) and doc.publisher:
-                    publisher = doc.publisher[0]
-                elif isinstance(doc.publisher, str):
-                    publisher = doc.publisher
-            
-            published_date = None
-            if doc.first_publish_year:
-                published_date = str(doc.first_publish_year)
-            
-            # Extract subjects from validated model
-            subjects = doc.subject[:10] if doc.subject else []  # Limit to 10 subjects
-            
-            # Build Open Library URL
-            ol_url = f"https://openlibrary.org{doc.key}" if doc.key else f"https://openlibrary.org/search?q={quote(title)}"
-            
-            # Build book metadata using Pydantic model
-            book = BookMetadata(
-                title=title,
-                authors=authors,
-                description=description,
-                source='openlibrary',
-                url=ol_url,
-                isbn_10=isbn_10,
-                isbn_13=isbn_13,
-                publisher=publisher,
-                published_date=published_date,
-                subjects=subjects,
-                page_count=None,  # Not easily available in current model
-                language=doc.get('language', [None])[0] if doc.get('language') else None,
-                oclc=None,
-                lccn=None,
-                edition=None,
-                preview_url=None,
-                cover_url=None
-            )
-            
-            return book
-            
-        except Exception as e:
-            print(f"[ERROR] Failed to parse Open Library entry: {e}")
-            return None
-    
-    def _search_googlebooks(self, query: str, limit: int) -> List[BookMetadata]:
-        """Search Google Books API for books."""
-        try:
-            # Format query for Google Books API
-            search_query = quote(query)
-            
-            # Build request URL
-            url = f"{self.googlebooks_base_url}?q={search_query}&maxResults={min(limit, 40)}"
-            
-            # Make request
-            response = requests.get(url, timeout=30)
-            response.raise_for_status()
-            
-            # Parse JSON response
-            data = response.json()
-            
-            books = []
-            items = data.get('items', [])
-            
-            for item in items:
-                book = self._parse_googlebooks_item(item)
-                if book:
-                    books.append(book)
-            
-            return books
-            
-        except Exception as e:
-            print(f"[ERROR] Google Books search failed: {e}")
-            return []
-    
-    def _parse_googlebooks_item(self, item: Dict) -> BookMetadata | None:
-        """Parse a single Google Books item into book metadata."""
-        try:
-            volume_info = item.get('volumeInfo', {})
-            
-            # Extract basic fields
-            title = volume_info.get('title', '').strip()
-            if not title:
-                return None
-            
-            # Extract authors
-            authors = volume_info.get('authors', [])
-            if not isinstance(authors, list):
-                authors = []
-            
-            # Extract description
-            description = volume_info.get('description', '')
-            
-            # Extract ISBNs
-            isbn_10 = None
-            isbn_13 = None
-            industry_identifiers = volume_info.get('industryIdentifiers', [])
-            for identifier in industry_identifiers:
-                if identifier.get('type') == 'ISBN_10':
-                    isbn_10 = identifier.get('identifier')
-                elif identifier.get('type') == 'ISBN_13':
-                    isbn_13 = identifier.get('identifier')
-            
-            # Extract publication info
-            publisher = volume_info.get('publisher')
-            published_date = volume_info.get('publishedDate')
-            
-            # Extract categories (subjects)
-            categories = volume_info.get('categories', [])
-            if not isinstance(categories, list):
-                categories = []
-            
-            # Extract page count
-            page_count = volume_info.get('pageCount')
-            
-            # Extract language
-            language = volume_info.get('language')
-            
-            # Build Google Books URL
-            google_url = volume_info.get('infoLink', f"https://books.google.com/books?q={quote(title)}")
-            
-            # Extract preview URL
-            preview_url = volume_info.get('previewLink')
-            
-            # Extract cover URL
-            cover_url = None
-            image_links = volume_info.get('imageLinks', {})
-            if image_links:
-                cover_url = image_links.get('thumbnail') or image_links.get('smallThumbnail')
-            
-            # Build book metadata using Pydantic model
-            book = BookMetadata(
-                title=title,
-                authors=authors,
-                description=description,
-                source='googlebooks',
-                url=google_url,
-                isbn_10=isbn_10,
-                isbn_13=isbn_13,
-                publisher=publisher,
-                published_date=published_date,
-                page_count=page_count,
-                categories=categories,
-                language=language,
-                preview_url=preview_url,
-                cover_url=cover_url,
-                oclc=None,
-                lccn=None,
-                edition=None
-            )
-            
-            return book
-            
-        except Exception as e:
-            print(f"[ERROR] Failed to parse Google Books entry: {e}")
-            return None
-    
-    def _search_academia(self, query: str, limit: int) -> List[PaperMetadata]:
-        """Search Academia.edu for academic papers (web scraping approach)."""
-        try:
-            # Format query for Academia.edu search
-            search_query = quote(query)
-            
-            # Build search URL
-            url = f"{self.academia_base_url}/search?q={search_query}"
-            
-            # Headers to mimic a real browser request
-            headers = {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-                'Accept-Language': 'en-US,en;q=0.5',
-                'Accept-Encoding': 'gzip, deflate, br',
-                'Connection': 'keep-alive',
-                'Upgrade-Insecure-Requests': '1',
-            }
-            
-            # Make request with rate limiting
-            time.sleep(1)  # Respectful rate limiting
-            response = requests.get(url, headers=headers, timeout=30)
-            response.raise_for_status()
-            
-            papers = []
-            
-            # For now, return a simulated result to avoid complex HTML parsing
-            # In a production implementation, you would parse the HTML response
-            # This is a placeholder that demonstrates the structure
-            
-            # Note: Academia.edu search results would require HTML parsing with BeautifulSoup
-            # which would need to be added as a dependency. For now, we'll return empty
-            # but show the framework is in place.
-            
-            print(f"[INFO] Academia.edu search initiated for '{query}' - HTML parsing not implemented")
-            return papers
-            
-        except Exception as e:
-            print(f"[ERROR] Academia.edu search failed: {e}")
-            return []
-    
-    def _parse_academia_paper(self, paper_element) -> PaperMetadata | None:
-        """Parse Academia.edu paper element into paper metadata."""
-        # This would be implemented with BeautifulSoup HTML parsing
-        # Placeholder for the structure
-        try:
-            # Extract from HTML elements:
-            # - Title from .work-title or similar
-            # - Authors from .author-name or similar  
-            # - Abstract from .abstract or similar
-            # - URL from href attributes
-            # - Publication info from metadata
-            
-            return None  # Placeholder
-            
-        except Exception as e:
-            print(f"[ERROR] Failed to parse Academia.edu entry: {e}")
-            return None
-
-    def _search_semantic_scholar(
-        self, query: str, limit: int, published_after: datetime | None = None
-    ) -> List[PaperMetadata]:
-        """Search Semantic Scholar API for academic papers."""
-        try:
-            url = f"{self.semantic_scholar_base_url}/paper/search"
-            params: dict = {
-                'query': query,
-                'limit': min(limit, 100),
-                'fields': 'paperId,title,abstract,authors,venue,year,doi,url',
-            }
-            if published_after is not None:
-                # Semantic Scholar only has year-level granularity
-                params['year'] = f"{published_after.year}-"
-            
-            # Make request with rate limiting
-            time.sleep(0.1)  # Respectful rate limiting for API
-            response = requests.get(url, params=params, timeout=30)
-            response.raise_for_status()
-            
-            # Parse JSON response
-            data = response.json()
-            
-            papers = []
-            paper_data = data.get('data', [])
-            
-            for paper_item in paper_data:
-                paper = self._parse_semantic_scholar_paper(paper_item)
-                if paper:
-                    papers.append(paper)
-            
-            return papers
-            
-        except Exception as e:
-            print(f"[ERROR] Semantic Scholar search failed: {e}")
-            return []
-
-    def _parse_semantic_scholar_paper(self, paper_data: Dict) -> PaperMetadata | None:
-        """Parse a single Semantic Scholar paper into paper metadata."""
-        try:
-            # Extract basic fields
-            title = paper_data.get('title', '').strip()
-            if not title:
-                return None
-                
-            abstract = paper_data.get('abstract', '') or ''
-            
-            # Extract authors
-            authors = []
-            author_list = paper_data.get('authors', [])
-            for author in author_list:
-                if isinstance(author, dict) and 'name' in author:
-                    authors.append(author['name'])
-                elif isinstance(author, str):
-                    authors.append(author)
-            
-            # Extract publication info
-            venue = paper_data.get('venue') or ''
-            year = paper_data.get('year')
-            doi = paper_data.get('doi')
-            paper_id = paper_data.get('paperId', '')
-            
-            # Build URLs
-            paper_url = paper_data.get('url') or f"https://www.semanticscholar.org/paper/{paper_id}"
-            
-            # Format publication date
-            published_date = None
-            if year:
-                published_date = f"{year}-01-01"
-            
-            # Build paper metadata using Pydantic model
-            paper = PaperMetadata(
-                title=title,
-                authors=authors,
-                abstract=abstract,
-                source='semanticscholar',
-                url=paper_url,
-                pdf_url=None,  # Semantic Scholar doesn't provide direct PDF URLs
-                published_date=published_date,
-                doi=doi,
-                journal=venue,
-                volume=None,
-                issue=None,
-                pages=None,
-                arxiv_id=None,
-                connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(title)}"
-            )
-            
-            # Validate academic quality
-            is_valid, reasons = validate_academic_content(
-                title=title,
-                authors=authors,
-                abstract=abstract,
-                venue=venue,
-                criteria=self.validation_criteria
-            )
-            
-            if not is_valid:
-                logger.debug(f"Semantic Scholar paper rejected: {'; '.join(reasons)}")
-                return None
-            
-            # Calculate confidence score
-            confidence = get_academic_confidence_score(
-                title=title,
-                authors=authors,
-                abstract=abstract,
-                venue=venue,
-                source_quality=SourceQuality.FIVE_STAR
-            )
-            
-            if confidence < self.min_confidence_score:
-                logger.debug(f"Semantic Scholar paper low confidence: {confidence:.2f}")
-                return None
-            
-            logger.debug(f"Semantic Scholar paper accepted with confidence: {confidence:.2f}")
-            return paper
-            
-        except Exception as e:
-            logger.error(f"Failed to parse Semantic Scholar entry: {e}")
-            return None
 
     def _print_quality_summary(self, source_stats: Dict, total_papers: int, total_books: int):
         """Print summary of search results by source quality"""
         print(f"\n📊 Search Quality Summary:")
         print(f"   Total Results: {total_papers} papers, {total_books} books")
         print(f"   Sources Used:")
-        
+
         for source, stats in source_stats.items():
             if stats['papers_found'] + stats['books_found'] > 0:
                 quality_stars = "⭐" * stats['quality']

--- a/prisma/coordinator.py
+++ b/prisma/coordinator.py
@@ -59,8 +59,14 @@ class PrismaCoordinator:
         errors = []
         warnings = []
 
-        # Block offline only when internet-dependent sources are requested
-        _internet_sources = {'arxiv', 'semanticscholar', 'openlibrary', 'googlebooks', 'academia'}
+        # Block offline only when internet-dependent sources are requested.
+        # Derived from the SearchAgent's own source registry rather than a
+        # hand-maintained literal -- previously this list had to be
+        # remembered and updated by hand every time a source was added or
+        # removed (the exact kind of gap that made the 2026-07-29
+        # `academia` cleanup need a manual find-and-fix pass across
+        # several files).
+        _internet_sources = self.search_agent.available_sources
         _requested_sources = set(config.get('sources', []))
         _needs_internet = bool(_requested_sources & _internet_sources)
         if _needs_internet and not connectivity.is_online:

--- a/prisma/integrations/sources/__init__.py
+++ b/prisma/integrations/sources/__init__.py
@@ -1,0 +1,80 @@
+"""Registry of every discovery source.
+
+`SearchAgent` (`prisma/agents/search_agent.py`) depends only on
+`build_sources()`'s output, never on an individual concrete module --
+adding a new source means adding one module here plus one entry in
+`build_sources()`, with no change to `SearchAgent` itself.
+"""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from ...utils.config import SearchConfig, SourceQuotaConfig
+from .arxiv import ArxivSource
+from .base import Source, SourceSearchResult
+from .googlebooks import GoogleBooksSource
+from .ieee_xplore import IEEEXploreSource
+from .openlibrary import OpenLibrarySource
+from .pubmed import PubMedSource
+from .semantic_scholar import SemanticScholarSource
+
+__all__ = ["Source", "SourceSearchResult", "build_sources"]
+
+
+def _override(config: SearchConfig, name: str) -> SourceQuotaConfig:
+    return config.source_overrides.get(name, SourceQuotaConfig())
+
+
+def build_sources(config: Optional[SearchConfig] = None) -> Dict[str, Source]:
+    """Build one instance of every discovery source, keyed by name,
+    applying `config.source_overrides` on top of each module's built-in
+    default. Called once by `SearchAgent.__init__()`; tests can pass a
+    fresh `SearchConfig()` (or one with specific overrides) to control
+    what gets built.
+    """
+    config = config or SearchConfig()
+
+    arxiv_o = _override(config, "arxiv")
+    ss_o = _override(config, "semanticscholar")
+    ol_o = _override(config, "openlibrary")
+    gb_o = _override(config, "googlebooks")
+    pm_o = _override(config, "pubmed")
+    ieee_o = _override(config, "ieee_xplore")
+
+    pubmed_key = pm_o.resolve_api_key("pubmed")
+    # NCBI's rate limit is deterministically 3 req/s without a key, 10 with
+    # one (https://support.nlm.nih.gov/kbArticle/?pn=KA-05317) -- auto-pick
+    # the right default when a key is present, still overridable explicitly.
+    pubmed_rps = pm_o.requests_per_second or (10.0 if pubmed_key else 3.0)
+
+    googlebooks_key = gb_o.resolve_api_key("googlebooks")
+    # The 10,000/day cap is documented as per-key/per-project -- only claim
+    # it once a key is actually configured; an explicit override still wins.
+    googlebooks_daily_cap = gb_o.daily_cap or (10_000 if googlebooks_key else None)
+
+    return {
+        "arxiv": ArxivSource(
+            requests_per_second=arxiv_o.requests_per_second or 1 / 3,
+        ),
+        "semanticscholar": SemanticScholarSource(
+            requests_per_second=ss_o.requests_per_second or 1.0,
+            api_key=ss_o.resolve_api_key("semanticscholar"),
+        ),
+        "openlibrary": OpenLibrarySource(
+            requests_per_second=ol_o.requests_per_second or 3.0,
+        ),
+        "googlebooks": GoogleBooksSource(
+            requests_per_second=gb_o.requests_per_second or 0.5,
+            daily_cap=googlebooks_daily_cap,
+            api_key=googlebooks_key,
+        ),
+        "pubmed": PubMedSource(
+            requests_per_second=pubmed_rps,
+            api_key=pubmed_key,
+        ),
+        "ieee_xplore": IEEEXploreSource(
+            requests_per_second=ieee_o.requests_per_second or 0.5,
+            daily_cap=ieee_o.daily_cap,
+            api_key=ieee_o.resolve_api_key("ieee_xplore"),
+        ),
+    }

--- a/prisma/integrations/sources/arxiv.py
+++ b/prisma/integrations/sources/arxiv.py
@@ -14,6 +14,7 @@ import requests
 
 from ...services.rate_limiter import RateLimiter
 from ...storage.models.agent_models import PaperMetadata
+from ...storage.models.api_response_models import ArXivEntry
 from .base import Source, SourceSearchResult
 
 logger = logging.getLogger(__name__)
@@ -73,27 +74,36 @@ class ArxivSource(Source):
 
 def _parse_entry(entry) -> Optional[PaperMetadata]:
     try:
-        title = entry.find(f"{_ATOM_NS}title").text.strip().replace("\n", " ")
-        summary = entry.find(f"{_ATOM_NS}summary").text.strip().replace("\n", " ")
         arxiv_id = entry.find(f"{_ATOM_NS}id").text.split("/")[-1]
-
-        authors = []
-        for author in entry.findall(f"{_ATOM_NS}author"):
-            name = author.find(f"{_ATOM_NS}name").text
-            authors.append(name)
-
-        published = entry.find(f"{_ATOM_NS}published").text[:10]  # YYYY-MM-DD
-
+        authors = [
+            {"name": author.find(f"{_ATOM_NS}name").text}
+            for author in entry.findall(f"{_ATOM_NS}author")
+        ]
+        # Validated through ArXivEntry so a missing required field (title,
+        # summary, published) raises here rather than surfacing as a
+        # confusing downstream AttributeError -- also reuses the model's
+        # own title/summary strip+newline-collapse validators instead of
+        # duplicating that cleanup inline.
+        validated = ArXivEntry.model_validate(
+            {
+                "id": arxiv_id,
+                "title": entry.find(f"{_ATOM_NS}title").text,
+                "summary": entry.find(f"{_ATOM_NS}summary").text,
+                "authors": authors,
+                "published": entry.find(f"{_ATOM_NS}published").text,
+                "pdf_url": f"https://arxiv.org/pdf/{arxiv_id}.pdf",
+            }
+        )
         return PaperMetadata(
-            title=title,
-            authors=authors,
-            abstract=summary,
+            title=validated.title,
+            authors=[a.name for a in validated.authors],
+            abstract=validated.summary,
             source="arxiv",
-            arxiv_id=arxiv_id,
-            url=f"https://arxiv.org/abs/{arxiv_id}",
-            pdf_url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",
-            published_date=published,
-            connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(title)}",
+            arxiv_id=validated.id,
+            url=f"https://arxiv.org/abs/{validated.id}",
+            pdf_url=validated.pdf_url,
+            published_date=validated.published[:10],  # YYYY-MM-DD
+            connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(validated.title)}",
             doi=None,
             # arXiv isn't stored anywhere else on this model, but is a real,
             # recognized venue -- needed so SearchAgent's centralized

--- a/prisma/integrations/sources/arxiv.py
+++ b/prisma/integrations/sources/arxiv.py
@@ -1,0 +1,109 @@
+"""arXiv discovery source -- XML Atom API, no key, no hard-enforced rate
+limit, but arXiv's own Terms of Use ask for no more than one request every
+3 seconds on a single connection (https://info.arxiv.org/help/api/tou.html).
+"""
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import Optional
+from urllib.parse import quote
+
+import requests
+
+from ...services.rate_limiter import RateLimiter
+from ...storage.models.agent_models import PaperMetadata
+from .base import Source, SourceSearchResult
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "http://export.arxiv.org/api/query"
+_PROBE_URL = f"{_BASE_URL}?search_query=test&max_results=1"
+_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+
+
+class ArxivSource(Source):
+    name = "arxiv"
+
+    def __init__(self, requests_per_second: float = 1 / 3):
+        self._limiter = RateLimiter(requests_per_second=requests_per_second)
+
+    def probe(self, timeout: float = 5.0) -> bool:
+        if not self._limiter.acquire(timeout=timeout):
+            return False
+        try:
+            r = requests.get(_PROBE_URL, timeout=timeout)
+            return r.status_code < 500
+        except Exception as exc:
+            logger.warning("arxiv probe failed: %s", exc)
+            return False
+
+    def search(
+        self, query: str, limit: int, published_after: Optional[datetime] = None
+    ) -> SourceSearchResult:
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("arxiv: rate limit exhausted, skipping this search")
+            return SourceSearchResult()
+        try:
+            search_query = f"all:{quote(query)}"
+            if published_after is not None:
+                date_str = published_after.strftime("%Y%m%d%H%M%S")
+                search_query += f"+AND+submittedDate:[{date_str}+TO+99991231235959]"
+
+            url = (
+                f"{_BASE_URL}?search_query={search_query}"
+                f"&start=0&max_results={limit}"
+                f"&sortBy=submittedDate&sortOrder=descending"
+            )
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            root = ET.fromstring(response.content)
+
+            papers = []
+            for entry in root.findall(f"{_ATOM_NS}entry"):
+                paper = _parse_entry(entry)
+                if paper:
+                    papers.append(paper)
+            return SourceSearchResult(papers=papers)
+        except Exception as exc:
+            logger.error("arXiv search failed: %s", exc)
+            return SourceSearchResult()
+
+
+def _parse_entry(entry) -> Optional[PaperMetadata]:
+    try:
+        title = entry.find(f"{_ATOM_NS}title").text.strip().replace("\n", " ")
+        summary = entry.find(f"{_ATOM_NS}summary").text.strip().replace("\n", " ")
+        arxiv_id = entry.find(f"{_ATOM_NS}id").text.split("/")[-1]
+
+        authors = []
+        for author in entry.findall(f"{_ATOM_NS}author"):
+            name = author.find(f"{_ATOM_NS}name").text
+            authors.append(name)
+
+        published = entry.find(f"{_ATOM_NS}published").text[:10]  # YYYY-MM-DD
+
+        return PaperMetadata(
+            title=title,
+            authors=authors,
+            abstract=summary,
+            source="arxiv",
+            arxiv_id=arxiv_id,
+            url=f"https://arxiv.org/abs/{arxiv_id}",
+            pdf_url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",
+            published_date=published,
+            connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(title)}",
+            doi=None,
+            # arXiv isn't stored anywhere else on this model, but is a real,
+            # recognized venue -- needed so SearchAgent's centralized
+            # academic-content validation (which checks venue/publisher)
+            # doesn't reject every arXiv paper for lacking one.
+            journal="arXiv",
+            volume=None,
+            issue=None,
+            pages=None,
+        )
+    except Exception as exc:
+        logger.error("Failed to parse arXiv entry: %s", exc)
+        return None

--- a/prisma/integrations/sources/base.py
+++ b/prisma/integrations/sources/base.py
@@ -1,0 +1,59 @@
+"""Common interface every discovery source implements.
+
+`SearchAgent` (`prisma/agents/search_agent.py`) depends on this
+abstraction, not on any concrete source module -- adding a new source
+means adding one module here plus one registry entry in `__init__.py`,
+never touching `SearchAgent` itself.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ...storage.models.agent_models import BookMetadata, PaperMetadata
+
+
+class SourceSearchResult(BaseModel):
+    """What one source's search() call returns -- merged across every
+    requested source by SearchAgent into the aggregate SearchResult
+    (storage.models.agent_models.SearchResult)."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    papers: List[PaperMetadata] = Field(default_factory=list)
+    books: List[BookMetadata] = Field(default_factory=list)
+
+
+class Source(ABC):
+    """One discovery source: papers and/or books fetched from one external
+    API, enforcing its own quota. `name` must match the corresponding key
+    in `storage.models.source_quality.SOURCE_REGISTRY` and
+    `utils.config.SearchConfig.valid_sources`.
+    """
+
+    name: str
+
+    @abstractmethod
+    def search(
+        self,
+        query: str,
+        limit: int,
+        published_after: Optional[datetime] = None,
+    ) -> SourceSearchResult:
+        """Fetch results for `query`, at most `limit` items. Must not
+        raise on a network/parse failure -- log and return an empty
+        SourceSearchResult, the same contract SearchAgent already relies
+        on today for a source that's down. Must call its own
+        `prisma.services.rate_limiter.RateLimiter` before every request it
+        makes; if the limiter denies (timeout elapsed, or a daily cap
+        exhausted), log a warning and return empty rather than blocking
+        the whole search."""
+        raise NotImplementedError
+
+    def probe(self, timeout: float = 5.0) -> bool:
+        """Lightweight reachability check used by SearchAgent.preflight().
+        Default assumes reachable; override for a real cheap ping. Must
+        never raise."""
+        return True

--- a/prisma/integrations/sources/googlebooks.py
+++ b/prisma/integrations/sources/googlebooks.py
@@ -10,13 +10,14 @@ belongs to us until a key is actually configured.
 from __future__ import annotations
 
 import logging
-from typing import Dict, Optional
+from typing import Optional
 from urllib.parse import quote
 
 import requests
 
 from ...services.rate_limiter import RateLimiter
 from ...storage.models.agent_models import BookMetadata
+from ...storage.models.api_response_models import GoogleBooksItem, GoogleBooksVolumeInfo
 from .base import Source, SourceSearchResult
 
 logger = logging.getLogger(__name__)
@@ -60,11 +61,19 @@ class GoogleBooksSource(Source):
                 params["key"] = self._api_key
             response = requests.get(_BASE_URL, params=params, timeout=30)
             response.raise_for_status()
-            data = response.json()
+            raw_items = response.json().get("items", [])
 
             books = []
-            for item in data.get("items", []):
-                book = _parse_item(item)
+            for raw_item in raw_items:
+                # Validated per-item, not via the GoogleBooksResponse
+                # wrapper, so one malformed item doesn't drop the whole
+                # response -- same resilience the old raw-dict parsing had.
+                try:
+                    validated = GoogleBooksItem.model_validate(raw_item)
+                    book = _to_book_metadata(validated.volumeInfo)
+                except Exception as exc:
+                    logger.debug("Google Books item failed to parse, skipping: %s", exc)
+                    continue
                 if book:
                     books.append(book)
             return SourceSearchResult(books=books)
@@ -73,65 +82,41 @@ class GoogleBooksSource(Source):
             return SourceSearchResult()
 
 
-def _parse_item(item: Dict) -> Optional[BookMetadata]:
-    try:
-        volume_info = item.get("volumeInfo", {})
-
-        title = volume_info.get("title", "").strip()
-        if not title:
-            return None
-
-        authors = volume_info.get("authors", [])
-        if not isinstance(authors, list):
-            authors = []
-
-        description = volume_info.get("description", "")
-
-        isbn_10 = None
-        isbn_13 = None
-        for identifier in volume_info.get("industryIdentifiers", []):
-            if identifier.get("type") == "ISBN_10":
-                isbn_10 = identifier.get("identifier")
-            elif identifier.get("type") == "ISBN_13":
-                isbn_13 = identifier.get("identifier")
-
-        publisher = volume_info.get("publisher")
-        published_date = volume_info.get("publishedDate")
-
-        categories = volume_info.get("categories", [])
-        if not isinstance(categories, list):
-            categories = []
-
-        page_count = volume_info.get("pageCount")
-        language = volume_info.get("language")
-
-        google_url = volume_info.get("infoLink", f"https://books.google.com/books?q={quote(title)}")
-        preview_url = volume_info.get("previewLink")
-
-        cover_url = None
-        image_links = volume_info.get("imageLinks", {})
-        if image_links:
-            cover_url = image_links.get("thumbnail") or image_links.get("smallThumbnail")
-
-        return BookMetadata(
-            title=title,
-            authors=authors,
-            description=description,
-            source="googlebooks",
-            url=google_url,
-            isbn_10=isbn_10,
-            isbn_13=isbn_13,
-            publisher=publisher,
-            published_date=published_date,
-            page_count=page_count,
-            categories=categories,
-            language=language,
-            preview_url=preview_url,
-            cover_url=cover_url,
-            oclc=None,
-            lccn=None,
-            edition=None,
-        )
-    except Exception as exc:
-        logger.error("Failed to parse Google Books entry: %s", exc)
+def _to_book_metadata(volume_info: GoogleBooksVolumeInfo) -> Optional[BookMetadata]:
+    title = volume_info.title.strip()
+    if not title:
         return None
+
+    isbn_10 = None
+    isbn_13 = None
+    for identifier in volume_info.industryIdentifiers:
+        if identifier.get("type") == "ISBN_10":
+            isbn_10 = identifier.get("identifier")
+        elif identifier.get("type") == "ISBN_13":
+            isbn_13 = identifier.get("identifier")
+
+    google_url = volume_info.infoLink or f"https://books.google.com/books?q={quote(title)}"
+
+    cover_url = None
+    if volume_info.imageLinks:
+        cover_url = volume_info.imageLinks.get("thumbnail") or volume_info.imageLinks.get("smallThumbnail")
+
+    return BookMetadata(
+        title=title,
+        authors=volume_info.authors,
+        description=volume_info.description or "",
+        source="googlebooks",
+        url=google_url,
+        isbn_10=isbn_10,
+        isbn_13=isbn_13,
+        publisher=volume_info.publisher,
+        published_date=volume_info.publishedDate,
+        page_count=volume_info.pageCount,
+        categories=volume_info.categories,
+        language=volume_info.language,
+        preview_url=volume_info.previewLink,
+        cover_url=cover_url,
+        oclc=None,
+        lccn=None,
+        edition=None,
+    )

--- a/prisma/integrations/sources/googlebooks.py
+++ b/prisma/integrations/sources/googlebooks.py
@@ -1,0 +1,137 @@
+"""Google Books discovery source.
+
+No documented per-second limit; the real constraint is a 10,000
+requests/day quota, but that quota is per API-key/project -- running
+anonymously (no key, today's default) shares Google's unspecified,
+much lower anonymous pool instead, so the default here throttles more
+conservatively than the with-key case and does not claim the 10k/day cap
+belongs to us until a key is actually configured.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+from urllib.parse import quote
+
+import requests
+
+from ...services.rate_limiter import RateLimiter
+from ...storage.models.agent_models import BookMetadata
+from .base import Source, SourceSearchResult
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.googleapis.com/books/v1/volumes"
+_PROBE_URL = f"{_BASE_URL}?q=test&maxResults=1"
+
+
+class GoogleBooksSource(Source):
+    name = "googlebooks"
+
+    def __init__(
+        self,
+        requests_per_second: float = 0.5,
+        daily_cap: Optional[int] = None,
+        api_key: Optional[str] = None,
+    ):
+        self._limiter = RateLimiter(requests_per_second=requests_per_second, daily_cap=daily_cap)
+        self._api_key = api_key
+
+    def probe(self, timeout: float = 5.0) -> bool:
+        if not self._limiter.acquire(timeout=timeout):
+            return False
+        try:
+            params = {"q": "test", "maxResults": 1}
+            if self._api_key:
+                params["key"] = self._api_key
+            r = requests.get(_BASE_URL, params=params, timeout=timeout)
+            return r.status_code < 500
+        except Exception as exc:
+            logger.warning("googlebooks probe failed: %s", exc)
+            return False
+
+    def search(self, query: str, limit: int, published_after=None) -> SourceSearchResult:
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("googlebooks: rate limit exhausted, skipping this search")
+            return SourceSearchResult()
+        try:
+            params = {"q": query, "maxResults": min(limit, 40)}
+            if self._api_key:
+                params["key"] = self._api_key
+            response = requests.get(_BASE_URL, params=params, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+
+            books = []
+            for item in data.get("items", []):
+                book = _parse_item(item)
+                if book:
+                    books.append(book)
+            return SourceSearchResult(books=books)
+        except Exception as exc:
+            logger.error("Google Books search failed: %s", exc)
+            return SourceSearchResult()
+
+
+def _parse_item(item: Dict) -> Optional[BookMetadata]:
+    try:
+        volume_info = item.get("volumeInfo", {})
+
+        title = volume_info.get("title", "").strip()
+        if not title:
+            return None
+
+        authors = volume_info.get("authors", [])
+        if not isinstance(authors, list):
+            authors = []
+
+        description = volume_info.get("description", "")
+
+        isbn_10 = None
+        isbn_13 = None
+        for identifier in volume_info.get("industryIdentifiers", []):
+            if identifier.get("type") == "ISBN_10":
+                isbn_10 = identifier.get("identifier")
+            elif identifier.get("type") == "ISBN_13":
+                isbn_13 = identifier.get("identifier")
+
+        publisher = volume_info.get("publisher")
+        published_date = volume_info.get("publishedDate")
+
+        categories = volume_info.get("categories", [])
+        if not isinstance(categories, list):
+            categories = []
+
+        page_count = volume_info.get("pageCount")
+        language = volume_info.get("language")
+
+        google_url = volume_info.get("infoLink", f"https://books.google.com/books?q={quote(title)}")
+        preview_url = volume_info.get("previewLink")
+
+        cover_url = None
+        image_links = volume_info.get("imageLinks", {})
+        if image_links:
+            cover_url = image_links.get("thumbnail") or image_links.get("smallThumbnail")
+
+        return BookMetadata(
+            title=title,
+            authors=authors,
+            description=description,
+            source="googlebooks",
+            url=google_url,
+            isbn_10=isbn_10,
+            isbn_13=isbn_13,
+            publisher=publisher,
+            published_date=published_date,
+            page_count=page_count,
+            categories=categories,
+            language=language,
+            preview_url=preview_url,
+            cover_url=cover_url,
+            oclc=None,
+            lccn=None,
+            edition=None,
+        )
+    except Exception as exc:
+        logger.error("Failed to parse Google Books entry: %s", exc)
+        return None

--- a/prisma/integrations/sources/ieee_xplore.py
+++ b/prisma/integrations/sources/ieee_xplore.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import requests
 
 from ...services.rate_limiter import RateLimiter
 from ...storage.models.agent_models import PaperMetadata
+from ...storage.models.api_response_models import IEEEXploreArticle
 from .base import Source, SourceSearchResult
 
 logger = logging.getLogger(__name__)
@@ -87,8 +88,18 @@ class IEEEXploreSource(Source):
             data = response.json()
 
             papers = []
-            for article in data.get("articles", []):
-                paper = _parse_article(article)
+            for raw_article in data.get("articles", []):
+                # Validated per-article, not via a top-level wrapper, so one
+                # malformed article doesn't drop the whole batch -- and
+                # `authors` is intentionally typed Any on the model (its
+                # real shape is unconfirmed), so _extract_authors still
+                # does the interpretation after validation.
+                try:
+                    validated = IEEEXploreArticle.model_validate(raw_article)
+                    paper = _to_paper_metadata(validated)
+                except Exception as exc:
+                    logger.debug("IEEE Xplore article failed to parse, skipping: %s", exc)
+                    continue
                 if paper:
                     papers.append(paper)
             return SourceSearchResult(papers=papers)
@@ -97,8 +108,7 @@ class IEEEXploreSource(Source):
             return SourceSearchResult()
 
 
-def _extract_authors(article: Dict) -> List[str]:
-    authors_field = article.get("authors")
+def _extract_authors(authors_field) -> List[str]:
     if isinstance(authors_field, dict):
         # documented shape: {"authors": [{"full_name": "...", ...}, ...]}
         entries = authors_field.get("authors", [])
@@ -118,46 +128,33 @@ def _extract_authors(article: Dict) -> List[str]:
     return names
 
 
-def _parse_article(article: Dict) -> Optional[PaperMetadata]:
-    try:
-        title = (article.get("title") or "").strip()
-        if not title:
-            return None
-
-        authors = _extract_authors(article)
-        abstract = article.get("abstract") or ""
-        doi = article.get("doi") or None
-        journal = article.get("publication_title") or ""
-        published_date = article.get("publication_date") or (
-            str(article.get("publication_year")) if article.get("publication_year") else None
-        )
-        article_number = article.get("article_number")
-        url = article.get("html_url") or (
-            f"https://ieeexplore.ieee.org/document/{article_number}" if article_number else None
-        )
-        if not url:
-            return None
-
-        return PaperMetadata(
-            title=title,
-            authors=authors,
-            abstract=abstract,
-            source="ieee_xplore",
-            url=url,
-            pdf_url=article.get("pdf_url"),
-            published_date=published_date,
-            doi=doi,
-            journal=journal,
-            volume=article.get("volume") or None,
-            issue=article.get("issue") or None,
-            pages=(
-                f"{article['start_page']}-{article['end_page']}"
-                if article.get("start_page") and article.get("end_page")
-                else None
-            ),
-            arxiv_id=None,
-            connected_papers_url=None,
-        )
-    except Exception as exc:
-        logger.error("Failed to parse IEEE Xplore entry: %s", exc)
+def _to_paper_metadata(article: IEEEXploreArticle) -> Optional[PaperMetadata]:
+    title = article.title.strip()
+    if not title:
         return None
+
+    published_date = article.publication_date or (
+        str(article.publication_year) if article.publication_year else None
+    )
+    url = article.html_url or (
+        f"https://ieeexplore.ieee.org/document/{article.article_number}" if article.article_number else None
+    )
+    if not url:
+        return None
+
+    return PaperMetadata(
+        title=title,
+        authors=_extract_authors(article.authors),
+        abstract=article.abstract or "",
+        source="ieee_xplore",
+        url=url,
+        pdf_url=article.pdf_url,
+        published_date=published_date,
+        doi=article.doi,
+        journal=article.publication_title or "",
+        volume=article.volume,
+        issue=article.issue,
+        pages=f"{article.start_page}-{article.end_page}" if article.start_page and article.end_page else None,
+        arxiv_id=None,
+        connected_papers_url=None,
+    )

--- a/prisma/integrations/sources/ieee_xplore.py
+++ b/prisma/integrations/sources/ieee_xplore.py
@@ -1,0 +1,163 @@
+"""IEEE Xplore discovery source -- Metadata API
+(https://developer.ieee.org/docs/read/IEEE_Xplore_Metadata_API_Overview).
+
+UNVERIFIED AGAINST A REAL KEY as of 2026-07-29 -- an API key is required
+even to make one request (no anonymous mode at all, unlike every other
+source here), and the user doesn't have one yet. Field names below come
+from IEEE's own published docs (developer.ieee.org/docs/read/
+Metadata_API_responses and .../Metadata_API_details), not from a live
+response, so treat the parsing as a best-effort first pass to correct
+once real responses are available. The rate limit (1 req / 2s, no daily
+cap) is a deliberately conservative placeholder -- IEEE does not publish
+a rate limit or daily quota anywhere in their public docs; get the real
+numbers from IEEE's API user guide (emailed after registration) and
+update `requests_per_second`/`daily_cap` via config once you have them,
+rather than trusting this default long-term.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import requests
+
+from ...services.rate_limiter import RateLimiter
+from ...storage.models.agent_models import PaperMetadata
+from .base import Source, SourceSearchResult
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://ieeexploreapi.ieee.org/api/v1/search/articles"
+
+
+class IEEEXploreSource(Source):
+    name = "ieee_xplore"
+
+    def __init__(
+        self,
+        requests_per_second: float = 0.5,
+        daily_cap: Optional[int] = None,
+        api_key: Optional[str] = None,
+    ):
+        self._limiter = RateLimiter(requests_per_second=requests_per_second, daily_cap=daily_cap)
+        self._api_key = api_key
+
+    def _configured(self) -> bool:
+        if not self._api_key:
+            logger.warning("ieee_xplore: no api_key configured — skipping (key is required, no anonymous mode)")
+            return False
+        return True
+
+    def probe(self, timeout: float = 5.0) -> bool:
+        if not self._configured():
+            return False
+        if not self._limiter.acquire(timeout=timeout):
+            return False
+        try:
+            r = requests.get(
+                _BASE_URL,
+                params={"apikey": self._api_key, "querytext": "test", "max_records": 1},
+                timeout=timeout,
+            )
+            return r.status_code < 500
+        except Exception as exc:
+            logger.warning("ieee_xplore probe failed: %s", exc)
+            return False
+
+    def search(
+        self, query: str, limit: int, published_after: Optional[datetime] = None
+    ) -> SourceSearchResult:
+        if not self._configured():
+            return SourceSearchResult()
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("ieee_xplore: rate limit exhausted, skipping this search")
+            return SourceSearchResult()
+        try:
+            params = {
+                "apikey": self._api_key,
+                "querytext": query,
+                "max_records": min(limit, 200),  # IEEE's own documented per-query cap
+            }
+            if published_after is not None:
+                params["start_year"] = published_after.year
+
+            response = requests.get(_BASE_URL, params=params, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+
+            papers = []
+            for article in data.get("articles", []):
+                paper = _parse_article(article)
+                if paper:
+                    papers.append(paper)
+            return SourceSearchResult(papers=papers)
+        except Exception as exc:
+            logger.error("IEEE Xplore search failed: %s", exc)
+            return SourceSearchResult()
+
+
+def _extract_authors(article: Dict) -> List[str]:
+    authors_field = article.get("authors")
+    if isinstance(authors_field, dict):
+        # documented shape: {"authors": [{"full_name": "...", ...}, ...]}
+        entries = authors_field.get("authors", [])
+    elif isinstance(authors_field, list):
+        entries = authors_field
+    else:
+        entries = []
+
+    names = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            name = entry.get("full_name") or entry.get("name")
+            if name:
+                names.append(name)
+        elif isinstance(entry, str):
+            names.append(entry)
+    return names
+
+
+def _parse_article(article: Dict) -> Optional[PaperMetadata]:
+    try:
+        title = (article.get("title") or "").strip()
+        if not title:
+            return None
+
+        authors = _extract_authors(article)
+        abstract = article.get("abstract") or ""
+        doi = article.get("doi") or None
+        journal = article.get("publication_title") or ""
+        published_date = article.get("publication_date") or (
+            str(article.get("publication_year")) if article.get("publication_year") else None
+        )
+        article_number = article.get("article_number")
+        url = article.get("html_url") or (
+            f"https://ieeexplore.ieee.org/document/{article_number}" if article_number else None
+        )
+        if not url:
+            return None
+
+        return PaperMetadata(
+            title=title,
+            authors=authors,
+            abstract=abstract,
+            source="ieee_xplore",
+            url=url,
+            pdf_url=article.get("pdf_url"),
+            published_date=published_date,
+            doi=doi,
+            journal=journal,
+            volume=article.get("volume") or None,
+            issue=article.get("issue") or None,
+            pages=(
+                f"{article['start_page']}-{article['end_page']}"
+                if article.get("start_page") and article.get("end_page")
+                else None
+            ),
+            arxiv_id=None,
+            connected_papers_url=None,
+        )
+    except Exception as exc:
+        logger.error("Failed to parse IEEE Xplore entry: %s", exc)
+        return None

--- a/prisma/integrations/sources/openlibrary.py
+++ b/prisma/integrations/sources/openlibrary.py
@@ -1,0 +1,115 @@
+"""Open Library discovery source -- Internet Archive's book API.
+
+No key. Default rate limit for anonymous requests is 1 req/s; identified
+requests (a descriptive User-Agent) get 3 req/s per Open Library's own
+policy, so this always sends one -- a legitimate, free 3x, not a guess.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from urllib.parse import quote
+
+import requests
+
+from ...services.rate_limiter import RateLimiter
+from ...storage.models.agent_models import BookMetadata
+from ...storage.models.api_response_models import OpenLibraryDocument, OpenLibraryResponse
+from .base import Source, SourceSearchResult
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://openlibrary.org"
+_PROBE_URL = f"{_BASE_URL}/search.json?q=test&limit=1"
+_HEADERS = {"User-Agent": "Prisma/1.0 (+https://github.com/CServinL/prisma)"}
+
+
+class OpenLibrarySource(Source):
+    name = "openlibrary"
+
+    def __init__(self, requests_per_second: float = 3.0):
+        self._limiter = RateLimiter(requests_per_second=requests_per_second)
+
+    def probe(self, timeout: float = 5.0) -> bool:
+        if not self._limiter.acquire(timeout=timeout):
+            return False
+        try:
+            r = requests.get(_PROBE_URL, headers=_HEADERS, timeout=timeout)
+            return r.status_code < 500
+        except Exception as exc:
+            logger.warning("openlibrary probe failed: %s", exc)
+            return False
+
+    def search(self, query: str, limit: int, published_after=None) -> SourceSearchResult:
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("openlibrary: rate limit exhausted, skipping this search")
+            return SourceSearchResult()
+        try:
+            search_query = quote(query)
+            url = f"{_BASE_URL}/search.json?q={search_query}&limit={limit}"
+            response = requests.get(url, headers=_HEADERS, timeout=30)
+            response.raise_for_status()
+
+            api_response = OpenLibraryResponse.model_validate(response.json())
+            books = []
+            for doc in api_response.docs:
+                book = _parse_doc(doc)
+                if book:
+                    books.append(book)
+            return SourceSearchResult(books=books)
+        except Exception as exc:
+            logger.error("Open Library search failed: %s", exc)
+            return SourceSearchResult()
+
+
+def _parse_doc(doc: OpenLibraryDocument) -> Optional[BookMetadata]:
+    try:
+        title = doc.title.strip()
+        if not title:
+            return None
+
+        authors = [name.strip() for name in doc.author_name if name.strip()]
+
+        isbn_10 = None
+        isbn_13 = None
+        for isbn in doc.isbn:
+            isbn_clean = isbn.replace("-", "").replace(" ", "")
+            if len(isbn_clean) == 10:
+                isbn_10 = isbn_clean
+            elif len(isbn_clean) == 13:
+                isbn_13 = isbn_clean
+
+        publisher = doc.publisher[0] if doc.publisher else None
+        published_date = str(doc.first_publish_year) if doc.first_publish_year else None
+        subjects = doc.subject[:10]  # cap to 10 subjects
+        # `doc` is a Pydantic model, not a dict -- .get() doesn't exist on
+        # it. This line previously called doc.get(...) here, which raised
+        # AttributeError on every single document and was silently
+        # swallowed by the caller's broad except -- Open Library has
+        # returned zero results ever since this model was introduced.
+        language = doc.language[0] if doc.language else None
+
+        ol_url = f"https://openlibrary.org{doc.key}" if doc.key else f"https://openlibrary.org/search?q={quote(title)}"
+
+        return BookMetadata(
+            title=title,
+            authors=authors,
+            description="",
+            source="openlibrary",
+            url=ol_url,
+            isbn_10=isbn_10,
+            isbn_13=isbn_13,
+            publisher=publisher,
+            published_date=published_date,
+            subjects=subjects,
+            page_count=None,
+            language=language,
+            oclc=None,
+            lccn=None,
+            edition=None,
+            preview_url=None,
+            cover_url=None,
+        )
+    except Exception as exc:
+        logger.error("Failed to parse Open Library entry: %s", exc)
+        return None

--- a/prisma/integrations/sources/pubmed.py
+++ b/prisma/integrations/sources/pubmed.py
@@ -19,6 +19,7 @@ import requests
 
 from ...services.rate_limiter import RateLimiter
 from ...storage.models.agent_models import PaperMetadata
+from ...storage.models.api_response_models import PubMedSummaryResult
 from .base import Source, SourceSearchResult
 
 logger = logging.getLogger(__name__)
@@ -68,10 +69,17 @@ class PubMedSource(Source):
 
             papers = []
             for pmid in pmids:
-                summary = summaries.get(pmid)
-                if not summary:
+                raw_summary = summaries.get(pmid)
+                if not raw_summary:
                     continue
-                paper = _parse_summary(pmid, summary, abstracts.get(pmid, ""))
+                # Validated per-article, not via a top-level wrapper, so one
+                # malformed article doesn't drop the whole batch.
+                try:
+                    validated = PubMedSummaryResult.model_validate(raw_summary)
+                    paper = _to_paper_metadata(validated, abstracts.get(pmid, ""))
+                except Exception as exc:
+                    logger.debug("PubMed article %s failed to parse, skipping: %s", pmid, exc)
+                    continue
                 if paper:
                     papers.append(paper)
             return SourceSearchResult(papers=papers)
@@ -127,42 +135,32 @@ class PubMedSource(Source):
         return abstracts
 
 
-def _parse_summary(pmid: str, summary: dict, abstract: str) -> Optional[PaperMetadata]:
-    try:
-        title = (summary.get("title") or "").strip()
-        if not title:
-            return None
-
-        authors = [a.get("name", "").strip() for a in summary.get("authors", []) if a.get("name")]
-
-        doi = None
-        for article_id in summary.get("articleids", []):
-            if article_id.get("idtype") == "doi":
-                doi = article_id.get("value")
-                break
-
-        journal = summary.get("fulljournalname") or summary.get("source") or ""
-        published_date = _normalize_pubdate(summary.get("pubdate", ""))
-
-        return PaperMetadata(
-            title=title,
-            authors=authors,
-            abstract=abstract,
-            source="pubmed",
-            url=f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
-            pdf_url=None,
-            published_date=published_date,
-            doi=doi,
-            journal=journal,
-            volume=summary.get("volume") or None,
-            issue=summary.get("issue") or None,
-            pages=summary.get("pages") or None,
-            arxiv_id=None,
-            connected_papers_url=None,
-        )
-    except Exception as exc:
-        logger.error("Failed to parse PubMed entry %s: %s", pmid, exc)
+def _to_paper_metadata(summary: PubMedSummaryResult, abstract: str) -> Optional[PaperMetadata]:
+    title = summary.title.strip()
+    if not title:
         return None
+
+    authors = [a.name.strip() for a in summary.authors if a.name.strip()]
+    doi = next((a.value for a in summary.articleids if a.idtype == "doi"), None)
+    journal = summary.fulljournalname or summary.source or ""
+    published_date = _normalize_pubdate(summary.pubdate)
+
+    return PaperMetadata(
+        title=title,
+        authors=authors,
+        abstract=abstract,
+        source="pubmed",
+        url=f"https://pubmed.ncbi.nlm.nih.gov/{summary.uid}/",
+        pdf_url=None,
+        published_date=published_date,
+        doi=doi,
+        journal=journal,
+        volume=summary.volume,
+        issue=summary.issue,
+        pages=summary.pages,
+        arxiv_id=None,
+        connected_papers_url=None,
+    )
 
 
 _MONTHS = {

--- a/prisma/integrations/sources/pubmed.py
+++ b/prisma/integrations/sources/pubmed.py
@@ -1,0 +1,196 @@
+"""PubMed discovery source -- NCBI E-utilities (esearch -> esummary ->
+efetch). No key required (3 req/s); a free NCBI account API key raises
+the limit to 10 req/s (https://support.nlm.nih.gov/kbArticle/?pn=KA-05317).
+
+Three real HTTP round-trips per search() call -- esearch for PMIDs,
+esummary for structured metadata, efetch for abstract text (esummary
+doesn't include abstracts at all) -- so the rate limiter is acquired
+three times per logical search, matching real quota consumption rather
+than under-counting it.
+"""
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import requests
+
+from ...services.rate_limiter import RateLimiter
+from ...storage.models.agent_models import PaperMetadata
+from .base import Source, SourceSearchResult
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+_ESEARCH_URL = f"{_BASE_URL}/esearch.fcgi"
+_ESUMMARY_URL = f"{_BASE_URL}/esummary.fcgi"
+_EFETCH_URL = f"{_BASE_URL}/efetch.fcgi"
+
+
+class PubMedSource(Source):
+    name = "pubmed"
+
+    def __init__(self, requests_per_second: float = 3.0, api_key: Optional[str] = None):
+        self._limiter = RateLimiter(requests_per_second=requests_per_second)
+        self._api_key = api_key
+
+    def _params(self, **extra) -> dict:
+        params = dict(extra)
+        if self._api_key:
+            params["api_key"] = self._api_key
+        return params
+
+    def probe(self, timeout: float = 5.0) -> bool:
+        if not self._limiter.acquire(timeout=timeout):
+            return False
+        try:
+            r = requests.get(
+                _ESEARCH_URL,
+                params=self._params(db="pubmed", term="test", retmax=1, retmode="json"),
+                timeout=timeout,
+            )
+            return r.status_code < 500
+        except Exception as exc:
+            logger.warning("pubmed probe failed: %s", exc)
+            return False
+
+    def search(
+        self, query: str, limit: int, published_after: Optional[datetime] = None
+    ) -> SourceSearchResult:
+        try:
+            pmids = self._esearch(query, limit, published_after)
+            if not pmids:
+                return SourceSearchResult()
+            summaries = self._esummary(pmids)
+            abstracts = self._efetch_abstracts(pmids)
+
+            papers = []
+            for pmid in pmids:
+                summary = summaries.get(pmid)
+                if not summary:
+                    continue
+                paper = _parse_summary(pmid, summary, abstracts.get(pmid, ""))
+                if paper:
+                    papers.append(paper)
+            return SourceSearchResult(papers=papers)
+        except Exception as exc:
+            logger.error("PubMed search failed: %s", exc)
+            return SourceSearchResult()
+
+    def _esearch(self, query: str, limit: int, published_after: Optional[datetime]) -> List[str]:
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("pubmed: rate limit exhausted, skipping this search")
+            return []
+        params = self._params(db="pubmed", term=query, retmax=limit, retmode="json", sort="date")
+        if published_after is not None:
+            params["datetype"] = "pdat"
+            params["mindate"] = published_after.strftime("%Y/%m/%d")
+            params["maxdate"] = "3000/12/31"
+        response = requests.get(_ESEARCH_URL, params=params, timeout=30)
+        response.raise_for_status()
+        return response.json().get("esearchresult", {}).get("idlist", [])
+
+    def _esummary(self, pmids: List[str]) -> Dict[str, dict]:
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("pubmed: rate limit exhausted, skipping esummary")
+            return {}
+        params = self._params(db="pubmed", id=",".join(pmids), retmode="json", version="2.0")
+        response = requests.get(_ESUMMARY_URL, params=params, timeout=30)
+        response.raise_for_status()
+        result = response.json().get("result", {})
+        return {uid: result[uid] for uid in result.get("uids", []) if uid in result}
+
+    def _efetch_abstracts(self, pmids: List[str]) -> Dict[str, str]:
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("pubmed: rate limit exhausted, skipping efetch (abstracts will be empty)")
+            return {}
+        params = self._params(db="pubmed", id=",".join(pmids), rettype="abstract", retmode="xml")
+        response = requests.get(_EFETCH_URL, params=params, timeout=30)
+        response.raise_for_status()
+
+        abstracts: Dict[str, str] = {}
+        try:
+            root = ET.fromstring(response.content)
+            for article in root.findall(".//PubmedArticle"):
+                pmid_el = article.find(".//PMID")
+                if pmid_el is None or not pmid_el.text:
+                    continue
+                parts = [
+                    "".join(el.itertext()).strip()
+                    for el in article.findall(".//Abstract/AbstractText")
+                ]
+                abstracts[pmid_el.text] = " ".join(p for p in parts if p)
+        except ET.ParseError as exc:
+            logger.warning("pubmed: failed to parse efetch abstracts XML: %s", exc)
+        return abstracts
+
+
+def _parse_summary(pmid: str, summary: dict, abstract: str) -> Optional[PaperMetadata]:
+    try:
+        title = (summary.get("title") or "").strip()
+        if not title:
+            return None
+
+        authors = [a.get("name", "").strip() for a in summary.get("authors", []) if a.get("name")]
+
+        doi = None
+        for article_id in summary.get("articleids", []):
+            if article_id.get("idtype") == "doi":
+                doi = article_id.get("value")
+                break
+
+        journal = summary.get("fulljournalname") or summary.get("source") or ""
+        published_date = _normalize_pubdate(summary.get("pubdate", ""))
+
+        return PaperMetadata(
+            title=title,
+            authors=authors,
+            abstract=abstract,
+            source="pubmed",
+            url=f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
+            pdf_url=None,
+            published_date=published_date,
+            doi=doi,
+            journal=journal,
+            volume=summary.get("volume") or None,
+            issue=summary.get("issue") or None,
+            pages=summary.get("pages") or None,
+            arxiv_id=None,
+            connected_papers_url=None,
+        )
+    except Exception as exc:
+        logger.error("Failed to parse PubMed entry %s: %s", pmid, exc)
+        return None
+
+
+_MONTHS = {
+    m: f"{i:02d}"
+    for i, m in enumerate(
+        ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+        start=1,
+    )
+}
+
+
+def _normalize_pubdate(pubdate: str) -> Optional[str]:
+    """PubMed's `pubdate` is free-form ("2026 Jul", "2026 Jul 15", "2026") --
+    normalize to YYYY-MM-DD/YYYY-MM/YYYY, matching the other sources'
+    published_date shape, rather than passing NCBI's raw display string
+    through unchanged."""
+    if not pubdate:
+        return None
+    parts = pubdate.split()
+    year = parts[0]
+    if not year.isdigit():
+        return pubdate
+    if len(parts) == 1:
+        return year
+    month = _MONTHS.get(parts[1])
+    if month is None:
+        return year
+    if len(parts) == 2:
+        return f"{year}-{month}"
+    day = parts[2].zfill(2) if parts[2].isdigit() else None
+    return f"{year}-{month}-{day}" if day else f"{year}-{month}"

--- a/prisma/integrations/sources/semantic_scholar.py
+++ b/prisma/integrations/sources/semantic_scholar.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Optional
 from urllib.parse import quote
 
 import requests
 
 from ...services.rate_limiter import RateLimiter
 from ...storage.models.agent_models import PaperMetadata
+from ...storage.models.api_response_models import SemanticScholarPaper
 from .base import Source, SourceSearchResult
 
 logger = logging.getLogger(__name__)
@@ -63,11 +64,20 @@ class SemanticScholarSource(Source):
 
             response = requests.get(url, params=params, headers=self._headers, timeout=30)
             response.raise_for_status()
-            data = response.json()
+            raw_items = response.json().get("data", [])
 
             papers = []
-            for paper_item in data.get("data", []):
-                paper = _parse_paper(paper_item)
+            for raw_item in raw_items:
+                # One malformed item shouldn't drop the whole response --
+                # validated per-item, same resilience the old raw-dict
+                # parsing had, but now with real field validation instead of
+                # bare .get() calls.
+                try:
+                    validated = SemanticScholarPaper.model_validate(raw_item)
+                    paper = _to_paper_metadata(validated)
+                except Exception as exc:
+                    logger.debug("Semantic Scholar item failed to parse, skipping: %s", exc)
+                    continue
                 if paper:
                     papers.append(paper)
             return SourceSearchResult(papers=papers)
@@ -76,45 +86,29 @@ class SemanticScholarSource(Source):
             return SourceSearchResult()
 
 
-def _parse_paper(paper_data: Dict) -> Optional[PaperMetadata]:
-    try:
-        title = paper_data.get("title", "").strip()
-        if not title:
-            return None
-
-        abstract = paper_data.get("abstract", "") or ""
-
-        authors = []
-        for author in paper_data.get("authors", []):
-            if isinstance(author, dict) and "name" in author:
-                authors.append(author["name"])
-            elif isinstance(author, str):
-                authors.append(author)
-
-        venue = paper_data.get("venue") or ""
-        year = paper_data.get("year")
-        doi = paper_data.get("doi")
-        paper_id = paper_data.get("paperId", "")
-
-        paper_url = paper_data.get("url") or f"https://www.semanticscholar.org/paper/{paper_id}"
-        published_date = f"{year}-01-01" if year else None
-
-        return PaperMetadata(
-            title=title,
-            authors=authors,
-            abstract=abstract,
-            source="semanticscholar",
-            url=paper_url,
-            pdf_url=None,  # Semantic Scholar doesn't provide direct PDF URLs
-            published_date=published_date,
-            doi=doi,
-            journal=venue,
-            volume=None,
-            issue=None,
-            pages=None,
-            arxiv_id=None,
-            connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(title)}",
-        )
-    except Exception as exc:
-        logger.error("Failed to parse Semantic Scholar entry: %s", exc)
+def _to_paper_metadata(paper: SemanticScholarPaper) -> Optional[PaperMetadata]:
+    title = paper.title.strip()
+    if not title:
         return None
+
+    authors = [a.name for a in paper.authors if a.name]
+    venue = paper.venue or ""
+    paper_url = paper.url or f"https://www.semanticscholar.org/paper/{paper.paperId}"
+    published_date = f"{paper.year}-01-01" if paper.year else None
+
+    return PaperMetadata(
+        title=title,
+        authors=authors,
+        abstract=paper.abstract or "",
+        source="semanticscholar",
+        url=paper_url,
+        pdf_url=None,  # Semantic Scholar doesn't provide direct PDF URLs
+        published_date=published_date,
+        doi=paper.doi,
+        journal=venue,
+        volume=None,
+        issue=None,
+        pages=None,
+        arxiv_id=None,
+        connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(title)}",
+    )

--- a/prisma/integrations/sources/semantic_scholar.py
+++ b/prisma/integrations/sources/semantic_scholar.py
@@ -1,0 +1,120 @@
+"""Semantic Scholar discovery source -- Academic Graph API.
+
+Rate limit is genuinely ambiguous in Semantic Scholar's own published docs
+(some pages say 5000 req/5min shared across all unauthenticated users,
+others say 1000 req/s shared) -- default to a conservative 1 req/s either
+way. An API key doesn't raise that per-second number, it just moves you off
+the shared anonymous pool onto a guaranteed-not-throttled-by-others one, so
+`requests_per_second` doesn't change with a key here, only the `x-api-key`
+header gets added.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Dict, Optional
+from urllib.parse import quote
+
+import requests
+
+from ...services.rate_limiter import RateLimiter
+from ...storage.models.agent_models import PaperMetadata
+from .base import Source, SourceSearchResult
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.semanticscholar.org/graph/v1"
+_PROBE_URL = f"{_BASE_URL}/paper/search?query=test&limit=1"
+
+
+class SemanticScholarSource(Source):
+    name = "semanticscholar"
+
+    def __init__(self, requests_per_second: float = 1.0, api_key: Optional[str] = None):
+        self._limiter = RateLimiter(requests_per_second=requests_per_second)
+        self._headers = {"x-api-key": api_key} if api_key else {}
+
+    def probe(self, timeout: float = 5.0) -> bool:
+        if not self._limiter.acquire(timeout=timeout):
+            return False
+        try:
+            r = requests.get(_PROBE_URL, headers=self._headers, timeout=timeout)
+            return r.status_code < 500
+        except Exception as exc:
+            logger.warning("semanticscholar probe failed: %s", exc)
+            return False
+
+    def search(
+        self, query: str, limit: int, published_after: Optional[datetime] = None
+    ) -> SourceSearchResult:
+        if not self._limiter.acquire(timeout=30.0):
+            logger.warning("semanticscholar: rate limit exhausted, skipping this search")
+            return SourceSearchResult()
+        try:
+            url = f"{_BASE_URL}/paper/search"
+            params: dict = {
+                "query": query,
+                "limit": min(limit, 100),
+                "fields": "paperId,title,abstract,authors,venue,year,doi,url",
+            }
+            if published_after is not None:
+                # Semantic Scholar only has year-level granularity
+                params["year"] = f"{published_after.year}-"
+
+            response = requests.get(url, params=params, headers=self._headers, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+
+            papers = []
+            for paper_item in data.get("data", []):
+                paper = _parse_paper(paper_item)
+                if paper:
+                    papers.append(paper)
+            return SourceSearchResult(papers=papers)
+        except Exception as exc:
+            logger.error("Semantic Scholar search failed: %s", exc)
+            return SourceSearchResult()
+
+
+def _parse_paper(paper_data: Dict) -> Optional[PaperMetadata]:
+    try:
+        title = paper_data.get("title", "").strip()
+        if not title:
+            return None
+
+        abstract = paper_data.get("abstract", "") or ""
+
+        authors = []
+        for author in paper_data.get("authors", []):
+            if isinstance(author, dict) and "name" in author:
+                authors.append(author["name"])
+            elif isinstance(author, str):
+                authors.append(author)
+
+        venue = paper_data.get("venue") or ""
+        year = paper_data.get("year")
+        doi = paper_data.get("doi")
+        paper_id = paper_data.get("paperId", "")
+
+        paper_url = paper_data.get("url") or f"https://www.semanticscholar.org/paper/{paper_id}"
+        published_date = f"{year}-01-01" if year else None
+
+        return PaperMetadata(
+            title=title,
+            authors=authors,
+            abstract=abstract,
+            source="semanticscholar",
+            url=paper_url,
+            pdf_url=None,  # Semantic Scholar doesn't provide direct PDF URLs
+            published_date=published_date,
+            doi=doi,
+            journal=venue,
+            volume=None,
+            issue=None,
+            pages=None,
+            arxiv_id=None,
+            connected_papers_url=f"https://www.connectedpapers.com/search?q={quote(title)}",
+        )
+    except Exception as exc:
+        logger.error("Failed to parse Semantic Scholar entry: %s", exc)
+        return None

--- a/prisma/services/rate_limiter.py
+++ b/prisma/services/rate_limiter.py
@@ -1,0 +1,85 @@
+"""Generic in-process rate limiter — not source-specific.
+
+Every source in `prisma/integrations/sources/` owns one instance of this,
+configured with that source's real published quota. This is intentionally
+NOT the supervisor's resource_lock.py/ResourceManager pattern (HTTP-based
+cross-process leasing for the GPU compute pools) — every caller of
+SearchAgent (coordinator.py, stream_runner.py, research_stream_manager.py)
+only ever runs inside the single `api` worker process, so there's no
+cross-process contention to arbitrate, only two same-process call paths
+(the background stream scheduler thread and on-demand API requests)
+sharing one quota. A thread-safe token bucket is sufficient and avoids
+the network round-trip and fail-open complexity the supervisor pattern
+needs for its harder problem.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime, timezone
+
+
+class RateLimiter:
+    """Token-bucket rate limiter with an optional hard daily cap.
+
+    `requests_per_second` refills the bucket continuously (burst capacity
+    is always 1 — sources here are called in a simple sequential loop, not
+    bursts, so smoothing to a steady rate is what matches each API's real
+    published guidance). `daily_cap`, if set, is a separate hard ceiling
+    tracked by UTC calendar day — for quotas like Google Books' 10,000
+    requests/day, where waiting for a fresh token would mean waiting up to
+    a whole day, so a denial should surface immediately instead of via a
+    long block.
+    """
+
+    def __init__(self, requests_per_second: float, daily_cap: int | None = None):
+        if requests_per_second <= 0:
+            raise ValueError("requests_per_second must be > 0")
+        self._interval = 1.0 / requests_per_second
+        self._daily_cap = daily_cap
+
+        self._lock = threading.Lock()
+        self._next_allowed = time.monotonic()
+
+        self._day: str | None = None
+        self._day_count = 0
+
+    def _daily_cap_available(self) -> bool:
+        """Must be called with self._lock held. Returns False only when
+        daily_cap is set and already exhausted for the current UTC day —
+        otherwise increments today's counter and returns True."""
+        if self._daily_cap is None:
+            return True
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        if today != self._day:
+            self._day = today
+            self._day_count = 0
+        if self._day_count >= self._daily_cap:
+            return False
+        self._day_count += 1
+        return True
+
+    def acquire(self, timeout: float = 30.0) -> bool:
+        """Blocks until a token is free or `timeout` seconds elapse.
+        Returns False immediately (no waiting) if the daily cap is already
+        exhausted — waiting for a day-boundary reset is never the right
+        behavior for a caller. Returns False if `timeout` elapses first.
+        Callers should treat False the same as a failed/unreachable source
+        today: log a warning and skip it for this search, not raise."""
+        deadline = time.monotonic() + timeout
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                if now >= self._next_allowed:
+                    # Only consume daily budget once we're actually about to
+                    # grant — checking it on every retry-loop iteration would
+                    # double-consume it for a single logical acquire() call.
+                    if not self._daily_cap_available():
+                        return False
+                    self._next_allowed = now + self._interval
+                    return True
+                wait = self._next_allowed - now
+            remaining = deadline - time.monotonic()
+            if wait > remaining:
+                return False
+            time.sleep(min(wait, remaining))

--- a/prisma/storage/models/api_response_models.py
+++ b/prisma/storage/models/api_response_models.py
@@ -71,6 +71,7 @@ class SemanticScholarPaper(BaseModel):
     influentialCitationCount: Optional[int] = Field(None, description="Influential citation count")
     isOpenAccess: Optional[bool] = Field(None, description="Open access status")
     openAccessPdf: Optional[Dict[str, str]] = Field(None, description="Open access PDF info")
+    doi: Optional[str] = Field(None, description="Digital Object Identifier")
     
     @field_validator('title')
     @classmethod
@@ -104,6 +105,7 @@ class GoogleBooksVolumeInfo(BaseModel):
     language: Optional[str] = Field(None, description="Language")
     previewLink: Optional[str] = Field(None, description="Preview link")
     infoLink: Optional[str] = Field(None, description="Info link")
+    imageLinks: Optional[Dict[str, str]] = Field(None, description="Cover image links (thumbnail, smallThumbnail)")
 
 
 class GoogleBooksItem(BaseModel):
@@ -155,6 +157,72 @@ class ArXivEntry(BaseModel):
     def validate_summary(cls, v):
         """Clean and validate summary"""
         return v.strip().replace('\n', ' ') if v else ""
+
+
+class PubMedArticleId(BaseModel):
+    """One entry in a PubMed esummary article's `articleids` list (pubmed, doi, pmc, etc.)"""
+    model_config = ConfigDict(populate_by_name=True)
+
+    idtype: str = Field(..., description="ID type: pubmed, doi, pmc, etc.")
+    value: str = Field(..., description="The identifier value")
+
+
+class PubMedAuthor(BaseModel):
+    """PubMed esummary author entry"""
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field("", description="Author display name, e.g. 'Smith J'")
+
+
+class PubMedSummaryResult(BaseModel):
+    """One article's esummary.fcgi (db=pubmed, version=2.0) JSON result --
+    validated before parsing so a shape change in NCBI's response surfaces
+    as a clear validation error instead of a silently-empty/wrong field."""
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    uid: str = Field(..., description="PubMed ID (PMID)")
+    title: str = Field("", description="Article title")
+    authors: List[PubMedAuthor] = Field(default_factory=list)
+    source: str = Field("", description="Abbreviated journal name")
+    fulljournalname: Optional[str] = Field(None, description="Full journal name")
+    pubdate: str = Field("", description="Free-form publication date, e.g. '2026 Jul 15'")
+    volume: Optional[str] = Field(None)
+    issue: Optional[str] = Field(None)
+    pages: Optional[str] = Field(None)
+    articleids: List[PubMedArticleId] = Field(default_factory=list)
+
+
+class IEEEXploreArticle(BaseModel):
+    """One article from IEEE Xplore's Metadata API
+    (https://developer.ieee.org/docs/read/Metadata_API_responses).
+    UNVERIFIED against a real API response as of 2026-07-29 -- field names
+    come from IEEE's own published docs, not a live call (no API key
+    available yet); correct this model once real responses can be checked."""
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    title: str = Field("")
+    abstract: Optional[str] = Field(None)
+    authors: Optional[Any] = Field(None, description="Either {'authors': [...]} or a flat list -- shape unconfirmed")
+    doi: Optional[str] = Field(None)
+    publication_title: Optional[str] = Field(None)
+    publication_year: Optional[int] = Field(None)
+    publication_date: Optional[str] = Field(None)
+    volume: Optional[str] = Field(None)
+    issue: Optional[str] = Field(None)
+    start_page: Optional[str] = Field(None)
+    end_page: Optional[str] = Field(None)
+    article_number: Optional[int] = Field(None)
+    html_url: Optional[str] = Field(None)
+    pdf_url: Optional[str] = Field(None)
+
+
+class IEEEXploreSearchResponse(BaseModel):
+    """Top-level IEEE Xplore Metadata API search response."""
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    totalfound: int = Field(0)
+    totalsearched: int = Field(0)
+    articles: List[IEEEXploreArticle] = Field(default_factory=list)
 
 
 class LLMRelevanceResult(BaseModel):

--- a/prisma/storage/models/source_quality.py
+++ b/prisma/storage/models/source_quality.py
@@ -67,12 +67,12 @@ class AcademicValidationCriteria(BaseModel):
 SOURCE_REGISTRY: Dict[str, SourceMetadata] = {
     
     # ⭐⭐⭐⭐⭐ FIVE STAR SOURCES
-    "semantic_scholar": SourceMetadata(
+    "semanticscholar": SourceMetadata(
         name="Semantic Scholar",
         quality=SourceQuality.FIVE_STAR,
         access_method="api",
         requires_llm=False,
-        rate_limits="1000 req/sec public, higher with API key",
+        rate_limits="~1 req/s conservative default (public docs conflict: cited anywhere from 5000 req/5min to 1000 req/s on the shared anonymous pool); 1 req/s guaranteed (not shared) with a free API key",
         content_types=["papers", "citations", "authors"],
         description="AI-powered academic search with curated content and rich metadata",
         strengths=[
@@ -111,6 +111,26 @@ SOURCE_REGISTRY: Dict[str, SourceMetadata] = {
         ]
     ),
     
+    "pubmed": SourceMetadata(
+        name="PubMed",
+        quality=SourceQuality.FIVE_STAR,
+        access_method="api",
+        requires_llm=False,
+        rate_limits="3 req/s without a key, 10 req/s with a free NCBI account API key",
+        content_types=["papers", "biomedical_literature"],
+        description="NCBI's biomedical and life-sciences literature database, via the E-utilities API",
+        strengths=[
+            "Free, official NCBI API with well-documented endpoints",
+            "Authoritative for biomedical/clinical/life-sciences literature",
+            "Structured metadata (esummary) plus full abstract text (efetch)",
+            "DOI, journal, and author information"
+        ],
+        limitations=[
+            "Biomedical/life-sciences focus, not general-purpose",
+            "Three separate API calls per search (esearch/esummary/efetch)"
+        ]
+    ),
+
     # ⭐⭐⭐⭐ FOUR STAR SOURCES
     "openlibrary": SourceMetadata(
         name="Open Library",
@@ -156,6 +176,27 @@ SOURCE_REGISTRY: Dict[str, SourceMetadata] = {
         ]
     ),
     
+    "ieee_xplore": SourceMetadata(
+        name="IEEE Xplore",
+        quality=SourceQuality.FOUR_STAR,
+        access_method="api",
+        requires_llm=False,
+        rate_limits="Unverified as of 2026-07-29 -- IEEE publishes no rate limit or daily quota anywhere in their docs; a conservative provisional default (0.5 req/s, no daily cap) is used until a registered key's real API user guide arrives",
+        content_types=["papers", "conference_papers", "standards"],
+        description="IEEE's engineering/CS literature database, via the Metadata API",
+        strengths=[
+            "Structured JSON API with rich metadata (DOI, venue, volume/issue/pages)",
+            "Strong coverage of engineering and computer science",
+            "Covers journals, conference papers, and standards"
+        ],
+        limitations=[
+            "API key required for every request -- no anonymous mode at all",
+            "Real rate limit/daily quota not publicly documented -- current default is a guess, not verified",
+            "Max 200 records per query",
+            "Full text is paywalled outside open-access articles"
+        ]
+    ),
+
     # ⭐⭐⭐ THREE STAR SOURCES
     "zotero": SourceMetadata(
         name="Zotero Local Database",
@@ -179,73 +220,6 @@ SOURCE_REGISTRY: Dict[str, SourceMetadata] = {
         ]
     ),
     
-    # ⭐⭐ TWO STAR SOURCES  
-    "academia_rss": SourceMetadata(
-        name="Academia.edu RSS Feeds",
-        quality=SourceQuality.TWO_STAR,
-        access_method="rss",
-        requires_llm=True,
-        rate_limits="Respectful scraping needed",
-        content_types=["papers", "theses", "presentations"],
-        description="Individual researcher RSS feeds from Academia.edu",
-        strengths=[
-            "Real-time updates from researchers",
-            "XML structure easier to parse",
-            "Academic social network content"
-        ],
-        limitations=[
-            "Requires knowing specific usernames",
-            "Limited metadata in RSS",
-            "Need LLM to extract details",
-            "Individual feeds only"
-        ]
-    ),
-    
-    # ⭐ ONE STAR SOURCES
-    "academia_search": SourceMetadata(
-        name="Academia.edu Search",
-        quality=SourceQuality.ONE_STAR,
-        access_method="html_scraping",
-        requires_llm=True,
-        rate_limits="Very limited, anti-bot measures",
-        content_types=["papers", "theses", "presentations"],
-        description="Direct HTML scraping of Academia.edu search results",
-        strengths=[
-            "Large repository of academic content",
-            "Theses and conference presentations",
-            "International academic content"
-        ],
-        limitations=[
-            "No API, only HTML scraping",
-            "Anti-bot measures and CAPTCHAs",
-            "Requires LLM for data extraction",
-            "Rate limiting and blocking risks",
-            "HTML structure changes frequently"
-        ]
-    ),
-    
-    "researchgate": SourceMetadata(
-        name="ResearchGate",
-        quality=SourceQuality.ONE_STAR,
-        access_method="html_scraping",
-        requires_llm=True,
-        rate_limits="Aggressive anti-scraping",
-        content_types=["papers", "preprints", "datasets"],
-        description="Academic social network requiring HTML scraping",
-        strengths=[
-            "Large academic community",
-            "Pre-publication papers",
-            "Researcher networking data",
-            "Research datasets"
-        ],
-        limitations=[
-            "No public API",
-            "Strong anti-scraping measures",
-            "Requires authentication",
-            "Legal and ToS concerns",
-            "Complex HTML structure"
-        ]
-    )
 }
 
 

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -7,7 +7,7 @@ import os
 import tomllib
 import logging
 from pathlib import Path
-from typing import Any, Optional, List
+from typing import Any, Dict, Optional, List
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 logger = logging.getLogger(__name__)
@@ -184,6 +184,47 @@ class OutputConfig(BaseModel):
         return v
 
 
+class SourceQuotaConfig(BaseModel):
+    """Per-source quota/API-key override for one entry in
+    SearchConfig.source_overrides. Any field left unset falls back to that
+    source module's own hardcoded, web-verified default (see
+    prisma/integrations/sources/) -- so zero config is required for any
+    source to work out of the box; this only matters once you have a real
+    API key (raises a source's rate limit) or want to tune a limit
+    yourself. Same api_key/api_key_env resolver pattern as ZoteroConfig
+    above -- api_key_env takes priority, keeps the real secret out of this
+    file."""
+    model_config = ConfigDict(extra="ignore")
+
+    requests_per_second: Optional[float] = Field(
+        None, gt=0, description="Override this source's rate limit (requests/second)"
+    )
+    daily_cap: Optional[int] = Field(
+        None, ge=1, description="Override this source's hard daily request cap"
+    )
+    api_key: Optional[str] = Field(None, description="API key -- prefer api_key_env instead")
+    api_key_env: Optional[str] = Field(
+        None,
+        description="Env var holding the API key -- takes priority over api_key when set, same pattern as ZoteroConfig.api_key_env",
+    )
+
+    def resolve_api_key(self, source_name: str = "") -> Optional[str]:
+        """Same fail-loud contract as ZoteroConfig.resolve_api_key(): if
+        api_key_env is set but the env var isn't, raise rather than
+        silently falling back to None/an unauthenticated request.
+        `source_name` is only used to make the error message point at the
+        right [sources.*] block."""
+        if self.api_key_env:
+            key = os.environ.get(self.api_key_env)
+            if not key:
+                label = f"sources.{source_name}" if source_name else "a source"
+                raise RuntimeError(
+                    f"{label}.api_key_env={self.api_key_env!r} is set but not present in the environment"
+                )
+            return key
+        return self.api_key
+
+
 class SearchConfig(BaseModel):
     """Search configuration"""
     model_config = ConfigDict(extra="ignore")
@@ -196,11 +237,19 @@ class SearchConfig(BaseModel):
     min_confidence_score: float = Field(0.5, ge=0.0, le=1.0)
     prefer_high_quality: bool = Field(True)
     require_academic_validation: bool = Field(True)
+    source_overrides: Dict[str, SourceQuotaConfig] = Field(
+        default_factory=dict,
+        description=(
+            "Per-source quota/API-key overrides, keyed by source name "
+            "(e.g. 'pubmed', 'ieee_xplore', 'semanticscholar', 'googlebooks'). "
+            "Sources not listed here use their module's built-in defaults."
+        ),
+    )
 
     @field_validator('sources')
     @classmethod
     def validate_sources(cls, v):
-        valid_sources = ['arxiv', 'zotero', 'pubmed', 'google_scholar', 'semanticscholar', 'openlibrary', 'googlebooks', 'academia']
+        valid_sources = ['arxiv', 'zotero', 'pubmed', 'google_scholar', 'semanticscholar', 'openlibrary', 'googlebooks', 'ieee_xplore']
         for source in v:
             if source not in valid_sources:
                 raise ValueError(f'source "{source}" not in valid sources: {valid_sources}')

--- a/tests/unit/agents/test_search_agent.py
+++ b/tests/unit/agents/test_search_agent.py
@@ -22,11 +22,11 @@ class TestSearchAgent(unittest.TestCase):
         self.search_agent = SearchAgent()
     
     def test_initialization(self):
-        """Test SearchAgent initializes correctly."""
-        self.assertIsNotNone(self.search_agent.arxiv_base_url)
-        self.assertEqual(self.search_agent.arxiv_base_url, "http://export.arxiv.org/api/query")
-    
-    @patch('prisma.agents.search_agent.requests.get')
+        """Test SearchAgent builds its source registry correctly."""
+        expected = {"arxiv", "semanticscholar", "openlibrary", "googlebooks", "pubmed", "ieee_xplore"}
+        self.assertEqual(self.search_agent.available_sources, expected)
+
+    @patch('prisma.integrations.sources.arxiv.requests.get')
     def test_search_success(self, mock_get):
         """Test successful search operation."""
         # Mock response

--- a/tests/unit/integrations/sources/test_arxiv.py
+++ b/tests/unit/integrations/sources/test_arxiv.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, patch
+
+from prisma.integrations.sources.arxiv import ArxivSource
+
+_ATOM_FEED = b'''<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://arxiv.org/abs/test.123</id>
+    <title>A Sufficiently Long Test Paper Title About Machine Learning</title>
+    <summary>This is a long enough abstract to pass the minimum length validation criteria used elsewhere in the pipeline for academic content.</summary>
+    <published>2024-01-01T00:00:00Z</published>
+    <author><name>Test Author</name></author>
+  </entry>
+</feed>'''
+
+
+@patch("prisma.integrations.sources.arxiv.requests.get")
+def test_search_parses_entries(mock_get):
+    mock_response = MagicMock(status_code=200, content=_ATOM_FEED)
+    mock_get.return_value = mock_response
+
+    source = ArxivSource()
+    result = source.search("machine learning", limit=1)
+
+    assert len(result.papers) == 1
+    paper = result.papers[0]
+    assert paper.arxiv_id == "test.123"
+    assert paper.source == "arxiv"
+    assert paper.journal == "arXiv"  # so centralized validation sees a venue
+    assert result.books == []
+
+
+@patch("prisma.integrations.sources.arxiv.requests.get")
+def test_search_returns_empty_on_http_error(mock_get):
+    mock_get.side_effect = Exception("network down")
+    source = ArxivSource()
+    result = source.search("test", limit=1)
+    assert result.papers == []
+    assert result.books == []
+
+
+@patch("prisma.integrations.sources.arxiv.requests.get")
+def test_rate_limiter_denial_skips_the_call(mock_get):
+    source = ArxivSource()
+    source._limiter.acquire = MagicMock(return_value=False)
+    result = source.search("test", limit=1)
+    assert result.papers == []
+    mock_get.assert_not_called()

--- a/tests/unit/integrations/sources/test_googlebooks.py
+++ b/tests/unit/integrations/sources/test_googlebooks.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock, patch
+
+from prisma.integrations.sources.googlebooks import GoogleBooksSource
+
+_RESPONSE = {
+    "items": [
+        {
+            "volumeInfo": {
+                "title": "Deep Learning",
+                "authors": ["Ian Goodfellow"],
+                "description": "A textbook.",
+                "industryIdentifiers": [
+                    {"type": "ISBN_10", "identifier": "0262035618"},
+                    {"type": "ISBN_13", "identifier": "9780262035613"},
+                ],
+                "publisher": "MIT Press",
+                "publishedDate": "2016",
+                "categories": ["Computers"],
+                "pageCount": 800,
+                "language": "en",
+                "infoLink": "https://books.google.com/books?id=x",
+                "imageLinks": {"thumbnail": "https://books.google.com/thumb.jpg"},
+            }
+        }
+    ]
+}
+
+
+@patch("prisma.integrations.sources.googlebooks.requests.get")
+def test_search_parses_items(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: _RESPONSE)
+    source = GoogleBooksSource()
+
+    result = source.search("deep learning", limit=1)
+
+    assert len(result.books) == 1
+    book = result.books[0]
+    assert book.isbn_13 == "9780262035613"
+    assert book.cover_url == "https://books.google.com/thumb.jpg"
+
+
+@patch("prisma.integrations.sources.googlebooks.requests.get")
+def test_api_key_added_to_params(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {"items": []})
+    source = GoogleBooksSource(api_key="secret")
+
+    source.search("query", limit=1)
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"]["key"] == "secret"
+
+
+def test_daily_cap_exhausted_skips_request():
+    source = GoogleBooksSource(daily_cap=1)
+    source._limiter.acquire = MagicMock(side_effect=[True, False])
+
+    with patch("prisma.integrations.sources.googlebooks.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"items": []})
+        source.search("q1", limit=1)
+        result = source.search("q2", limit=1)
+
+    assert result.books == []
+    assert mock_get.call_count == 1

--- a/tests/unit/integrations/sources/test_googlebooks.py
+++ b/tests/unit/integrations/sources/test_googlebooks.py
@@ -5,6 +5,7 @@ from prisma.integrations.sources.googlebooks import GoogleBooksSource
 _RESPONSE = {
     "items": [
         {
+            "id": "abc123XYZ",
             "volumeInfo": {
                 "title": "Deep Learning",
                 "authors": ["Ian Goodfellow"],

--- a/tests/unit/integrations/sources/test_ieee_xplore.py
+++ b/tests/unit/integrations/sources/test_ieee_xplore.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+from prisma.integrations.sources.ieee_xplore import IEEEXploreSource, _parse_article
+
+_FAKE_ARTICLE = {
+    "title": "A Sufficiently Long Test Paper Title About Robotics",
+    "authors": {"authors": [{"full_name": "Jane Doe"}, {"full_name": "John Smith"}]},
+    "abstract": "A long enough abstract to pass validation elsewhere in the pipeline for real.",
+    "doi": "10.1109/TEST.2026.1234567",
+    "publication_title": "IEEE Transactions on Testing",
+    "publication_year": 2026,
+    "volume": "5",
+    "issue": "2",
+    "start_page": "10",
+    "end_page": "20",
+    "article_number": 9999999,
+    "pdf_url": None,
+}
+
+
+def test_no_api_key_skips_entirely_without_network():
+    source = IEEEXploreSource()  # no key
+    with patch("prisma.integrations.sources.ieee_xplore.requests.get") as mock_get:
+        result = source.search("robotics", limit=3)
+    assert result.papers == []
+    mock_get.assert_not_called()
+
+
+def test_no_api_key_fails_probe():
+    source = IEEEXploreSource()
+    assert source.probe() is False
+
+
+@patch("prisma.integrations.sources.ieee_xplore.requests.get")
+def test_search_with_key_parses_articles(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {"articles": [_FAKE_ARTICLE]})
+    source = IEEEXploreSource(api_key="secret")
+
+    result = source.search("robotics", limit=3)
+
+    assert len(result.papers) == 1
+    paper = result.papers[0]
+    assert paper.authors == ["Jane Doe", "John Smith"]
+    assert paper.pages == "10-20"
+    assert paper.url == "https://ieeexplore.ieee.org/document/9999999"
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"]["apikey"] == "secret"
+
+
+def test_parse_article_flat_authors_list():
+    article = dict(_FAKE_ARTICLE, authors=["Solo Author"])
+    paper = _parse_article(article)
+    assert paper.authors == ["Solo Author"]
+
+
+def test_parse_article_missing_title_returns_none():
+    assert _parse_article({"title": ""}) is None
+
+
+def test_parse_article_no_url_returns_none():
+    article = dict(_FAKE_ARTICLE)
+    article.pop("article_number")
+    article["html_url"] = None
+    assert _parse_article(article) is None

--- a/tests/unit/integrations/sources/test_ieee_xplore.py
+++ b/tests/unit/integrations/sources/test_ieee_xplore.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
-from prisma.integrations.sources.ieee_xplore import IEEEXploreSource, _parse_article
+from prisma.integrations.sources.ieee_xplore import IEEEXploreSource, _to_paper_metadata
+from prisma.storage.models.api_response_models import IEEEXploreArticle
 
 _FAKE_ARTICLE = {
     "title": "A Sufficiently Long Test Paper Title About Robotics",
@@ -49,17 +50,19 @@ def test_search_with_key_parses_articles(mock_get):
 
 
 def test_parse_article_flat_authors_list():
-    article = dict(_FAKE_ARTICLE, authors=["Solo Author"])
-    paper = _parse_article(article)
+    article = IEEEXploreArticle.model_validate(dict(_FAKE_ARTICLE, authors=["Solo Author"]))
+    paper = _to_paper_metadata(article)
     assert paper.authors == ["Solo Author"]
 
 
 def test_parse_article_missing_title_returns_none():
-    assert _parse_article({"title": ""}) is None
+    article = IEEEXploreArticle.model_validate({"title": ""})
+    assert _to_paper_metadata(article) is None
 
 
 def test_parse_article_no_url_returns_none():
-    article = dict(_FAKE_ARTICLE)
-    article.pop("article_number")
-    article["html_url"] = None
-    assert _parse_article(article) is None
+    raw = dict(_FAKE_ARTICLE)
+    raw.pop("article_number")
+    raw["html_url"] = None
+    article = IEEEXploreArticle.model_validate(raw)
+    assert _to_paper_metadata(article) is None

--- a/tests/unit/integrations/sources/test_openlibrary.py
+++ b/tests/unit/integrations/sources/test_openlibrary.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+from prisma.integrations.sources.openlibrary import OpenLibrarySource
+
+_RESPONSE = {
+    "start": 0,
+    "num_found": 1,
+    "docs": [
+        {
+            "title": "Deep Learning",
+            "author_name": ["Ian Goodfellow"],
+            "first_publish_year": 2016,
+            "isbn": ["0262035618", "9780262035613"],
+            "key": "/works/OL123W",
+            "publisher": ["MIT Press"],
+            "language": ["eng"],
+            "subject": ["Machine learning", "Neural networks"],
+        }
+    ],
+}
+
+
+@patch("prisma.integrations.sources.openlibrary.requests.get")
+def test_search_parses_docs(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: _RESPONSE)
+    source = OpenLibrarySource()
+
+    result = source.search("deep learning", limit=1)
+
+    assert len(result.books) == 1
+    book = result.books[0]
+    assert book.title == "Deep Learning"
+    assert book.isbn_10 == "0262035618"
+    assert book.isbn_13 == "9780262035613"
+    # Regression test: doc is a Pydantic model, not a dict -- a prior bug
+    # called doc.get('language', ...) here, which raised AttributeError on
+    # every single document and silently returned zero books in
+    # production. This must read the real field, not raise.
+    assert book.language == "eng"
+
+
+@patch("prisma.integrations.sources.openlibrary.requests.get")
+def test_sends_identifying_user_agent(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {"start": 0, "num_found": 0, "docs": []})
+    source = OpenLibrarySource()
+
+    source.search("query", limit=1)
+
+    _, kwargs = mock_get.call_args
+    assert "User-Agent" in kwargs["headers"]
+
+
+@patch("prisma.integrations.sources.openlibrary.requests.get")
+def test_doc_with_no_language_returns_none(mock_get):
+    docs = dict(_RESPONSE)
+    docs["docs"] = [{**_RESPONSE["docs"][0], "language": []}]
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: docs)
+    source = OpenLibrarySource()
+
+    result = source.search("deep learning", limit=1)
+
+    assert result.books[0].language is None

--- a/tests/unit/integrations/sources/test_pubmed.py
+++ b/tests/unit/integrations/sources/test_pubmed.py
@@ -1,0 +1,91 @@
+from unittest.mock import MagicMock, patch
+
+from prisma.integrations.sources.pubmed import PubMedSource, _normalize_pubdate
+
+_ESEARCH_RESPONSE = {"esearchresult": {"idlist": ["111"]}}
+_ESUMMARY_RESPONSE = {
+    "result": {
+        "uids": ["111"],
+        "111": {
+            "uid": "111",
+            "title": "A Sufficiently Long Test Paper Title About Genomics",
+            "authors": [{"name": "Jane Doe"}],
+            "fulljournalname": "Journal of Testing",
+            "source": "J Test",
+            "pubdate": "2026 Jul 15",
+            "volume": "5",
+            "issue": "2",
+            "pages": "10-20",
+            "articleids": [{"idtype": "doi", "value": "10.1234/test"}],
+        },
+    }
+}
+_EFETCH_XML = b"""<?xml version="1.0"?>
+<PubmedArticleSet>
+<PubmedArticle><MedlineCitation><PMID>111</PMID>
+<Article><Abstract><AbstractText>This is a long enough abstract to pass validation elsewhere in the pipeline for real.</AbstractText></Abstract></Article>
+</MedlineCitation></PubmedArticle>
+</PubmedArticleSet>"""
+
+
+def _mock_response(json_data=None, content=None):
+    m = MagicMock(status_code=200)
+    if json_data is not None:
+        m.json = lambda: json_data
+    if content is not None:
+        m.content = content
+    return m
+
+
+@patch("prisma.integrations.sources.pubmed.requests.get")
+def test_search_makes_three_calls_and_parses(mock_get):
+    mock_get.side_effect = [
+        _mock_response(json_data=_ESEARCH_RESPONSE),
+        _mock_response(json_data=_ESUMMARY_RESPONSE),
+        _mock_response(content=_EFETCH_XML),
+    ]
+    source = PubMedSource()
+
+    result = source.search("genomics", limit=3)
+
+    assert mock_get.call_count == 3
+    assert len(result.papers) == 1
+    paper = result.papers[0]
+    assert paper.doi == "10.1234/test"
+    assert paper.journal == "Journal of Testing"
+    assert paper.published_date == "2026-07-15"
+    assert "long enough abstract" in paper.abstract
+
+
+@patch("prisma.integrations.sources.pubmed.requests.get")
+def test_empty_esearch_short_circuits(mock_get):
+    mock_get.return_value = _mock_response(json_data={"esearchresult": {"idlist": []}})
+    source = PubMedSource()
+
+    result = source.search("nothing matches this", limit=3)
+
+    assert result.papers == []
+    assert mock_get.call_count == 1  # esummary/efetch never called
+
+
+@patch("prisma.integrations.sources.pubmed.requests.get")
+def test_api_key_added_to_every_call(mock_get):
+    mock_get.side_effect = [
+        _mock_response(json_data=_ESEARCH_RESPONSE),
+        _mock_response(json_data=_ESUMMARY_RESPONSE),
+        _mock_response(content=_EFETCH_XML),
+    ]
+    source = PubMedSource(api_key="secret")
+
+    source.search("genomics", limit=3)
+
+    for call in mock_get.call_args_list:
+        assert call.kwargs["params"]["api_key"] == "secret"
+
+
+def test_normalize_pubdate_variants():
+    assert _normalize_pubdate("2026") == "2026"
+    assert _normalize_pubdate("2026 Jul") == "2026-07"
+    assert _normalize_pubdate("2026 Jul 15") == "2026-07-15"
+    assert _normalize_pubdate("") is None
+    assert _normalize_pubdate("2026 Unknown 15") == "2026"

--- a/tests/unit/integrations/sources/test_registry.py
+++ b/tests/unit/integrations/sources/test_registry.py
@@ -1,0 +1,32 @@
+"""Consistency checks across the three places a source name has to agree:
+build_sources()'s registry, SOURCE_REGISTRY (quality metadata), and
+SearchConfig.valid_sources. A mismatch here silently degrades a source to
+the ONE_STAR default quality (get_source_quality's fallback) instead of
+raising -- this is exactly the class of bug the semanticscholar/
+semantic_scholar naming mismatch was (fixed 2026-07-29)."""
+
+from prisma.integrations.sources import build_sources
+from prisma.storage.models.source_quality import SOURCE_REGISTRY, SourceQuality, get_source_quality
+from prisma.utils.config import SearchConfig
+
+
+def test_every_built_source_name_matches_its_registry_key():
+    sources = build_sources()
+    for key, source in sources.items():
+        assert key == source.name
+
+
+def test_every_built_source_has_real_quality_metadata():
+    """Regression test for the semantic_scholar/semanticscholar mismatch:
+    every source actually wired into SearchAgent must resolve to its real
+    SOURCE_REGISTRY entry, not silently fall back to ONE_STAR."""
+    sources = build_sources()
+    for name in sources:
+        assert name in SOURCE_REGISTRY, f"{name!r} has no SOURCE_REGISTRY entry"
+        assert get_source_quality(name) != SourceQuality.ONE_STAR or SOURCE_REGISTRY[name].quality == SourceQuality.ONE_STAR
+
+
+def test_every_built_source_name_is_config_valid():
+    sources = build_sources()
+    config = SearchConfig(sources=list(sources.keys()))  # raises if any name is rejected
+    assert set(config.sources) == set(sources.keys())

--- a/tests/unit/integrations/sources/test_semantic_scholar.py
+++ b/tests/unit/integrations/sources/test_semantic_scholar.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock, patch
+
+from prisma.integrations.sources.semantic_scholar import SemanticScholarSource
+
+_RESPONSE = {
+    "data": [
+        {
+            "paperId": "abc123",
+            "title": "A Sufficiently Long Test Paper Title About Deep Learning",
+            "abstract": "This is a long enough abstract to pass the minimum length validation criteria used elsewhere in the pipeline.",
+            "authors": [{"name": "Jane Doe"}],
+            "venue": "NeurIPS",
+            "year": 2024,
+            "doi": "10.1234/abc",
+            "url": "https://www.semanticscholar.org/paper/abc123",
+        }
+    ]
+}
+
+
+@patch("prisma.integrations.sources.semantic_scholar.requests.get")
+def test_search_parses_papers(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: _RESPONSE)
+    source = SemanticScholarSource()
+
+    result = source.search("deep learning", limit=1)
+
+    assert len(result.papers) == 1
+    paper = result.papers[0]
+    assert paper.doi == "10.1234/abc"
+    assert paper.journal == "NeurIPS"
+    assert paper.source == "semanticscholar"
+
+
+@patch("prisma.integrations.sources.semantic_scholar.requests.get")
+def test_api_key_sets_header(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {"data": []})
+    source = SemanticScholarSource(api_key="secret-key")
+
+    source.search("query", limit=1)
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["headers"] == {"x-api-key": "secret-key"}
+
+
+@patch("prisma.integrations.sources.semantic_scholar.requests.get")
+def test_no_key_sends_no_auth_header(mock_get):
+    mock_get.return_value = MagicMock(status_code=200, json=lambda: {"data": []})
+    source = SemanticScholarSource()
+
+    source.search("query", limit=1)
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["headers"] == {}

--- a/tests/unit/services/test_rate_limiter.py
+++ b/tests/unit/services/test_rate_limiter.py
@@ -1,0 +1,72 @@
+"""Unit tests for the generic token-bucket RateLimiter -- no network."""
+
+import threading
+import time
+
+import pytest
+
+from prisma.services.rate_limiter import RateLimiter
+
+
+def test_rejects_non_positive_rate():
+    with pytest.raises(ValueError):
+        RateLimiter(requests_per_second=0)
+    with pytest.raises(ValueError):
+        RateLimiter(requests_per_second=-1)
+
+
+def test_smooths_to_configured_rate():
+    limiter = RateLimiter(requests_per_second=20)  # 1 token per 0.05s
+    start = time.monotonic()
+    for _ in range(5):
+        assert limiter.acquire(timeout=1.0)
+    elapsed = time.monotonic() - start
+    # 5 tokens at 20/s: first is immediate, remaining 4 spaced 0.05s apart
+    assert 0.15 <= elapsed <= 0.35
+
+
+def test_timeout_denies_when_bucket_empty():
+    limiter = RateLimiter(requests_per_second=1)
+    assert limiter.acquire(timeout=0.1)  # first token free
+    assert not limiter.acquire(timeout=0.05)  # next isn't due for ~1s
+
+
+def test_daily_cap_denies_immediately_without_waiting():
+    limiter = RateLimiter(requests_per_second=1000, daily_cap=2)
+    assert limiter.acquire(timeout=0.5)
+    assert limiter.acquire(timeout=0.5)
+    start = time.monotonic()
+    assert not limiter.acquire(timeout=5.0)
+    # Denial must be immediate, not after waiting out most of the timeout --
+    # waiting for a day-boundary reset is never the right behavior.
+    assert time.monotonic() - start < 0.5
+
+
+def test_daily_cap_not_double_consumed_by_retry_loop():
+    """Regression test: a call that has to wait for the per-second
+    interval (not the daily cap) must only consume one unit of daily
+    budget for that one logical acquire(), even though it internally
+    loops/retries while waiting."""
+    limiter = RateLimiter(requests_per_second=50, daily_cap=3)
+    for _ in range(3):
+        assert limiter.acquire(timeout=1.0)
+    assert not limiter.acquire(timeout=0.1)
+
+
+def test_thread_safe_under_concurrent_callers():
+    limiter = RateLimiter(requests_per_second=100)
+    granted = []
+    lock = threading.Lock()
+
+    def worker():
+        if limiter.acquire(timeout=3.0):
+            with lock:
+                granted.append(1)
+
+    threads = [threading.Thread(target=worker) for _ in range(30)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(granted) == 30


### PR DESCRIPTION
## Summary
- `SearchAgent`'s monolithic if/elif dispatch + per-source fetch/parse methods move into `prisma/integrations/sources/` — one module per source, each implementing a `Source` interface and owning its own `RateLimiter` (thread-safe token bucket, `prisma/services/rate_limiter.py`).
- Adds **PubMed** and **IEEE Xplore** as new sources (IEEE requires the user's own API key; its real rate limit is unverified and uses a conservative provisional default).
- Drops Academia.edu/RSS, ResearchGate, and their aspirational `SOURCE_REGISTRY` entries — no reliable API for any of them.
- Config-driven per-source quota/API-key overrides (`[search.source_overrides.<name>]` in `config.toml`), zero config required by default.
- Centralizes academic-content validation in `SearchAgent` (previously only arxiv/semanticscholar validated inline, each hardcoding `SourceQuality.FIVE_STAR`) — now applied uniformly to every paper source at its real quality rating.

## Bugs found and fixed along the way
- **OpenLibrary silently returned zero books, always.** Its parser called `doc.get(...)` on a Pydantic model with no `.get()` method — `AttributeError` on every result, swallowed by a broad `except`. Confirmed live before/after (0 books → 5 books for the same query).
- **`semantic_scholar`/`semanticscholar` key mismatch** in `SOURCE_REGISTRY` silently degraded Semantic Scholar to the lowest quality tier instead of its real 5-star rating, affecting both search order and confidence scoring.

## Test plan
- [x] `python3 -m py_compile` on every changed/new file
- [x] `pytest tests/ -q` — 695 passed, 24 skipped (was 664 before this branch)
- [x] New tests: `tests/unit/services/test_rate_limiter.py`, `tests/unit/integrations/sources/test_*.py` (7 files, mocked HTTP), including a registry-consistency test guarding against the semanticscholar-style key-mismatch bug recurring
- [x] Live smoke test: arxiv, openlibrary, pubmed, and full `SearchAgent.search()` end-to-end against real APIs — confirmed working. semanticscholar/googlebooks hit real anonymous-tier 429s from repeated testing this session (not a code bug); verified via mocked unit tests instead.
- [x] Diagrams regenerated (`docs/diagrams/gen.sh`) — no diff, this change doesn't affect the diagrammed subsystems