### PR TITLE
Promote VaultService's underscore-prefixed API to a real public surface

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -1347,7 +1347,7 @@ def taint_node(slug: str):
     targets a single file via both ChromaIndexer.taint_file and
     KnowledgeGraphService.taint_file (see their docstrings — both work by
     dropping the file's manifest entry and enqueuing it directly)."""
-    path = _vault._find_file(slug)
+    path = _vault.find_file(slug)
     if path is None:
         raise HTTPException(status_code=404, detail=f"node not found: {slug!r}")
     rel = str(path.relative_to(_vault.root))
@@ -1474,7 +1474,7 @@ def view_html(slug: str, request: Request):
     path = _vault.find_companion(slug)
     if path is None:
         # Standalone .html file (no .md companion)
-        found = _vault._find_file(slug)
+        found = _vault.find_file(slug)
         if found is not None and found.suffix == ".html":
             path = found
     if path is None:
@@ -1590,7 +1590,7 @@ _search_index_lock = threading.Lock()
 def _refresh_search_index() -> None:
     with _search_index_lock:
         seen: set[str] = set()
-        for path in _vault._all_md_files():
+        for path in _vault.iter_files():
             key = str(path)
             seen.add(key)
             try:
@@ -2008,7 +2008,7 @@ def zotero_import(key: str):
         raise HTTPException(status_code=404, detail=f"Zotero item not found: {key!r}")
 
     # Return existing import if already in vault
-    for path in _vault._all_md_files():
+    for path in _vault.iter_files():
         raw = path.read_text(encoding="utf-8")
         from prisma.services.vault import _parse_frontmatter
         fm, _ = _parse_frontmatter(raw)
@@ -2044,27 +2044,12 @@ def zotero_import(key: str):
         body = "\n".join(lines)
 
     citekey = make_citekey(item.authors, item.year, item.title)
-    from prisma.services.vault import _slugify, _render_frontmatter
-    slug = _vault._unique_slug(_slugify(citekey))
-    fm: dict = {
-        "type": "source",
-        "title": item.title,
-        "citekey": citekey,
-        "zotero_key": item.key,
-        "authors": item.authors,
-        "tags": [t.tag for t in item.tags],
-    }
-    if item.year:
-        fm["year"] = item.year
-    if item.doi:
-        fm["doi"] = item.doi
-    if item.url:
-        fm["url"] = item.url
-    path = _vault.default_dirs[NodeType.source] / f"{slug}.md"
-    _vault.ensure_dirs()
-    path.write_text(_render_frontmatter(fm) + body, encoding="utf-8")
+    source = _vault.create_source_from_citekey(
+        citekey, item.title, body,
+        zotero_key=item.key, authors=item.authors, tags=[t.tag for t in item.tags],
+        year=item.year, doi=item.doi, url=item.url,
+    )
     _indexer.mark_stale()
-    source = _vault.get_source(slug)
     _activity.info("action=import_zotero key=%s slug=%s title=%r", key, source.slug, source.title)
     html, broken_links, broken_citations = vault_render(source.body, _vault)
     return RenderedNode(

--- a/prisma/services/chroma_service.py
+++ b/prisma/services/chroma_service.py
@@ -324,7 +324,7 @@ class ChromaIndexer:
             # filter by at query time, so this is the only place that can keep
             # chat transcripts out of search_vault's results.
             all_files = [
-                p for p in self._vault._all_md_files()
+                p for p in self._vault.iter_files()
                 if "chats" not in p.relative_to(self._vault.root).parts
             ]
             _log.info("chroma full index start: %d files total", len(all_files))

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -1218,7 +1218,7 @@ class KnowledgeGraphService:
         except OSError:
             return "note"
         fm = _frontmatter(body)
-        node_type = self._vault._node_type_from_fm(fm)
+        node_type = self._vault.node_type_from_frontmatter(fm)
         return _TRUST_TIER_BY_NODE_TYPE.get(node_type, "note")
 
     # ── Background loop ───────────────────────────────────────────────────────
@@ -1321,7 +1321,7 @@ class KnowledgeGraphService:
             self._index_generation += 1
             generation = self._index_generation
         try:
-            all_files = [p for p in self._vault._all_md_files() if p.suffix in self.index_extensions]
+            all_files = list(self._vault.iter_files(extensions=self.index_extensions))
             _log.info("knowledge graph full index start: %d files total", len(all_files))
 
             # A fresh restart's full index still walks every file (a changed

--- a/prisma/services/renderer.py
+++ b/prisma/services/renderer.py
@@ -22,7 +22,7 @@ MAX_TRANSCLUSION_DEPTH = 5
 def _build_citekey_index(vault: VaultService) -> dict[str, str]:
     from prisma.services.vault import _parse_frontmatter
     index: dict[str, str] = {}
-    for path in vault._all_md_files():
+    for path in vault.iter_files():
         body = path.read_text(encoding="utf-8")
         fm, _ = _parse_frontmatter(body)
         citekey = fm.get("citekey")

--- a/prisma/services/vault.py
+++ b/prisma/services/vault.py
@@ -194,7 +194,12 @@ class VaultService:
 
     # ── Internal traversal ────────────────────────────────────────────────────
 
-    def _all_md_files(self) -> Iterator[Path]:
+    def iter_files(self, *, extensions: tuple[str, ...] = (".md",)) -> Iterator[Path]:
+        """Walk the vault root once, yielding files whose name ends in one
+        of *extensions*, skipping VCS/build directories and hidden dirs.
+        This is the vault's only directory walk -- callers that need a
+        different extension set (KG indexing, Chroma indexing) filter this
+        same stream instead of re-walking the filesystem themselves."""
         if not self.root.exists():
             return
         import os
@@ -205,18 +210,18 @@ class VaultService:
                 if d not in _SKIP_DIRS and not d.startswith(".")
             ]
             for fname in filenames:
-                if fname.endswith(".md"):
+                if fname.endswith(extensions):
                     yield Path(dirpath) / fname
 
     def _find_md(self, slug: str) -> Path | None:
         """Find a .md file whose slug matches. Does NOT find .html files."""
         slug_norm = _file_slug(slug).lower()
-        for path in self._all_md_files():
+        for path in self.iter_files():
             if _file_slug(path.stem).lower() == slug_norm:
                 return path
         return None
 
-    def _find_file(self, slug: str) -> Path | None:
+    def find_file(self, slug: str) -> Path | None:
         """Find a .md or .html file whose slug matches."""
         md = self._find_md(slug)
         if md is not None:
@@ -227,17 +232,12 @@ class VaultService:
             if candidate.exists():
                 return candidate
         slug_norm = _file_slug(slug).lower()
-        import os
-        for dirpath, dirnames, filenames in os.walk(self.root, followlinks=True):
-            dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".")]
-            for fname in filenames:
-                if fname.endswith(".html"):
-                    stem = fname[:-5]
-                    if _file_slug(stem).lower() == slug_norm:
-                        return Path(dirpath) / fname
+        for path in self.iter_files(extensions=(".html",)):
+            if _file_slug(path.stem).lower() == slug_norm:
+                return path
         return None
 
-    def _node_type_from_fm(self, fm: dict) -> NodeType:
+    def node_type_from_frontmatter(self, fm: dict) -> NodeType:
         raw = fm.get("type", "note")
         try:
             return NodeType(raw)
@@ -248,10 +248,10 @@ class VaultService:
 
     def list_nodes(self, node_type: NodeType | None = None) -> VaultListing:
         buckets: dict[NodeType, list[VaultNodeMeta]] = {t: [] for t in NodeType}
-        for path in self._all_md_files():
+        for path in self.iter_files():
             body = path.read_text(encoding="utf-8")
             fm, content = _parse_frontmatter(body)
-            nt = self._node_type_from_fm(fm)
+            nt = self.node_type_from_frontmatter(fm)
             if node_type and nt != node_type:
                 continue
             if nt == NodeType.stream:
@@ -363,6 +363,29 @@ class VaultService:
             modified_at=datetime.fromtimestamp(stat.st_mtime),
         )
 
+    def create_source_from_citekey(
+        self, citekey: str, title: str, body: str, *,
+        zotero_key: str, authors: list[str], tags: list[str],
+        year: int | None = None, doi: str | None = None, url: str | None = None,
+    ) -> Source:
+        """Create a source node from Zotero-derived metadata -- the
+        vault-side half of POST /zotero/import/{key}."""
+        self.ensure_dirs()
+        slug = self.unique_slug(citekey)
+        fm: dict = {
+            "type": "source", "title": title, "citekey": citekey,
+            "zotero_key": zotero_key, "authors": authors, "tags": tags,
+        }
+        if year:
+            fm["year"] = year
+        if doi:
+            fm["doi"] = doi
+        if url:
+            fm["url"] = url
+        path = self.default_dirs[NodeType.source] / f"{slug}.md"
+        path.write_text(_render_frontmatter(fm) + body, encoding="utf-8")
+        return self.get_source(slug)
+
     def get_chat(self, slug: str) -> Chat:
         path = self._find_md(slug)
         if path is None:
@@ -385,7 +408,7 @@ class VaultService:
 
     def create_chat(self, title: str, model: str = "llama3") -> Chat:
         self.ensure_dirs()
-        slug = self._unique_slug(_slugify(title))
+        slug = self.unique_slug(title)
         fm = {"type": "chat", "title": title, "model": model, "tags": ["chat"]}
         path = self.default_dirs[NodeType.chat] / f"{slug}.md"
         path.write_text(_render_frontmatter(fm), encoding="utf-8")
@@ -478,7 +501,7 @@ class VaultService:
             return note
 
     def get_any(self, slug: str) -> Note | Source | Chat | Stream:
-        path = self._find_file(slug)
+        path = self.find_file(slug)
         if path is None:
             # streams are stored as .yaml, not .md — _find_file won't find them
             try:
@@ -493,7 +516,7 @@ class VaultService:
             if companion_md.exists():
                 raw_md = companion_md.read_text(encoding="utf-8")
                 html_fm, _ = _parse_frontmatter(raw_md)
-            nt = self._node_type_from_fm(html_fm)
+            nt = self.node_type_from_frontmatter(html_fm)
             return Note(
                 slug=_file_slug(path.stem),
                 title=html_fm.get("title", path.stem),
@@ -506,7 +529,7 @@ class VaultService:
             )
         raw = path.read_text(encoding="utf-8")
         fm, _ = _parse_frontmatter(raw)
-        nt = self._node_type_from_fm(fm)
+        nt = self.node_type_from_frontmatter(fm)
         if nt == NodeType.source:
             return self.get_source(slug)
         if nt == NodeType.stream:
@@ -516,10 +539,10 @@ class VaultService:
         return self.get_note(slug)
 
     def slug_exists(self, slug: str) -> bool:
-        return self._find_file(slug) is not None
+        return self.find_file(slug) is not None
 
     def body_of(self, slug: str) -> str | None:
-        path = self._find_file(slug)
+        path = self.find_file(slug)
         if path is None:
             return None
         if path.suffix == ".html":
@@ -539,7 +562,7 @@ class VaultService:
 
     def set_node_type(self, slug: str, node_type: NodeType) -> None:
         """Update the type field for any node. For HTML files, creates/updates a companion .md."""
-        path = self._find_file(slug)
+        path = self.find_file(slug)
         if path is None:
             raise FileNotFoundError(f"node not found: {slug!r}")
         if path.suffix == ".html":
@@ -599,7 +622,7 @@ class VaultService:
         excerpt_of_chat: str | None = None,
     ) -> Note:
         self.ensure_dirs()
-        slug = self._unique_slug(_slugify(title))
+        slug = self.unique_slug(title)
         fm = {"type": "note", "title": title}
         if tags:
             fm["tags"] = tags
@@ -618,7 +641,10 @@ class VaultService:
         path.write_text(_render_frontmatter(fm) + body, encoding="utf-8")
         return self.get_note(slug)
 
-    def _unique_slug(self, base: str) -> str:
+    def unique_slug(self, title: str) -> str:
+        """Slugify *title* and disambiguate against existing .md files by
+        appending -1, -2, ... on collision."""
+        base = _slugify(title)
         slug = base
         n = 1
         while self._find_md(slug) is not None:
@@ -636,7 +662,7 @@ class VaultService:
 
     # ── Streams (stored as .yaml — the knowledge graph indexer skips non-.md files) ─
 
-    def _find_stream_path(self, slug: str) -> Path | None:
+    def find_stream_path(self, slug: str) -> Path | None:
         slug_norm = _file_slug(slug).lower()
         streams_dir = self.default_dirs[NodeType.stream]
         if not streams_dir.exists():
@@ -647,7 +673,7 @@ class VaultService:
         return None
 
     def get_stream(self, slug: str) -> Stream:
-        path = self._find_stream_path(slug)
+        path = self.find_stream_path(slug)
         if path is None:
             raise FileNotFoundError(f"stream not found: {slug!r}")
         fm = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
@@ -718,7 +744,7 @@ class VaultService:
         return self.get_stream(slug)
 
     def save_stream(self, slug: str, **updates: object) -> Stream:
-        path = self._find_stream_path(slug)
+        path = self.find_stream_path(slug)
         if path is None:
             raise FileNotFoundError(f"stream not found: {slug!r}")
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
@@ -731,7 +757,7 @@ class VaultService:
         return self.get_stream(slug)
 
     def append_stream_log(self, slug: str, entry: str) -> None:
-        path = self._find_stream_path(slug)
+        path = self.find_stream_path(slug)
         if path is None:
             return
         data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
@@ -808,7 +834,7 @@ class VaultService:
                         if companion_md.exists():
                             raw_md = companion_md.read_text(encoding="utf-8")
                             html_fm, _ = _parse_frontmatter(raw_md)
-                            html_nt = self._node_type_from_fm(html_fm)
+                            html_nt = self.node_type_from_frontmatter(html_fm)
                         nodes.append(VaultTreeNode(
                             name=name,
                             kind="file",
@@ -822,7 +848,7 @@ class VaultService:
                         fm, content = _parse_frontmatter(raw)
                         if fm.get("excerpt_of_chat"):
                             continue  # already shown in the chat's own Excerpt panel
-                        nt = self._node_type_from_fm(fm)
+                        nt = self.node_type_from_frontmatter(fm)
                         title = fm.get("title") or _first_heading(content) or path.stem
                         stream_status = None
                         if nt == NodeType.stream:
@@ -846,7 +872,7 @@ class VaultService:
     # ── Node operations ───────────────────────────────────────────────────────
 
     def move_node(self, slug: str, dest_dir: str) -> str:
-        path = self._find_file(slug)
+        path = self.find_file(slug)
         if path is None:
             raise FileNotFoundError(f"node not found: {slug!r}")
         # Normalise without resolving symlinks — resolve() follows them out of vault
@@ -882,7 +908,7 @@ class VaultService:
         return _file_slug(new_stem)
 
     def delete_node(self, slug: str) -> None:
-        path = self._find_file(slug)
+        path = self.find_file(slug)
         if path is None:
             raise FileNotFoundError(f"node not found: {slug!r}")
         path.unlink()
@@ -967,7 +993,7 @@ class VaultService:
         initial-reconciliation diffing. See _safe_sync_path for why streams/
         gets this one exception."""
         manifest = []
-        for path in self._all_md_files():
+        for path in self.iter_files():
             stat = path.stat()
             manifest.append((path.relative_to(self.root).as_posix(), stat.st_mtime, stat.st_size))
         streams_dir = self.default_dirs[NodeType.stream]
@@ -978,7 +1004,7 @@ class VaultService:
         return manifest
 
     def delete_stream(self, slug: str) -> None:
-        path = self._find_stream_path(slug)
+        path = self.find_stream_path(slug)
         if path is None:
             raise FileNotFoundError(f"stream not found: {slug!r}")
         path.unlink()

--- a/tests/unit/services/test_vault_public_surface.py
+++ b/tests/unit/services/test_vault_public_surface.py
@@ -1,0 +1,131 @@
+"""Unit tests for VaultService's promoted public surface — iter_files,
+find_file, node_type_from_frontmatter, unique_slug, find_stream_path,
+create_source_from_citekey — previously reached externally (renderer.py,
+app.py, chroma_service.py, knowledge_graph_service.py) only through their
+underscore-prefixed private equivalents."""
+import pytest
+
+from prisma.services.vault import VaultService
+from prisma.storage.models.vault_models import NodeType
+
+
+@pytest.fixture
+def vault(tmp_path):
+    v = VaultService(vault_root=tmp_path / "vault")
+    v.ensure_dirs()
+    return v
+
+
+class TestIterFiles:
+    def test_default_extension_is_md_only(self, vault):
+        vault.create_note("Note A")
+        (vault.root / "sources" / "companion.html").parent.mkdir(parents=True, exist_ok=True)
+        (vault.root / "sources" / "companion.html").write_text("<html></html>")
+
+        found = {p.suffix for p in vault.iter_files()}
+        assert found == {".md"}
+
+    def test_extensions_override_finds_only_matching_files(self, vault):
+        vault.create_note("Note A")
+        html_dir = vault.root / "sources"
+        html_dir.mkdir(parents=True, exist_ok=True)
+        (html_dir / "companion.html").write_text("<html></html>")
+
+        found = list(vault.iter_files(extensions=(".html",)))
+        assert len(found) == 1
+        assert found[0].suffix == ".html"
+
+    def test_multiple_extensions(self, vault):
+        vault.create_note("Note A")
+        html_dir = vault.root / "sources"
+        html_dir.mkdir(parents=True, exist_ok=True)
+        (html_dir / "companion.html").write_text("<html></html>")
+
+        found = {p.suffix for p in vault.iter_files(extensions=(".md", ".html"))}
+        assert found == {".md", ".html"}
+
+
+class TestFindFile:
+    def test_finds_md_file_by_slug(self, vault):
+        note = vault.create_note("My Note")
+        assert vault.find_file(note.slug) == vault._find_md(note.slug)
+
+    def test_finds_html_file_by_slug(self, vault):
+        html_dir = vault.root / "sources"
+        html_dir.mkdir(parents=True, exist_ok=True)
+        (html_dir / "paper.html").write_text("<html></html>")
+        found = vault.find_file("paper")
+        assert found is not None
+        assert found.name == "paper.html"
+
+    def test_returns_none_when_not_found(self, vault):
+        assert vault.find_file("does-not-exist") is None
+
+
+class TestNodeTypeFromFrontmatter:
+    def test_recognized_type(self, vault):
+        assert vault.node_type_from_frontmatter({"type": "source"}) == NodeType.source
+
+    def test_missing_type_defaults_to_note(self, vault):
+        assert vault.node_type_from_frontmatter({}) == NodeType.note
+
+    def test_unrecognized_type_falls_back_to_note(self, vault):
+        assert vault.node_type_from_frontmatter({"type": "not-a-real-type"}) == NodeType.note
+
+
+class TestUniqueSlug:
+    def test_slugifies_title(self, vault):
+        assert vault.unique_slug("Deep Learning") == "deep-learning"
+
+    def test_disambiguates_on_collision(self, vault):
+        vault.create_note("Deep Learning")
+        assert vault.unique_slug("Deep Learning") == "deep-learning-1"
+
+    def test_disambiguates_repeated_collisions(self, vault):
+        vault.create_note("Foo")
+        vault.create_note("Foo")
+        assert vault.unique_slug("Foo") == "foo-2"
+
+
+class TestFindStreamPath:
+    def test_finds_existing_stream(self, vault):
+        stream = vault.create_stream(title="My Stream", query="q")
+        path = vault.find_stream_path(stream.slug)
+        assert path is not None
+        assert path.suffix == ".yaml"
+
+    def test_returns_none_when_not_found(self, vault):
+        assert vault.find_stream_path("does-not-exist") is None
+
+
+class TestCreateSourceFromCitekey:
+    def test_creates_source_with_full_metadata(self, vault):
+        source = vault.create_source_from_citekey(
+            "smith2024", "A Great Paper", "paper body text",
+            zotero_key="ABC123", authors=["Jane Smith"], tags=["ml"],
+            year=2024, doi="10.1/xyz", url="https://example.com/paper",
+        )
+        assert source.citekey == "smith2024"
+        assert source.title == "A Great Paper"
+        assert source.body == "paper body text"
+        assert source.zotero_key == "ABC123"
+        assert source.authors == ["Jane Smith"]
+        assert source.year == 2024
+        assert source.doi == "10.1/xyz"
+
+    def test_omits_optional_fields_when_not_given(self, vault):
+        source = vault.create_source_from_citekey(
+            "smith2024", "A Great Paper", "body",
+            zotero_key="ABC123", authors=[], tags=[],
+        )
+        assert source.year is None
+        assert source.doi is None
+
+    def test_slug_disambiguated_on_citekey_collision(self, vault):
+        vault.create_source_from_citekey(
+            "smith2024", "First", "body1", zotero_key="A", authors=[], tags=[],
+        )
+        second = vault.create_source_from_citekey(
+            "smith2024", "Second", "body2", zotero_key="B", authors=[], tags=[],
+        )
+        assert second.slug == "smith2024-1"

--- a/tests/unit/services/test_vault_streams.py
+++ b/tests/unit/services/test_vault_streams.py
@@ -145,7 +145,7 @@ class TestAppendStreamLog:
         vault.append_stream_log("log-test", "found 1 paper")
 
         import yaml
-        path = vault._find_stream_path("log-test")
+        path = vault.find_stream_path("log-test")
         data = yaml.safe_load(path.read_text())
         assert len(data["log"]) == 2
         assert data["log"][0]["entry"] == "found 3 papers"


### PR DESCRIPTION
## Summary
Five `VaultService` methods -- `_all_md_files`, `_find_file`, `_node_type_from_fm`, `_unique_slug`, `_find_stream_path` -- were reached from outside `vault.py` at 9 production call sites across 4 modules (`renderer.py`, `app.py`, `chroma_service.py`, `knowledge_graph_service.py`), plus a private-function import (`_slugify`, `_render_frontmatter`) reassembling frontmatter creation in a route handler. The underscore said "don't depend on this"; every consumer depended on it anyway because there was no supported alternative.

- `_all_md_files` -> `iter_files(*, extensions=(".md",))` -- now parametrized, so KG indexing's `if p.suffix in self.index_extensions` re-filter can ask for the right extensions directly instead of filtering a `.md`-only stream that could never have yielded anything else -- a real latent bug for anyone who configured `kg.index_extensions` beyond the default `(".md",)`.
- `_find_file` -> `find_file`, reusing `iter_files` instead of its own second `os.walk` + skip-dir-pruning copy.
- `_node_type_from_fm` -> `node_type_from_frontmatter`.
- `_unique_slug(base)` -> `unique_slug(title)` -- now takes the raw title and slugifies internally, so callers (including two internal ones) stop importing/calling the private `_slugify` themselves.
- `_find_stream_path` -> `find_stream_path`.
- New `create_source_from_citekey()` moves `POST /zotero/import/{key}`'s hand-assembled slug/frontmatter/write-file sequence into `VaultService`, matching `create_chat()`'s existing shape -- the route no longer imports vault-internal functions at all.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F5).

## Test plan
- [x] `pytest tests/unit -q` -- 706 passed (17 new tests for the promoted surface + `create_source_from_citekey`)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs