### PR TITLE
Consolidate asset-URL rewriting into prisma/services/asset_rewrite.py

### DIFF
--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -28,7 +28,8 @@ prisma/                        # repo root
 │   │   ├── dedup.py               # Shared duplicate-detection logic (stream_runner + /maintenance/deduplicate)
 │   │   ├── knowledge_graph_service.py  # Native Kùzu-backed knowledge graph indexer (watchdog + Ollama, per-section) — runs inside kg_app.py
 │   │   ├── knowledge_graph_client.py   # Thin HTTP client app.py uses to reach kg_app.py
-│   │   └── chroma_service.py      # ChromaDB semantic index (watchdog + nomic-embed-text)
+│   │   ├── chroma_service.py      # ChromaDB semantic index (watchdog + nomic-embed-text)
+│   │   └── asset_rewrite.py       # Rewrites relative asset URLs to /vault/assets/... (used by notes/view routes)
 │   ├── storage/
 │   │   ├── models/
 │   │   │   ├── agent_models.py          # PaperMetadata, BookMetadata, SearchResult

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -57,6 +57,7 @@ _t("vault ok")
 
 _t("importing renderer")
 from prisma.services.renderer import render as vault_render
+from prisma.services.asset_rewrite import asset_prefix, rewrite_html
 _t("renderer ok")
 
 _t("importing knowledge_graph_client")
@@ -1406,21 +1407,10 @@ def get_note(slug: str, request: Request, format: str = "html"):
             has_md = bool(_vault.get_md_body(html_path))
 
         if format == "md" and html_path is not None and has_md:
-            import re as _re
             md_body = _vault.get_md_body(html_path) or ""
             html, broken_links, broken_citations = vault_render(md_body, _vault)
-            try:
-                html_dir = html_path.parent.relative_to(_vault.root)
-                base = str(html_dir).replace("\\", "/").rstrip("/")
-                prefix = f"{request.base_url}vault/assets/{base}/" if base else f"{request.base_url}vault/assets/"
-                _ASSET_EXT = r'\.(?:png|jpg|jpeg|gif|webp|svg|ico|woff2?|ttf|eot|css|js|map)'
-                html = _re.sub(
-                    rf'(?<![:\w])(src)="(?!\s*(?:https?|data|javascript):|//|#|/)([^"]+{_ASSET_EXT})"',
-                    lambda mo: f'{mo.group(1)}="{prefix}{mo.group(2)}"',
-                    html,
-                )
-            except ValueError:
-                pass
+            prefix = asset_prefix(_vault.root, html_path, str(request.base_url))
+            html = rewrite_html(html, prefix, mode="markdown")
             original_ext = None  # render as plain markdown, no iframe
         else:
             import re as _re
@@ -1430,17 +1420,8 @@ def get_note(slug: str, request: Request, format: str = "html"):
             m = _re.search(r"<body[^>]*>(.*?)</body>", body, _re.DOTALL | _re.IGNORECASE)
             html = (styles + "\n" + m.group(1).strip()) if m else body
             if html_path is not None:
-                try:
-                    html_dir = html_path.parent.relative_to(_vault.root)
-                    base = str(html_dir).replace("\\", "/").rstrip("/")
-                    prefix = f"{request.base_url}vault/assets/{base}/" if base else f"{request.base_url}vault/assets/"
-                    html = _re.sub(
-                        r'(?<![:\w])(src|href)="(?!\s*(?:https?|data|javascript|mailto|tel):|//|#|/)([^"]+)"',
-                        lambda mo: f'{mo.group(1)}="{prefix}{mo.group(2)}"',
-                        html,
-                    )
-                except ValueError:
-                    pass
+                prefix = asset_prefix(_vault.root, html_path, str(request.base_url))
+                html = rewrite_html(html, prefix, mode="fragment")
             broken_links, broken_citations = [], []
     else:
         html, broken_links, broken_citations = vault_render(body, _vault)
@@ -1499,58 +1480,8 @@ def view_html(slug: str, request: Request):
     if path is None:
         raise HTTPException(status_code=404, detail=f"no HTML file for {slug!r}")
     body = path.read_text(encoding="utf-8")
-    try:
-        html_dir = path.parent.relative_to(_vault.root)
-        base = str(html_dir).replace("\\", "/").rstrip("/")
-        prefix = f"{request.base_url}vault/assets/{base}/" if base else f"{request.base_url}vault/assets/"
-    except ValueError:
-        prefix = str(request.base_url) + "vault/assets/"
-    import re as _re
-
-    _ABS = r'(?:https?|data|javascript|mailto|tel):|//'
-    _SKIP = rf'(?!\s*(?:{_ABS}|#|/))'
-
-    def _rewrite(val: str) -> str:
-        if _re.match(rf'\s*(?:{_ABS}|#|/)', val):
-            return val
-        return prefix + val
-
-    # 1. WebKitGTK resolves xlink:href="data:..." as a relative URL — convert to SVG 2 href.
-    body = _re.sub(r'xlink:href="(data:[^"]*)"', r'href="\1"', body)
-
-    # 2. Standard HTML attributes: src, href, action, poster, data (object)
-    body = _re.sub(
-        rf'(?<![:\w])(src|href|action|poster|data)="{_SKIP}([^"]*)"',
-        lambda m: f'{m.group(1)}="{_rewrite(m.group(2))}"',
-        body,
-    )
-
-    # 3. srcset — comma-separated list of "url [descriptor]" entries
-    def _rewrite_srcset(m: _re.Match) -> str:
-        parts = []
-        for entry in m.group(1).split(","):
-            entry = entry.strip()
-            if not entry:
-                continue
-            tokens = entry.split()
-            tokens[0] = _rewrite(tokens[0])
-            parts.append(" ".join(tokens))
-        return f'srcset="{", ".join(parts)}"'
-    body = _re.sub(r'srcset="([^"]*)"', _rewrite_srcset, body)
-
-    # 4. CSS url() — covers both inline styles and <style> blocks
-    body = _re.sub(
-        rf"""url\(\s*(['"]?){_SKIP}([^'"\)]+)\1\s*\)""",
-        lambda m: f'url({m.group(1)}{_rewrite(m.group(2))}{m.group(1)})',
-        body,
-    )
-
-    # 5. JSON string values that are relative file paths (e.g. in data-* attributes or inline JS)
-    body = _re.sub(
-        rf'"({_SKIP}[^"]+\.(?:png|jpg|jpeg|gif|webp|svg|woff2?|ttf|eot|css|js))"',
-        lambda m: f'"{_rewrite(m.group(1))}"',
-        body,
-    )
+    prefix = asset_prefix(_vault.root, path, str(request.base_url))
+    body = rewrite_html(body, prefix, mode="full")
     interceptor = (
         "<script>"
         "document.addEventListener('click',function(e){"

--- a/prisma/services/asset_rewrite.py
+++ b/prisma/services/asset_rewrite.py
@@ -1,0 +1,102 @@
+"""Rewrites relative asset references (src/href/srcset/CSS url()/etc.) in
+vault-served HTML to absolute /vault/assets/... URLs, so the browser can
+fetch them regardless of which route rendered the HTML. Pure string
+transforms, no FastAPI Request dependency, so it's unit-testable without
+spinning up routes.
+
+Previously duplicated three times in prisma/server/app.py (get_note's two
+.html branches, view_html), each independently recomputing the same
+prefix and covering a different subset of attributes -- only view_html
+handled srcset, CSS url(), JSON string literals, and the WebKitGTK
+xlink:href fixup. Consolidated here; each caller picks the `mode` that
+matches what it renders.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Literal, Match
+
+_ABS = r'(?:https?|data|javascript|mailto|tel):|//'
+_SKIP = rf'(?!\s*(?:{_ABS}|#|/))'
+_ASSET_EXT = r'\.(?:png|jpg|jpeg|gif|webp|svg|ico|woff2?|ttf|eot|css|js|map)'
+
+
+def asset_prefix(vault_root: Path, file_path: Path, base_url: str) -> str:
+    """Absolute URL prefix for assets that sit alongside *file_path* in the
+    vault, e.g. "http://host:port/vault/assets/sub/dir/". Falls back to the
+    vault-root prefix if *file_path* isn't actually under *vault_root*."""
+    try:
+        rel_dir = file_path.parent.relative_to(vault_root)
+        base = "" if rel_dir == Path(".") else str(rel_dir).replace("\\", "/").rstrip("/")
+    except ValueError:
+        base = ""
+    return f"{base_url}vault/assets/{base}/" if base else f"{base_url}vault/assets/"
+
+
+def _rewrite_value(val: str, prefix: str) -> str:
+    if re.match(rf'\s*(?:{_ABS}|#|/)', val):
+        return val
+    return prefix + val
+
+
+def rewrite_html(html: str, prefix: str, *, mode: Literal["full", "fragment", "markdown"] = "full") -> str:
+    """Rewrite relative asset references in *html* to absolute URLs under
+    *prefix*. `mode` picks how much rewriting is applied:
+
+    - "markdown": markdown rendered via vault_render() -- only <img src>
+      (or similar) ever appears with a relative, asset-extension value;
+      everything else vault_render already emits fully-qualified.
+    - "fragment": an extracted <body>/<style> fragment from a companion
+      .html node -- src/href, no extension filter.
+    - "full" (default): a complete standalone .html document served to an
+      iframe -- src/href/action/poster/data, srcset, CSS url(), JSON
+      string literals, and the WebKitGTK xlink:href="data:..." fixup.
+    """
+    if mode == "markdown":
+        return re.sub(
+            rf'(?<![:\w])(src)="{_SKIP}([^"]+{_ASSET_EXT})"',
+            lambda mo: f'{mo.group(1)}="{prefix}{mo.group(2)}"',
+            html,
+        )
+
+    if mode == "fragment":
+        return re.sub(
+            rf'(?<![:\w])(src|href)="{_SKIP}([^"]*)"',
+            lambda mo: f'{mo.group(1)}="{prefix}{mo.group(2)}"',
+            html,
+        )
+
+    # mode == "full"
+    html = re.sub(r'xlink:href="(data:[^"]*)"', r'href="\1"', html)
+
+    html = re.sub(
+        rf'(?<![:\w])(src|href|action|poster|data)="{_SKIP}([^"]*)"',
+        lambda m: f'{m.group(1)}="{_rewrite_value(m.group(2), prefix)}"',
+        html,
+    )
+
+    def _rewrite_srcset(m: Match) -> str:
+        parts = []
+        for entry in m.group(1).split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            tokens = entry.split()
+            tokens[0] = _rewrite_value(tokens[0], prefix)
+            parts.append(" ".join(tokens))
+        return f'srcset="{", ".join(parts)}"'
+    html = re.sub(r'srcset="([^"]*)"', _rewrite_srcset, html)
+
+    html = re.sub(
+        rf"""url\(\s*(['"]?){_SKIP}([^'"\)]+)\1\s*\)""",
+        lambda m: f'url({m.group(1)}{_rewrite_value(m.group(2), prefix)}{m.group(1)})',
+        html,
+    )
+
+    html = re.sub(
+        rf'"({_SKIP}[^"]+\.(?:png|jpg|jpeg|gif|webp|svg|woff2?|ttf|eot|css|js))"',
+        lambda m: f'"{_rewrite_value(m.group(1), prefix)}"',
+        html,
+    )
+    return html

--- a/tests/unit/services/test_asset_rewrite.py
+++ b/tests/unit/services/test_asset_rewrite.py
@@ -1,0 +1,100 @@
+"""Unit tests for prisma.services.asset_rewrite — asset_prefix and rewrite_html.
+
+Previously this rewriting logic lived inline in three FastAPI route
+handlers (get_note's two .html branches, view_html) and could only be
+exercised through a full HTTP request. Extracting it to pure functions
+makes it directly testable, closing that coverage gap.
+"""
+from pathlib import Path
+
+from prisma.services.asset_rewrite import asset_prefix, rewrite_html
+
+
+class TestAssetPrefix:
+    def test_nested_subdir(self):
+        root = Path("/vault")
+        file_path = root / "sources" / "paper.html"
+        assert asset_prefix(root, file_path, "http://host:8765/") == "http://host:8765/vault/assets/sources/"
+
+    def test_file_directly_in_root(self):
+        root = Path("/vault")
+        file_path = root / "paper.html"
+        assert asset_prefix(root, file_path, "http://host:8765/") == "http://host:8765/vault/assets/"
+
+    def test_file_not_under_root_falls_back_to_root_prefix(self):
+        root = Path("/vault")
+        file_path = Path("/elsewhere/paper.html")
+        assert asset_prefix(root, file_path, "http://host:8765/") == "http://host:8765/vault/assets/"
+
+
+class TestRewriteHtmlMarkdownMode:
+    def test_rewrites_relative_asset_extension_src(self):
+        html = '<img src="figure1.png">'
+        out = rewrite_html(html, "http://h/vault/assets/sub/", mode="markdown")
+        assert out == '<img src="http://h/vault/assets/sub/figure1.png">'
+
+    def test_leaves_non_asset_extension_src_untouched(self):
+        html = '<img src="figure1.pdf">'
+        out = rewrite_html(html, "http://h/vault/assets/sub/", mode="markdown")
+        assert out == html
+
+    def test_leaves_absolute_and_data_urls_untouched(self):
+        html = '<img src="https://example.com/a.png"><img src="data:image/png;base64,xx.png">'
+        out = rewrite_html(html, "http://h/vault/assets/sub/", mode="markdown")
+        assert out == html
+
+    def test_leaves_root_relative_untouched(self):
+        html = '<img src="/already/absolute/path.png">'
+        out = rewrite_html(html, "http://h/vault/assets/sub/", mode="markdown")
+        assert out == html
+
+
+class TestRewriteHtmlFragmentMode:
+    def test_rewrites_src_and_href_regardless_of_extension(self):
+        html = '<img src="figure1.png"><a href="notes.html">link</a>'
+        out = rewrite_html(html, "http://h/vault/assets/sub/", mode="fragment")
+        assert out == (
+            '<img src="http://h/vault/assets/sub/figure1.png">'
+            '<a href="http://h/vault/assets/sub/notes.html">link</a>'
+        )
+
+    def test_skips_mailto_and_tel(self):
+        html = '<a href="mailto:a@b.com">mail</a><a href="tel:+123">call</a>'
+        out = rewrite_html(html, "http://h/vault/assets/sub/", mode="fragment")
+        assert out == html
+
+
+class TestRewriteHtmlFullMode:
+    def test_rewrites_standard_attributes(self):
+        html = '<img src="a.png"><a href="b.html"><form action="c"><video poster="d.jpg"><object data="e.svg">'
+        out = rewrite_html(html, "http://h/vault/assets/", mode="full")
+        assert 'src="http://h/vault/assets/a.png"' in out
+        assert 'href="http://h/vault/assets/b.html"' in out
+        assert 'action="http://h/vault/assets/c"' in out
+        assert 'poster="http://h/vault/assets/d.jpg"' in out
+        assert 'data="http://h/vault/assets/e.svg"' in out
+
+    def test_rewrites_srcset_each_entry_keeping_descriptors(self):
+        html = '<img srcset="a.png 1x, sub/b.png 2x">'
+        out = rewrite_html(html, "http://h/vault/assets/", mode="full")
+        assert out == '<img srcset="http://h/vault/assets/a.png 1x, http://h/vault/assets/sub/b.png 2x">'
+
+    def test_rewrites_css_url(self):
+        html = '<style>.x { background: url(bg.png); }</style>'
+        out = rewrite_html(html, "http://h/vault/assets/", mode="full")
+        assert 'url(http://h/vault/assets/bg.png)' in out
+
+    def test_rewrites_json_string_asset_paths(self):
+        html = '<script>var x = {"icon": "icon.svg"};</script>'
+        out = rewrite_html(html, "http://h/vault/assets/", mode="full")
+        assert '"icon": "http://h/vault/assets/icon.svg"' in out
+
+    def test_webkitgtk_xlink_href_data_fixup(self):
+        html = '<image xlink:href="data:image/png;base64,xx"/>'
+        out = rewrite_html(html, "http://h/vault/assets/", mode="full")
+        assert out == '<image href="data:image/png;base64,xx"/>'
+
+    def test_leaves_absolute_urls_untouched(self):
+        html = '<a href="https://example.com/x"><img src="//cdn.example.com/y.png">'
+        out = rewrite_html(html, "http://h/vault/assets/", mode="full")
+        assert out == html


### PR DESCRIPTION
## Summary
- `get_note`'s two `.html` branches and `view_html` each independently recomputed the same vault-relative asset prefix and rewrote a different subset of HTML -- only `view_html` covered `srcset`, CSS `url()`, JSON string literals, and the WebKitGTK `xlink:href="data:..."` fixup. Three diverged answers to one question, none testable without a FastAPI `Request`.
- Extracted to `prisma/services/asset_rewrite.py`: `asset_prefix()` + `rewrite_html()` (pure functions, `mode="markdown"|"fragment"|"full"` matching each caller's actual output shape).
- Fixed a real bug the new tests caught: when a file sits directly in the vault root, `relative_to()` returns `Path(".")`, which is truthy, so the old prefix ended up as `.../assets/./` instead of `.../assets/` in all three original call sites.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F2).

## Test plan
- [x] `pytest tests/unit -q` -- 677 passed (15 new tests for `asset_rewrite.py`, previously zero coverage on this logic)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs