### PR TITLE
Deduplicate supervisor.py's raw config.toml reads, fix precedence drift

### DIFF
--- a/prisma/server/supervisor.py
+++ b/prisma/server/supervisor.py
@@ -62,12 +62,40 @@ from pathlib import Path
 log = logging.getLogger("prisma.supervisor")
 
 
+def _read_raw_config() -> dict:
+    """Read config.toml as a raw dict, stdlib-only (this module can't import
+    ConfigLoader -- see the module docstring). Mirrors
+    ConfigLoader._get_config_path's precedence exactly (prisma/utils/config.py)
+    -- $PRISMA_CONFIG, then ~/.config/prisma/config.toml, then ./config.toml,
+    then ./prisma-config.toml -- so the supervisor and the workers it spawns
+    never silently disagree about which file is "the" config. If either side
+    changes its precedence, change the other to match.
+
+    Returns {} if no config file is found or it fails to parse -- every
+    caller already treats a missing/empty section as "use defaults."
+    """
+    import tomllib
+    candidates = []
+    env_config = os.environ.get("PRISMA_CONFIG")
+    if env_config:
+        candidates.append(Path(env_config).expanduser())
+    candidates += [
+        Path.home() / ".config" / "prisma" / "config.toml",
+        Path("./config.toml"),
+        Path("./prisma-config.toml"),
+    ]
+    for path in candidates:
+        if path.exists():
+            try:
+                return tomllib.loads(path.read_text()) or {}
+            except Exception:
+                return {}
+    return {}
+
+
 def _resolve_vault_root() -> Path:
     try:
-        import tomllib
-        cfg_path = Path.home() / ".config" / "prisma" / "config.toml"
-        cfg = tomllib.loads(cfg_path.read_text()) or {}
-        root = cfg.get("vault_root", "").strip()
+        root = _read_raw_config().get("vault_root", "").strip()
         if root:
             return Path(root).expanduser().resolve()
     except Exception:
@@ -84,10 +112,7 @@ def _venv_bin(name: str) -> str:
 
 def _ollama_base_url() -> str:
     try:
-        import tomllib
-        cfg_path = Path.home() / ".config" / "prisma" / "config.toml"
-        cfg = tomllib.loads(cfg_path.read_text()) or {}
-        host = cfg.get("llm", {}).get("host", "localhost:11434")
+        host = _read_raw_config().get("llm", {}).get("host", "localhost:11434")
         return f"http://{host}"
     except Exception:
         return "http://localhost:11434"
@@ -373,9 +398,7 @@ def _load_compute_pools() -> tuple[
     assumption when nothing is configured.
     """
     try:
-        import tomllib
-        cfg_path = Path.home() / ".config" / "prisma" / "config.toml"
-        cfg = tomllib.loads(cfg_path.read_text()) or {}
+        cfg = _read_raw_config()
         pools = cfg.get("compute_pools")
         if pools:
             capacity = {p["name"]: int(p.get("max_concurrent", 1)) for p in pools}

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -432,7 +432,14 @@ class ConfigLoader:
         return self.config.kg
 
     def _get_config_path(self) -> Optional[Path]:
-        """Get configuration file path from environment or default location."""
+        """Get configuration file path from environment or default location.
+
+        This exact precedence is duplicated in prisma/server/supervisor.py's
+        _read_raw_config() -- that module can't import this class (stdlib-only,
+        see its module docstring) but must resolve the same file the workers
+        it spawns will read. If either side's precedence changes, change the
+        other to match, or the supervisor and the api/kg workers it starts
+        can silently disagree about vault_root/compute_pools."""
         # Check environment variable first
         env_config = os.getenv('PRISMA_CONFIG')
         if env_config:

--- a/tests/unit/server/test_supervisor_resources.py
+++ b/tests/unit/server/test_supervisor_resources.py
@@ -14,9 +14,12 @@ from prisma.server.supervisor import (
     _check_pool_vram_fit,
     _load_compute_pools,
     _load_vram_profiles,
+    _ollama_base_url,
     _probe_model_vram,
     _process_memory_mb,
     _profile_missing_models,
+    _read_raw_config,
+    _resolve_vault_root,
     _save_vram_profile,
     _system_info,
 )
@@ -263,6 +266,99 @@ def test_load_compute_pools_type_field_is_authoritative_over_model_affinity(tmp_
         "local-ollama": {"prisma-kg:7b", "prisma-chat:7b"},
         "cloud_api": {"anthropic/claude-3.5-sonnet"},
     }
+
+
+# _read_raw_config's precedence mirrors ConfigLoader._get_config_path
+# (prisma/utils/config.py) exactly: $PRISMA_CONFIG, then
+# ~/.config/prisma/config.toml, then ./config.toml, then ./prisma-config.toml.
+# These tests pin that order down at this (stdlib-only) side too.
+
+def test_read_raw_config_returns_empty_dict_when_nothing_found(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)  # no ./config.toml or ./prisma-config.toml here either
+
+    assert _read_raw_config() == {}
+
+
+def test_read_raw_config_finds_home_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / ".config" / "prisma"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.toml").write_text('vault_root = "/home-config-vault"\n')
+
+    assert _read_raw_config() == {"vault_root": "/home-config-vault"}
+
+
+def test_read_raw_config_env_var_wins_over_home_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / ".config" / "prisma"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.toml").write_text('vault_root = "/home-config-vault"\n')
+    env_cfg = tmp_path / "custom.toml"
+    env_cfg.write_text('vault_root = "/env-config-vault"\n')
+    monkeypatch.setenv("PRISMA_CONFIG", str(env_cfg))
+
+    assert _read_raw_config() == {"vault_root": "/env-config-vault"}
+
+
+def test_read_raw_config_falls_back_to_cwd_config_toml(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)  # no ~/.config/prisma/config.toml
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config.toml").write_text('vault_root = "/cwd-config-vault"\n')
+
+    assert _read_raw_config() == {"vault_root": "/cwd-config-vault"}
+
+
+def test_read_raw_config_falls_back_to_cwd_prisma_config_toml(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "prisma-config.toml").write_text('vault_root = "/cwd-prisma-config-vault"\n')
+
+    assert _read_raw_config() == {"vault_root": "/cwd-prisma-config-vault"}
+
+
+def test_resolve_vault_root_reads_from_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / ".config" / "prisma"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.toml").write_text(f'vault_root = "{tmp_path / "my-vault"}"\n')
+
+    assert _resolve_vault_root() == (tmp_path / "my-vault").resolve()
+
+
+def test_resolve_vault_root_defaults_when_config_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert _resolve_vault_root() == tmp_path / "prisma-vault"
+
+
+def test_ollama_base_url_reads_llm_host_from_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+    cfg_dir = tmp_path / ".config" / "prisma"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.toml").write_text('[llm]\nhost = "gpu-box:11434"\n')
+
+    assert _ollama_base_url() == "http://gpu-box:11434"
+
+
+def test_ollama_base_url_defaults_when_config_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PRISMA_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    assert _ollama_base_url() == "http://localhost:11434"
 
 
 # ── contention stats: "why is the server busy" without grepping logs ────────


### PR DESCRIPTION
## Summary
- Three functions in `supervisor.py` (`_resolve_vault_root`, `_ollama_base_url`, the `compute_pools` loader) each carried their own copy of the same 3-line `tomllib` read, hardcoded to `~/.config/prisma/config.toml` only.
- Real divergence, not just duplication: `ConfigLoader._get_config_path` (`prisma/utils/config.py`) checks `$PRISMA_CONFIG`, then that home path, then `./config.toml`, then `./prisma-config.toml` -- a user running with `PRISMA_CONFIG` set, or a `./config.toml`, got a supervisor silently using hardcoded defaults (`~/prisma-vault`, `localhost:11434`, single pool) while the api/kg workers it spawns read the real file: a split-brain in vault root and compute-pool capacity, hidden further by the bare `except Exception: pass`.
- New `_read_raw_config()` implements the same 4-location precedence once, stdlib-only (this module still imports nothing beyond it -- see its module docstring).
- Cross-referenced with a comment on both sides (here and `ConfigLoader._get_config_path`) so future precedence changes don't drift apart again silently.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F6).

## Test plan
- [x] `pytest tests/unit -q` -- 715 passed (9 new tests pinning `_read_raw_config`'s precedence order and its two consumers, previously zero coverage)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs