### PR TITLE
Route AnalysisAgent through ChatLLM instead of hand-rolled LLM transport

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -79,6 +79,9 @@ require_academic_validation = true  # Apply academic content filters
 provider = "ollama"
 model = "llama3.1:8b"
 host = "localhost:11434"  # LLM service host
+# pool = "local-ollama"   # compute_pools entry to lease from; if provider = "openrouter", set this
+                           # explicitly to a dedicated pool -- otherwise a cloud call can be auto-routed
+                           # onto a model_affinity'd local-GPU pool and start denying real local calls
 
 # Chat module (ADR-014: backend-agnostic — ollama today, openrouter/anthropic-capable)
 [chat]

--- a/prisma/agents/analysis_agent.py
+++ b/prisma/agents/analysis_agent.py
@@ -3,36 +3,26 @@ Analysis Agent - Analyzes and summarizes academic papers using LLM.
 """
 
 import logging
-import requests
 import threading
-from typing import Dict, List, Any
+from typing import List
 from datetime import datetime
 import time
 
 from ..utils.config import config
 from ..storage.models.agent_models import PaperMetadata, PaperSummary, AnalysisResult
-from ..storage.models.api_response_models import OllamaGenerateResponse, LLMRelevanceResult, LLMIdentityResult
+from ..storage.models.api_response_models import LLMRelevanceResult, LLMIdentityResult
 from ..services import resource_lock
+from ..services.chat_llm import ChatLLM
 
 _ollama_log = logging.getLogger("prisma.ollama")
 
+_CONFIDENCE_MAP = {"HIGH": 0.9, "MEDIUM": 0.6, "LOW": 0.3}
 
-class _NormalizedResponse:
-    """Duck-types the slice of requests.Response this module's callers
-    actually use (.status_code, .json()) — lets _call_ollama_generate return
-    a uniform Ollama-native-shaped payload ({"response": ...}, parseable by
-    OllamaGenerateResponse) regardless of which backend actually served the
-    call, so no downstream call site needs to know or care which provider
-    answered."""
 
-    def __init__(self, status_code: int, payload: dict) -> None:
-        self.status_code = status_code
-        self._payload = payload
-
-    def json(self) -> dict:
-        return self._payload
-
-_RESOURCE_HOLDER = "api"  # must match the worker name supervisor.py restarts, so a crash releases our leases
+def _parse_confidence(token: str) -> float:
+    """Maps the LLM's HIGH/MEDIUM/LOW confidence label to a float, matching
+    a mid-range 0.5 for anything unrecognized rather than failing."""
+    return _CONFIDENCE_MAP.get(token.strip().upper(), 0.5)
 
 
 class AnalysisAgent:
@@ -40,100 +30,66 @@ class AnalysisAgent:
 
     def __init__(self, supervisor_host: str = "127.0.0.1", supervisor_port: int | None = None):
         self.llm_config = config.get_llm_config()
-        self.base_url = self.llm_config.base_url
         self.model = self.llm_config.model
         self._inference_sem = threading.Semaphore(self.llm_config.max_concurrent_inferences)
-        self._supervisor_host = supervisor_host
-        self._supervisor_port = supervisor_port if supervisor_port is not None else resource_lock.default_port()
+        supervisor_port = supervisor_port if supervisor_port is not None else resource_lock.default_port()
+        self._chat_llm = ChatLLM.from_llm_config(
+            self.llm_config, priority="background",
+            supervisor_host=supervisor_host, supervisor_port=supervisor_port,
+        )
 
-    def _call_ollama_generate(
-        self, prompt: str, options: dict, timeout: float
-    ) -> "requests.Response | _NormalizedResponse | None":
-        """Single choke point for every LLM completion call in this agent
-        (Ollama's native /api/generate, or llama.cpp's OpenAI-compatible
-        /v1/chat/completions — provider from llm.provider in config).
-
-        Wraps the supervisor's compute-pool lease (ADR-012) around the existing
-        process-local concurrency semaphore, so this agent can't run concurrently
-        against the same GPU/LLM backend as Graphify or ChromaDB indexing.
-        Returns None if no compute pool is free right now — callers should
-        treat that the same as any other LLM failure. Always returns
-        something exposing .status_code/.json() shaped like Ollama's
-        {"response": ...} payload (see _NormalizedResponse) — callers don't
-        need their own provider branch.
+    def _call_llm(self, prompt: str, *, temperature: float, max_tokens: int, timeout: float) -> str | None:
+        """Single choke point for every LLM completion call in this agent,
+        via the shared ChatLLM abstraction (ADR-014) -- provider-agnostic
+        (ollama/llama_cpp/openrouter all just work through the openai SDK's
+        base_url swap), resource_lock-gated with background priority so
+        this agent's bulk work never queues ahead of a live chat request.
+        The process-local semaphore layers on top of ChatLLM's own
+        cross-process lease, preserving this agent's existing concurrency
+        cap for its own calls specifically.
         """
-        with resource_lock.lease(
-            self._supervisor_host, self._supervisor_port, holder=_RESOURCE_HOLDER, model=self.model,
-        ) as granted:
-            if not granted:
-                return None
-            with self._inference_sem:
-                if self.llm_config.provider == "llama_cpp":
-                    resp = requests.post(
-                        f"{self.base_url}/v1/chat/completions",
-                        json={
-                            "model": self.model,
-                            "messages": [{"role": "user", "content": prompt}],
-                            "temperature": options.get("temperature", 0.7),
-                            "max_tokens": options.get("num_predict"),
-                        },
-                        timeout=timeout,
-                    )
-                    if resp.status_code != 200:
-                        return _NormalizedResponse(resp.status_code, {})
-                    content = resp.json()["choices"][0]["message"]["content"]
-                    # OllamaGenerateResponse requires model/created_at/done —
-                    # synthesize them; llama.cpp's OpenAI-compatible response
-                    # has no equivalents (Ollama-specific fields, not part of
-                    # the shape being translated from).
-                    return _NormalizedResponse(resp.status_code, {
-                        "model": self.model,
-                        "created_at": datetime.utcnow().isoformat() + "Z",
-                        "response": content,
-                        "done": True,
-                    })
-                return requests.post(
-                    f"{self.base_url}/api/generate",
-                    json={"model": self.model, "prompt": prompt, "stream": False, "options": options},
-                    timeout=timeout,
-                )
-    
+        with self._inference_sem:
+            return self._chat_llm.complete(
+                [{"role": "user", "content": prompt}],
+                temperature=temperature, max_tokens=max_tokens, timeout=timeout,
+            )
+
     def analyze(self, papers: List[PaperMetadata]) -> AnalysisResult:
         """
         Analyze papers and generate summaries.
-        
+
         Args:
             papers: List of paper metadata from SearchAgent
-            
+
         Returns:
             AnalysisResult with summaries and metadata
         """
         summaries = []
         processing_times = []
-        
+
         for paper in papers:
             start_time = time.time()
             summary = self._summarize_paper(paper)
             processing_time = time.time() - start_time
-            
+
             processing_times.append(processing_time)
             summaries.append(summary)
-        
+
         # Extract unique authors
         all_authors = []
         for paper in papers:
             all_authors.extend(paper.authors)
         unique_authors = list(set(all_authors))
-        
+
         # Calculate average processing time
         avg_processing_time = sum(processing_times) / len(processing_times) if processing_times else 0
-        
+
         # Generate top authors (most frequent)
         author_counts = {}
         for author in all_authors:
             author_counts[author] = author_counts.get(author, 0) + 1
         top_authors = sorted(author_counts.keys(), key=lambda x: author_counts[x], reverse=True)[:10]
-        
+
         return AnalysisResult(
             summaries=summaries,
             author_count=len(unique_authors),
@@ -143,29 +99,29 @@ class AnalysisAgent:
             top_authors=top_authors,
             common_themes=[]  # TODO: Implement theme extraction
         )
-    
+
     def _summarize_paper(self, paper: PaperMetadata) -> PaperSummary:
         """
         Summarize a single paper using Ollama.
-        
+
         Args:
             paper: Paper metadata from SearchAgent
-            
+
         Returns:
             PaperSummary with key findings, methodology, results
         """
         start_time = time.time()
-        
+
         # Try to get enhanced summary from Ollama
         enhanced_summary = self._get_ollama_summary(paper.title, paper.abstract)
-        
+
         # Extract key findings and methodology
         summary_text = enhanced_summary or paper.abstract
         key_findings = self._extract_key_findings(summary_text)
         methodology = self._extract_methodology(summary_text)
-        
+
         processing_time = time.time() - start_time
-        
+
         return PaperSummary(
             title=paper.title,
             authors=paper.authors,
@@ -178,19 +134,15 @@ class AnalysisAgent:
             analysis_confidence=0.8 if enhanced_summary else 0.5,
             processing_time=processing_time
         )
-    
-    def _log_ollama(self, op: str, elapsed_ms: float, data: dict | None, error: str | None = None, **kw) -> None:
+
+    def _log_ollama(self, op: str, elapsed_ms: float, error: str | None = None, **kw) -> None:
         if error:
             _ollama_log.warning("op=%s model=%s elapsed_ms=%.0f error=%s", op, self.model, elapsed_ms, error)
             return
-        prompt_tokens = data.get("prompt_eval_count") if data else None
-        gen_tokens = data.get("eval_count") if data else None
         extra = " ".join(f"{k}={v}" for k, v in kw.items())
         _ollama_log.info(
-            "op=%s model=%s elapsed_ms=%.0f prompt_tokens=%s gen_tokens=%s%s",
-            op, self.model, elapsed_ms, prompt_tokens if prompt_tokens is not None else "?",
-            gen_tokens if gen_tokens is not None else "?",
-            f" {extra}" if extra else "",
+            "op=%s model=%s elapsed_ms=%.0f%s",
+            op, self.model, elapsed_ms, f" {extra}" if extra else "",
         )
 
     def _get_ollama_summary(self, title: str, abstract: str) -> str:
@@ -204,47 +156,41 @@ Provide a clear, academic summary focusing on the main contribution and signific
 
         t0 = time.monotonic()
         try:
-            response = self._call_ollama_generate(
-                prompt, options={"temperature": 0.3, "num_predict": 200}, timeout=30,
-            )
+            text = self._call_llm(prompt, temperature=0.3, max_tokens=200, timeout=30)
             elapsed_ms = (time.monotonic() - t0) * 1000
-            if response is not None and response.status_code == 200:
-                data = response.json()
-                self._log_ollama("summarize", elapsed_ms, data)
-                ollama_response = OllamaGenerateResponse.model_validate(data)
-                return ollama_response.response.strip()
-            else:
-                error = f"status={response.status_code}" if response is not None else "no compute lease available"
-                self._log_ollama("summarize", elapsed_ms, None, error=error)
-                return ""
+            if text is not None:
+                self._log_ollama("summarize", elapsed_ms)
+                return text.strip()
+            self._log_ollama("summarize", elapsed_ms, error="no answer from LLM")
+            return ""
         except Exception as e:
             elapsed_ms = (time.monotonic() - t0) * 1000
-            self._log_ollama("summarize", elapsed_ms, None, error=str(e))
+            self._log_ollama("summarize", elapsed_ms, error=str(e))
             return ""
-    
+
     def _extract_key_findings(self, text: str) -> List[str]:
         """Extract key findings from summary text."""
         # Simple extraction for MVP - could be enhanced with NLP
         if "findings" in text.lower() or "results" in text.lower():
             return [text.split('.')[0] + '.']
         return ['Key findings extracted from analysis']
-    
+
     def _extract_methodology(self, text: str) -> str:
         """Extract methodology information from summary text."""
         # Simple extraction for MVP - could be enhanced with NLP
         if "method" in text.lower() or "approach" in text.lower():
             return "Methodology identified in analysis"
         return "Methodology analysis from abstract"
-    
+
     def assess_relevance(self, paper_title: str, paper_abstract: str, topic: str) -> LLMRelevanceResult:
         """
         Assess if a paper is relevant to a topic using semantic understanding via LLM.
-        
+
         Args:
             paper_title: Title of the paper
             paper_abstract: Abstract of the paper
             topic: Research topic to assess relevance against
-            
+
         Returns:
             Dict with relevance assessment results
         """
@@ -270,30 +216,24 @@ RELEVANCE: [HIGHLY_RELEVANT/RELEVANT/SOMEWHAT_RELEVANT/NOT_RELEVANT]
 CONFIDENCE: [HIGH/MEDIUM/LOW]
 REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
 
-            response = self._call_ollama_generate(
-                prompt, options={"temperature": 0.3, "num_predict": 250}, timeout=45,
-            )
+            text = self._call_llm(prompt, temperature=0.3, max_tokens=250, timeout=45)
             elapsed_ms = (time.monotonic() - t0) * 1000
 
-            if response is not None and response.status_code == 200:
-                data = response.json()
-                self._log_ollama("assess_relevance", elapsed_ms, data)
-                result = data.get('response', '').strip()
-                return self._parse_semantic_relevance(result)
-            else:
-                status = response.status_code if response is not None else "no compute lease available"
-                self._log_ollama("assess_relevance", elapsed_ms, None, error=str(status))
-                return LLMRelevanceResult(
-                    is_relevant=False,
-                    relevance_level="UNKNOWN",
-                    confidence=0.0,
-                    reasoning=f"LLM request failed with status {status}",
-                    semantic_score=0.0
-                )
+            if text is not None:
+                self._log_ollama("assess_relevance", elapsed_ms)
+                return self._parse_semantic_relevance(text.strip())
+            self._log_ollama("assess_relevance", elapsed_ms, error="no answer from LLM")
+            return LLMRelevanceResult(
+                is_relevant=False,
+                relevance_level="UNKNOWN",
+                confidence=0.0,
+                reasoning="LLM request failed: no answer from LLM",
+                semantic_score=0.0
+            )
 
         except Exception as e:
             elapsed_ms = (time.monotonic() - t0) * 1000
-            self._log_ollama("assess_relevance", elapsed_ms, None, error=str(e))
+            self._log_ollama("assess_relevance", elapsed_ms, error=str(e))
             return LLMRelevanceResult(
                 is_relevant=False,
                 relevance_level="UNKNOWN",
@@ -301,7 +241,7 @@ REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
                 reasoning=f"Assessment failed due to error: {e}",
                 semantic_score=0.0
             )
-    
+
     def _parse_semantic_relevance(self, response: str) -> LLMRelevanceResult:
         """Parse LLM response for semantic relevance assessment."""
         try:
@@ -309,7 +249,7 @@ REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
             relevance_level = "NOT_RELEVANT"
             confidence = "LOW"
             reasoning = "Unable to parse reasoning"
-            
+
             for line in lines:
                 if line.startswith("RELEVANCE:"):
                     relevance_level = line.split(":", 1)[1].strip()
@@ -317,10 +257,10 @@ REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
                     confidence = line.split(":", 1)[1].strip()
                 elif line.startswith("REASONING:"):
                     reasoning = line.split(":", 1)[1].strip()
-            
+
             # Convert to boolean and numeric score
             is_relevant = relevance_level in ["HIGHLY_RELEVANT", "RELEVANT", "SOMEWHAT_RELEVANT"]
-            
+
             # Semantic score based on relevance level
             score_map = {
                 "HIGHLY_RELEVANT": 0.9,
@@ -329,13 +269,9 @@ REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
                 "NOT_RELEVANT": 0.1
             }
             semantic_score = score_map.get(relevance_level, 0.0)
-            
-            # Convert confidence to float
-            confidence_value = 0.5  # Default
-            if confidence.upper() in ["LOW", "MEDIUM", "HIGH"]:
-                confidence_map = {"LOW": 0.3, "MEDIUM": 0.6, "HIGH": 0.9}
-                confidence_value = confidence_map[confidence.upper()]
-            
+
+            confidence_value = _parse_confidence(confidence)
+
             return LLMRelevanceResult(
                 is_relevant=is_relevant,
                 relevance_level=relevance_level,
@@ -343,16 +279,16 @@ REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
                 reasoning=reasoning,
                 semantic_score=semantic_score
             )
-            
+
         except Exception as e:
             return LLMRelevanceResult(
                 is_relevant=False,
                 relevance_level="NOT_RELEVANT",
-                confidence=0.3, 
+                confidence=0.3,
                 reasoning=f"Failed to parse LLM response: {e}",
                 semantic_score=0.0
             )
-    
+
     _RELEVANCE_BATCH_SIZE = 50  # items per LLM call — stays within 7B context window
 
     def batch_relevance_check(
@@ -404,17 +340,13 @@ REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
 
         t0 = time.monotonic()
         try:
-            response = self._call_ollama_generate(
-                prompt, options={"temperature": 0.1, "num_predict": 60}, timeout=30,
-            )
+            text = self._call_llm(prompt, temperature=0.1, max_tokens=60, timeout=30)
             elapsed_ms = (time.monotonic() - t0) * 1000
-            if response is None or response.status_code != 200:
-                error = f"status={response.status_code}" if response is not None else "no compute lease available"
-                self._log_ollama("batch_relevance", elapsed_ms, None, error=error, n=len(candidates))
+            if text is None:
+                self._log_ollama("batch_relevance", elapsed_ms, error="no answer from LLM", n=len(candidates))
                 return [True] * len(candidates)
-            data = response.json()
-            self._log_ollama("batch_relevance", elapsed_ms, data, n=len(candidates))
-            text = data.get("response", "").strip().lower()
+            self._log_ollama("batch_relevance", elapsed_ms, n=len(candidates))
+            text = text.strip().lower()
             if "none" in text and not any(ch.isdigit() for ch in text):
                 return [False] * len(candidates)
             import re
@@ -422,7 +354,7 @@ REASONING: [2-3 sentences explaining the semantic connection or lack thereof]"""
             return [i + 1 in selected for i in range(len(candidates))]
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
-            self._log_ollama("batch_relevance", elapsed_ms, None, error=str(exc), n=len(candidates))
+            self._log_ollama("batch_relevance", elapsed_ms, error=str(exc), n=len(candidates))
             return [True] * len(candidates)
 
     _IDENTITY_THRESHOLD = 8  # candidates per incoming paper; above this, switch to parallel
@@ -481,20 +413,18 @@ Respond with exactly one line per candidate:
 
         t0 = time.monotonic()
         try:
-            response = self._call_ollama_generate(
-                prompt, options={"temperature": 0.1, "num_predict": 30 * len(candidates)}, timeout=10 + 15 * len(candidates),
+            text = self._call_llm(
+                prompt, temperature=0.1, max_tokens=30 * len(candidates), timeout=10 + 15 * len(candidates),
             )
             elapsed_ms = (time.monotonic() - t0) * 1000
-            if response is None or response.status_code != 200:
-                error = f"status={response.status_code}" if response is not None else "no compute lease available"
-                self._log_ollama("check_identity_batch", elapsed_ms, None, error=error, n=len(candidates))
+            if text is None:
+                self._log_ollama("check_identity_batch", elapsed_ms, error="no answer from LLM", n=len(candidates))
                 return [LLMIdentityResult(are_same=False, confidence=0.0, reason="LLM unavailable")] * len(candidates)
-            data = response.json()
-            self._log_ollama("check_identity_batch", elapsed_ms, data, n=len(candidates))
-            return self._parse_batch_response(data.get("response", "").strip(), len(candidates))
+            self._log_ollama("check_identity_batch", elapsed_ms, n=len(candidates))
+            return self._parse_batch_response(text.strip(), len(candidates))
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
-            self._log_ollama("check_identity_batch", elapsed_ms, None, error=str(exc), n=len(candidates))
+            self._log_ollama("check_identity_batch", elapsed_ms, error=str(exc), n=len(candidates))
             return [LLMIdentityResult(are_same=False, confidence=0.0, reason=f"error: {exc}")] * len(candidates)
 
     def _parse_batch_response(self, text: str, n: int) -> list[LLMIdentityResult]:
@@ -517,16 +447,13 @@ Respond with exactly one line per candidate:
         reason = ""
         if not line:
             return LLMIdentityResult(are_same=False, confidence=0.0, reason="no response")
-        upper = line.upper()
-        # Check for YES/NO after the colon
         after_colon = line.split(":", 1)[-1] if ":" in line else line
         are_same = "YES" in after_colon.upper().split("|")[0]
         parts = [p.strip() for p in after_colon.split("|")]
         for part in parts:
             pupper = part.upper()
             if pupper.startswith("CONFIDENCE:"):
-                val = part.split(":", 1)[1].strip().upper()
-                confidence = {"HIGH": 0.9, "MEDIUM": 0.6, "LOW": 0.3}.get(val, 0.5)
+                confidence = _parse_confidence(part.split(":", 1)[1])
             elif pupper.startswith("REASON:"):
                 reason = part.split(":", 1)[1].strip()
         return LLMIdentityResult(are_same=are_same, confidence=confidence, reason=reason)
@@ -580,17 +507,13 @@ CONFIDENCE: [HIGH/MEDIUM/LOW]
 REASON: [one sentence]"""
         t0 = time.monotonic()
         try:
-            response = self._call_ollama_generate(
-                prompt, options={"temperature": 0.1, "num_predict": 60}, timeout=20,
-            )
+            text = self._call_llm(prompt, temperature=0.1, max_tokens=60, timeout=20)
             elapsed_ms = (time.monotonic() - t0) * 1000
-            if response is None or response.status_code != 200:
-                error = f"status={response.status_code}" if response is not None else "no compute lease available"
-                self._log_ollama("check_identity_single", elapsed_ms, None, error=error)
+            if text is None:
+                self._log_ollama("check_identity_single", elapsed_ms, error="no answer from LLM")
                 return LLMIdentityResult(are_same=False, confidence=0.0, reason="LLM unavailable")
-            data = response.json()
-            self._log_ollama("check_identity_single", elapsed_ms, data)
-            text = data.get("response", "").strip()
+            self._log_ollama("check_identity_single", elapsed_ms)
+            text = text.strip()
             are_same = False
             confidence = 0.5
             reason = ""
@@ -599,27 +522,11 @@ REASON: [one sentence]"""
                 if upper.startswith("SAME:"):
                     are_same = "YES" in upper
                 elif upper.startswith("CONFIDENCE:"):
-                    val = line.split(":", 1)[1].strip().upper()
-                    confidence = {"HIGH": 0.9, "MEDIUM": 0.6, "LOW": 0.3}.get(val, 0.5)
+                    confidence = _parse_confidence(line.split(":", 1)[1])
                 elif upper.startswith("REASON:"):
                     reason = line.split(":", 1)[1].strip()
             return LLMIdentityResult(are_same=are_same, confidence=confidence, reason=reason)
         except Exception as exc:
             elapsed_ms = (time.monotonic() - t0) * 1000
-            self._log_ollama("check_identity_single", elapsed_ms, None, error=str(exc))
+            self._log_ollama("check_identity_single", elapsed_ms, error=str(exc))
             return LLMIdentityResult(are_same=False, confidence=0.0, reason=f"error: {exc}")
-
-    def _simple_relevance_check(self, title: str, abstract: str, topic: str) -> LLMRelevanceResult:
-        """This method is deprecated - semantic evaluation should be used instead."""
-        return LLMRelevanceResult(
-            is_relevant=False,
-            relevance_level="NOT_RELEVANT",
-            confidence=0.0,
-            reasoning="Fallback method - semantic evaluation unavailable",
-            semantic_score=0.0,
-        )
-
-    def _fetch_full_text(self, paper: PaperMetadata) -> str:
-        """Fetch full text of paper if available."""
-        # TODO: Implement paper fetching from various sources
-        return ""

--- a/prisma/services/chat_llm.py
+++ b/prisma/services/chat_llm.py
@@ -18,7 +18,7 @@ import os
 from openai import OpenAI
 
 from prisma.services import resource_lock
-from prisma.utils.config import ChatConfig
+from prisma.utils.config import ChatConfig, LLMConfig
 
 _log = logging.getLogger("prisma.chat_llm")
 
@@ -32,16 +32,60 @@ class ChatLLM:
         ollama_host: str = "localhost:11434",
         supervisor_host: str = "127.0.0.1",
         supervisor_port: int | None = None,
+        priority: str = "interactive",
     ) -> None:
         self._config = chat_config
         self._ollama_host = ollama_host
         self._supervisor_host = supervisor_host
         self._supervisor_port = supervisor_port if supervisor_port is not None else resource_lock.default_port()
+        # A live chat request must never queue behind bulk background work —
+        # see resource_lock.lease's docstring. Callers doing background work
+        # instead (AnalysisAgent, via from_llm_config) pass priority="background".
+        self._priority = priority
         # timeout=180.0: without this, an OpenAI-SDK call has no default
         # ceiling at all — found live: this call site was the one gap the
         # kg-extraction num_predict bug didn't already cover elsewhere.
+        # Per-call complete(timeout=...) overrides this for callers that need
+        # tighter/looser bounds per prompt (see AnalysisAgent).
         self._client = OpenAI(
             base_url=self._resolve_base_url(), api_key=self._resolve_api_key(), timeout=180.0,
+        )
+
+    @classmethod
+    def from_llm_config(
+        cls,
+        llm_config: LLMConfig,
+        *,
+        priority: str = "background",
+        supervisor_host: str = "127.0.0.1",
+        supervisor_port: int | None = None,
+    ) -> "ChatLLM":
+        """Adapts LLMConfig (KG/AnalysisAgent's config shape) into the
+        ChatConfig this class actually needs. LLMConfig has no `max_tokens`
+        field -- ChatConfig's own default (2000) is used, and callers that
+        need tighter per-call caps pass complete(max_tokens=...). `pool`
+        defaults to ChatConfig's own default ("local-ollama") when
+        llm_config.pool isn't set -- callers running provider="openrouter"
+        should set `llm.pool` explicitly to a dedicated pool, or risk being
+        auto-routed onto a model_affinity'd local-GPU pool (see
+        resource_lock.lease's docstring)."""
+        kwargs = dict(
+            provider=llm_config.provider,
+            model=llm_config.model,
+            base_url=llm_config.base_url_override,
+            api_key_env=llm_config.api_key_env,
+        )
+        if llm_config.pool:
+            kwargs["pool"] = llm_config.pool
+        if llm_config.context_window is not None:
+            kwargs["context_window"] = llm_config.context_window
+        chat_config = ChatConfig(**kwargs)
+        return cls(
+            chat_config,
+            ollama_host=llm_config.host,
+            supervisor_host=supervisor_host,
+            supervisor_port=supervisor_port,
+            priority=priority,
         )
 
     @property
@@ -83,24 +127,39 @@ class ChatLLM:
             return key
         return "ollama"  # placeholder — Ollama/llama.cpp's OpenAI-compat endpoints ignore the key, but the SDK requires a non-empty string
 
-    def complete(self, messages: list[dict], temperature: float = 0.1) -> str | None:
+    def complete(
+        self,
+        messages: list[dict],
+        temperature: float = 0.1,
+        *,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+    ) -> str | None:
         """One resource_lock-gated chat completion call. Returns None if the
         lease was denied or the call failed — callers must treat that as
-        "couldn't get an answer right now," not "the model said nothing.\""""
+        "couldn't get an answer right now," not "the model said nothing."
+
+        `max_tokens`/`timeout` override this instance's config default for
+        just this call — e.g. AnalysisAgent wants a short cap for a
+        yes/no-style prompt and a long one for a full summary, from the
+        same ChatLLM instance."""
         with resource_lock.lease(
             self._supervisor_host, self._supervisor_port,
             holder=_RESOURCE_HOLDER, model=self._config.model, pool=self._config.pool,
-            priority="interactive",  # a live chat request — must never queue behind bulk background work
+            priority=self._priority,
         ) as granted:
             if not granted:
                 return None
             try:
-                resp = self._client.chat.completions.create(
+                kwargs = dict(
                     model=self._config.model,
                     messages=messages,
                     temperature=temperature,
-                    max_tokens=self._config.max_tokens,
+                    max_tokens=max_tokens if max_tokens is not None else self._config.max_tokens,
                 )
+                if timeout is not None:
+                    kwargs["timeout"] = timeout
+                resp = self._client.chat.completions.create(**kwargs)
             except Exception as exc:
                 _log.warning("chat completion failed: %s", exc)
                 return None

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -110,6 +110,18 @@ class LLMConfig(BaseModel):
             "(see KnowledgeGraphService._resolve_context_window) and ignore this field."
         ),
     )
+    pool: Optional[str] = Field(
+        None,
+        description=(
+            "compute_pools entry this backend's calls lease from — must match a name "
+            "in compute_pools. None lets the lease land on whichever pool has free "
+            "capacity, which is fine for local providers (ollama/llama_cpp) but risks "
+            "misattribution for provider=openrouter: without a dedicated pool, a cloud "
+            "call can be auto-routed onto a model_affinity'd local-GPU pool and start "
+            "denying real local calls for no hardware reason (see resource_lock.lease's "
+            "docstring). Set this explicitly when provider=openrouter."
+        ),
+    )
 
     @field_validator('provider')
     @classmethod

--- a/tests/unit/agents/test_analysis_agent.py
+++ b/tests/unit/agents/test_analysis_agent.py
@@ -11,23 +11,27 @@ from datetime import datetime
 # Add prisma to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
-from prisma.agents.analysis_agent import AnalysisAgent
+from prisma.agents.analysis_agent import AnalysisAgent, _parse_confidence
 from prisma.storage.models.agent_models import PaperMetadata, AnalysisResult, PaperSummary
+from prisma.utils.config import LLMConfig
 
 
 class TestAnalysisAgent(unittest.TestCase):
     """Test AnalysisAgent functionality."""
-    
+
     def setUp(self):
         """Set up test fixtures."""
-        self.analysis_agent = AnalysisAgent()
         # AnalysisAgent() reads prisma.utils.config's module-level `config`
-        # singleton (built once, at first import of that module, long before
-        # this test runs) — patching Path.exists here wouldn't retroactively
-        # change it. These tests assume the Ollama-native code path
-        # regardless of whatever real ~/.config/prisma/config.toml the
-        # machine running this test happens to have, so force it directly.
-        self.analysis_agent.llm_config.provider = 'ollama'
+        # singleton and, since ChatLLM.from_llm_config() now resolves the
+        # provider/base_url/api_key eagerly at construction time (not
+        # per-call like the old hand-rolled transport), a real machine's
+        # ~/.config/prisma/config.toml with e.g. provider=openrouter and an
+        # unset api_key_env would make construction itself raise. Force a
+        # known-good local config for the duration of construction instead
+        # of mutating llm_config after the fact (too late now to matter).
+        test_llm_config = LLMConfig(provider='ollama', model='qwen2.5:7b-32k', host='localhost:11434')
+        with patch('prisma.agents.analysis_agent.config.get_llm_config', return_value=test_llm_config):
+            self.analysis_agent = AnalysisAgent()
         self.sample_paper = PaperMetadata(
             title='Test Paper Title',
             authors=['Author One', 'Author Two'],
@@ -44,45 +48,32 @@ class TestAnalysisAgent(unittest.TestCase):
             issue=None,
             pages=None
         )
-    
+
     def test_initialization(self):
         """Test AnalysisAgent initializes correctly."""
         self.assertIsNotNone(self.analysis_agent.llm_config)
-        self.assertIsNotNone(self.analysis_agent.base_url)
         self.assertIsNotNone(self.analysis_agent.model)
-    
-    # Every test below that reaches _call_ollama_generate must mock
-    # resource_lock.acquire — otherwise it hits whatever supervisor happens
-    # to be reachable on the default port on the machine running the tests
-    # (e.g. a real `prisma serve` the developer has up), which is both flaky
-    # and an unintended side effect on production state.
-    @patch('prisma.agents.analysis_agent.resource_lock.acquire', return_value=(True, "local-ollama", "req-1"))
-    @patch('prisma.agents.analysis_agent.requests.post')
-    def test_analyze_papers(self, mock_post, mock_acquire):
-        """Test paper analysis functionality."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {'response': 'Summary of the paper.', 'done': True}
-        mock_post.return_value = mock_response
+        self.assertIsNotNone(self.analysis_agent._chat_llm)
 
-        papers = [self.sample_paper]
-        result = self.analysis_agent.analyze(papers)
+    # Every test below that reaches _call_llm mocks ChatLLM.complete directly
+    # on the agent's own instance -- the agent routes every LLM call through
+    # self._chat_llm (prisma.services.chat_llm.ChatLLM), so this is the one
+    # seam that matters regardless of provider (ollama/llama_cpp/openrouter).
+    def test_analyze_papers(self):
+        """Test paper analysis functionality."""
+        with patch.object(self.analysis_agent._chat_llm, 'complete', return_value='Summary of the paper.'):
+            papers = [self.sample_paper]
+            result = self.analysis_agent.analyze(papers)
 
         self.assertIsInstance(result, AnalysisResult)
         self.assertEqual(len(result.summaries), 1)
         self.assertEqual(result.author_count, 2)
         self.assertIsInstance(result.summaries[0], PaperSummary)
 
-    @patch('prisma.agents.analysis_agent.resource_lock.acquire', return_value=(True, "local-ollama", "req-1"))
-    @patch('prisma.agents.analysis_agent.requests.post')
-    def test_summarize_paper_structure(self, mock_post, mock_acquire):
+    def test_summarize_paper_structure(self):
         """Test paper summary structure."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {'response': 'Summary of the paper.', 'done': True}
-        mock_post.return_value = mock_response
-
-        summary = self.analysis_agent._summarize_paper(self.sample_paper)
+        with patch.object(self.analysis_agent._chat_llm, 'complete', return_value='Summary of the paper.'):
+            summary = self.analysis_agent._summarize_paper(self.sample_paper)
 
         self.assertIsInstance(summary, PaperSummary)
         self.assertEqual(summary.title, self.sample_paper.title)
@@ -93,72 +84,81 @@ class TestAnalysisAgent(unittest.TestCase):
         self.assertIsInstance(summary.methodology, str)
         self.assertIsInstance(summary.connected_papers_url, str)
 
-    @patch('prisma.agents.analysis_agent.resource_lock.acquire', return_value=(True, "local-ollama", "req-1"))
-    @patch('prisma.agents.analysis_agent.requests.post')
-    def test_ollama_integration_success(self, mock_post, mock_acquire):
-        """Test successful Ollama integration."""
-        # Mock successful Ollama response
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            'model': 'llama3.1:8b',
-            'created_at': '2024-01-01T00:00:00Z',
-            'response': 'This paper presents a novel approach to machine learning with significant improvements.',
-            'done': True
-        }
-        mock_post.return_value = mock_response
-
-        summary = self.analysis_agent._get_ollama_summary(
-            self.sample_paper.title,
-            self.sample_paper.abstract
-        )
+    def test_ollama_integration_success(self):
+        """Test successful LLM integration."""
+        with patch.object(
+            self.analysis_agent._chat_llm, 'complete',
+            return_value='This paper presents a novel approach to machine learning with significant improvements.',
+        ):
+            summary = self.analysis_agent._get_ollama_summary(
+                self.sample_paper.title,
+                self.sample_paper.abstract
+            )
 
         self.assertIsNotNone(summary)
         self.assertIn('machine learning', summary)
 
-    @patch('prisma.agents.analysis_agent.resource_lock.acquire', return_value=(True, "local-ollama", "req-1"))
-    @patch('prisma.agents.analysis_agent.requests.post')
-    def test_ollama_integration_failure(self, mock_post, mock_acquire):
-        """Test Ollama integration failure handling."""
-        # Mock failed Ollama response
-        mock_post.side_effect = Exception("Connection failed")
-
-        summary = self.analysis_agent._get_ollama_summary(
-            self.sample_paper.title,
-            self.sample_paper.abstract
-        )
+    def test_ollama_integration_failure(self):
+        """Test LLM integration failure handling."""
+        with patch.object(self.analysis_agent._chat_llm, 'complete', side_effect=Exception("Connection failed")):
+            summary = self.analysis_agent._get_ollama_summary(
+                self.sample_paper.title,
+                self.sample_paper.abstract
+            )
 
         # Should handle failure gracefully and return empty string
         self.assertEqual(summary, "")
-    
-    @patch(
-        'prisma.services.resource_lock.backoff.retry_with_backoff',
-        side_effect=lambda attempt, is_success, **kw: attempt(),
-    )
-    @patch('prisma.agents.analysis_agent.resource_lock.acquire', return_value=(False, None, None))
-    @patch('prisma.agents.analysis_agent.requests.post')
-    def test_ollama_summary_skips_call_when_lease_denied(self, mock_post, mock_acquire, mock_retry):
-        """No compute lease available should be handled like any other LLM failure, not crash."""
-        summary = self.analysis_agent._get_ollama_summary(
-            self.sample_paper.title,
-            self.sample_paper.abstract
-        )
+
+    def test_ollama_summary_returns_empty_when_no_answer(self):
+        """ChatLLM.complete() returning None (lease denied or call failed)
+        should be handled like any other LLM failure, not crash."""
+        with patch.object(self.analysis_agent._chat_llm, 'complete', return_value=None) as mock_complete:
+            summary = self.analysis_agent._get_ollama_summary(
+                self.sample_paper.title,
+                self.sample_paper.abstract
+            )
 
         self.assertEqual(summary, "")
-        self.assertFalse(mock_post.called)
+        self.assertTrue(mock_complete.called)
+
+    def test_call_llm_passes_per_call_max_tokens_and_timeout(self):
+        """Different operations tune max_tokens/timeout differently (e.g. a
+        short yes/no prompt vs a full summary) -- confirm those per-call
+        values actually reach ChatLLM.complete(), not just its config default."""
+        with patch.object(self.analysis_agent._chat_llm, 'complete', return_value='ok') as mock_complete:
+            self.analysis_agent._call_llm("prompt", temperature=0.2, max_tokens=42, timeout=7)
+
+        mock_complete.assert_called_once()
+        _, kwargs = mock_complete.call_args
+        self.assertEqual(kwargs['temperature'], 0.2)
+        self.assertEqual(kwargs['max_tokens'], 42)
+        self.assertEqual(kwargs['timeout'], 7)
 
     def test_extract_key_findings(self):
         """Test key findings extraction."""
         text_with_findings = "The results show significant improvements. Key findings indicate better performance."
         text_without_findings = "This is a simple text without specific indicators."
-        
+
         findings1 = self.analysis_agent._extract_key_findings(text_with_findings)
         findings2 = self.analysis_agent._extract_key_findings(text_without_findings)
-        
+
         self.assertIsInstance(findings1, list)
         self.assertIsInstance(findings2, list)
         self.assertTrue(len(findings1) > 0)
         self.assertTrue(len(findings2) > 0)
+
+
+class TestParseConfidence(unittest.TestCase):
+    def test_recognized_levels(self):
+        self.assertEqual(_parse_confidence("HIGH"), 0.9)
+        self.assertEqual(_parse_confidence("MEDIUM"), 0.6)
+        self.assertEqual(_parse_confidence("LOW"), 0.3)
+
+    def test_case_and_whitespace_insensitive(self):
+        self.assertEqual(_parse_confidence("  high  "), 0.9)
+
+    def test_unrecognized_defaults_to_mid(self):
+        self.assertEqual(_parse_confidence("banana"), 0.5)
 
 
 if __name__ == '__main__':

--- a/tests/unit/services/test_chat_llm.py
+++ b/tests/unit/services/test_chat_llm.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from prisma.services.chat_llm import ChatLLM
-from prisma.utils.config import ChatConfig
+from prisma.utils.config import ChatConfig, LLMConfig
 
 
 def _llm(**overrides) -> ChatLLM:
@@ -92,3 +92,74 @@ def test_complete_returns_none_on_client_exception():
          patch.object(llm._client.chat.completions, "create", side_effect=RuntimeError("boom")):
         result = llm.complete([{"role": "user", "content": "hi"}])
     assert result is None
+
+
+def test_complete_uses_config_max_tokens_by_default():
+    llm = _llm(max_tokens=2000)
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(message=MagicMock(content="ok"))]
+    with patch("prisma.services.chat_llm.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")), \
+         patch("prisma.services.chat_llm.resource_lock.release"), \
+         patch.object(llm._client.chat.completions, "create", return_value=mock_resp) as mock_create:
+        llm.complete([{"role": "user", "content": "hi"}])
+    assert mock_create.call_args.kwargs["max_tokens"] == 2000
+    assert "timeout" not in mock_create.call_args.kwargs
+
+
+def test_complete_per_call_max_tokens_and_timeout_override_config():
+    # AnalysisAgent needs a short cap for a yes/no prompt and a long one for
+    # a full summary, from the same ChatLLM instance -- confirm overrides
+    # actually reach the underlying client call.
+    llm = _llm(max_tokens=2000)
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(message=MagicMock(content="ok"))]
+    with patch("prisma.services.chat_llm.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")), \
+         patch("prisma.services.chat_llm.resource_lock.release"), \
+         patch.object(llm._client.chat.completions, "create", return_value=mock_resp) as mock_create:
+        llm.complete([{"role": "user", "content": "hi"}], max_tokens=42, timeout=7)
+    assert mock_create.call_args.kwargs["max_tokens"] == 42
+    assert mock_create.call_args.kwargs["timeout"] == 7
+
+
+def test_default_priority_is_interactive():
+    # Preserves chat's original behavior — a live chat request must never
+    # queue behind bulk background work.
+    assert _llm()._priority == "interactive"
+
+
+def test_explicit_priority_is_honored_in_lease():
+    llm = ChatLLM(ChatConfig(), ollama_host="localhost:11434", priority="background")
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(message=MagicMock(content="ok"))]
+    with patch("prisma.services.chat_llm.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")) as mock_acquire, \
+         patch("prisma.services.chat_llm.resource_lock.release"), \
+         patch("prisma.services.chat_llm.resource_lock.backoff.retry_with_backoff",
+               side_effect=lambda attempt, is_success, **kw: attempt()), \
+         patch.object(llm._client.chat.completions, "create", return_value=mock_resp):
+        llm.complete([{"role": "user", "content": "hi"}])
+    assert mock_acquire.call_args.kwargs["priority"] == "background"
+
+
+class TestFromLlmConfig:
+    def test_adapts_fields_and_defaults_priority_to_background(self):
+        llm_config = LLMConfig(provider="ollama", model="qwen2.5:7b-32k", host="localhost:11434")
+        llm = ChatLLM.from_llm_config(llm_config)
+        assert llm._config.provider == "ollama"
+        assert llm._config.model == "qwen2.5:7b-32k"
+        assert llm._priority == "background"
+        assert llm._resolve_base_url() == "http://localhost:11434/v1"
+
+    def test_pool_passed_through_when_set(self):
+        llm_config = LLMConfig(provider="openrouter", model="x", pool="cloud-openrouter")
+        llm = ChatLLM.from_llm_config(llm_config)
+        assert llm._config.pool == "cloud-openrouter"
+
+    def test_pool_falls_back_to_chat_config_default_when_unset(self):
+        llm_config = LLMConfig(provider="ollama", model="x")
+        llm = ChatLLM.from_llm_config(llm_config)
+        assert llm._config.pool == ChatConfig().pool
+
+    def test_explicit_priority_override(self):
+        llm_config = LLMConfig(provider="ollama", model="x")
+        llm = ChatLLM.from_llm_config(llm_config, priority="interactive")
+        assert llm._priority == "interactive"


### PR DESCRIPTION
## Summary
- `AnalysisAgent` had its own `requests.post`-based transport (`_call_ollama_generate`), with a hand-written `provider=="llama_cpp"` branch translating OpenAI-shaped responses back into Ollama's native `{"response": ...}` shape. Setting `llm.provider="openrouter"` silently broke every relevance check, summary, and dedup identity call: that branch falls through to Ollama's native `/api/generate`, an endpoint OpenRouter doesn't expose, with no API key attached -- while chat and KG extraction (already on `ChatLLM`) kept working. It also never passed `pool=` to `resource_lock.lease()`, so a cloud model could be auto-routed onto a `model_affinity`'d local-GPU pool.
- `ChatLLM` gains a `priority` constructor param (default `"interactive"`, preserving chat's existing behavior) and per-call `max_tokens`/`timeout` overrides on `complete()`, so background callers with per-operation tuning (`AnalysisAgent`) don't have to share chat's single config-wide `max_tokens` or its "must never queue behind bulk work" priority.
- New `ChatLLM.from_llm_config()` classmethod adapts `LLMConfig` (KG/AnalysisAgent's config shape) into the `ChatConfig` this class needs.
- `LLMConfig` gains an optional `pool` field so `provider=openrouter` setups can pin a dedicated pool instead of risking the model_affinity misattribution above.
- `AnalysisAgent` now builds one `ChatLLM` (`priority="background"`) in `__init__` and routes every prompt through a single `_call_llm()` choke point. The process-local semaphore is kept, layered on top of `ChatLLM`'s own cross-process lease, preserving the existing concurrency cap.
- Also removes two dead methods (`_simple_relevance_check`, `_fetch_full_text`, zero callers) and unifies the HIGH/MEDIUM/LOW confidence-parsing map that was duplicated across two response parsers, into `_parse_confidence()`.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F3, F9).

## Test plan
- [x] `pytest tests/unit -q` -- 689 passed (new tests for `ChatLLM.from_llm_config`, per-call `max_tokens`/`timeout`, `priority`, and `_parse_confidence`)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs