### PR TITLE
Load kg_app.py's config once instead of 12 separate ConfigLoader() reads

### DIFF
--- a/prisma/server/kg_app.py
+++ b/prisma/server/kg_app.py
@@ -12,7 +12,6 @@ place `KnowledgeGraphService` may run.
 from __future__ import annotations
 
 import logging
-import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -39,146 +38,64 @@ _LOG_PATHS = _log_setup.configure()
 _log = logging.getLogger("prisma.knowledge_graph")
 
 
-# ── Vault root / config helpers — vault_root and the kg: section both go
-# through ConfigLoader/KGConfig (utils/config.py) now; supervisor.py keeps
-# its own separate, deliberately stdlib-only resolver (see its module
-# docstring's "stdlib + yaml only" constraint) since it can't depend on
-# Pydantic. ───────────────────────────────────────────────────────────────
+# ── Config — loaded once here; supervisor.py keeps its own separate,
+# deliberately stdlib-only resolver (see its module docstring's "stdlib
+# only" constraint) since it can't depend on Pydantic. ─────────────────────
 
-def _resolve_vault_root() -> Path:
-    from prisma.utils.config import ConfigLoader
+def _load_config():
+    """Returns (ConfigLoader-or-None, PrismaConfig). A broken/unreadable
+    config.toml falls back to an in-memory default PrismaConfig() rather
+    than stopping this process from starting at all -- every field below
+    already has a sensible default in the Pydantic model, so a load
+    failure and "config.toml not present" should behave identically."""
+    from prisma.utils.config import ConfigLoader, PrismaConfig
     try:
-        return ConfigLoader().get_vault_root()
+        loader = ConfigLoader()
+        return loader, loader.config
     except Exception:
-        return Path.home() / "prisma-vault"
+        return None, PrismaConfig()
 
 
-def _ollama_model() -> str:
+def _resolve_vault_root(loader) -> Path:
+    if loader is not None:
+        try:
+            return loader.get_vault_root()
+        except Exception:
+            pass
+    return Path.home() / "prisma-vault"
+
+
+def _resolve_kg_api_key(llm_config) -> str:
     try:
-        from prisma.utils.config import ConfigLoader
-        return ConfigLoader().get_llm_config().model
+        return llm_config.resolve_api_key()
     except Exception:
-        return "qwen2.5:7b-32k"
-
-
-def _llm_base_url() -> str:
-    # Delegates to LLMConfig.base_url (utils/config.py) rather than
-    # re-deriving the per-provider URL shape here — that property already
-    # knows ollama/llama_cpp are OpenAI-compatible on {host}/v1 while
-    # openrouter's is the fixed https://openrouter.ai/api/v1, so this stays
-    # correct as providers are added instead of drifting from it.
-    try:
-        from prisma.utils.config import ConfigLoader
-        return ConfigLoader().get_llm_config().base_url
-    except Exception:
-        return "http://localhost:11434"
-
-
-def _llm_provider() -> str:
-    try:
-        from prisma.utils.config import ConfigLoader
-        return ConfigLoader().get_llm_config().provider
-    except Exception:
+        _log.warning("could not resolve openrouter API key for KG extraction", exc_info=True)
         return "ollama"
 
 
-def _llm_api_key() -> str:
-    # Only meaningful for provider=openrouter — ollama/llama_cpp's local
-    # OpenAI-compat servers don't check the key at all (dummy value kept for
-    # API compatibility with the openai SDK, which requires a non-empty
-    # string). Mirrors ChatLLM._resolve_api_key's same env-var-by-name
-    # pattern (ADR-014) — the real key never lives in config.toml itself.
-    try:
-        from prisma.utils.config import ConfigLoader
-        cfg = ConfigLoader().get_llm_config()
-        if cfg.provider == "openrouter":
-            if not cfg.api_key_env:
-                raise RuntimeError("llm.provider is 'openrouter' but llm.api_key_env is not set")
-            key = os.environ.get(cfg.api_key_env)
-            if not key:
-                raise RuntimeError(f"llm.api_key_env={cfg.api_key_env!r} is not set in the environment")
-            return key
-    except Exception:
-        _log.warning("could not resolve openrouter API key for KG extraction", exc_info=True)
-    return "ollama"
-
-
-def _llm_context_window() -> int | None:
-    # Static override for providers with no live-queryable endpoint
-    # (openrouter) — see LLMConfig.context_window's own docstring.
-    try:
-        from prisma.utils.config import ConfigLoader
-        return ConfigLoader().get_llm_config().context_window
-    except Exception:
-        return None
-
-
-def _max_output_fraction() -> float:
-    from prisma.utils.config import ConfigLoader
-    try:
-        return ConfigLoader().get_kg_config().max_output_fraction
-    except Exception:
-        return 0.25
-
-
-def _max_entities() -> int:
-    from prisma.utils.config import ConfigLoader
-    try:
-        return ConfigLoader().get_kg_config().max_entities
-    except Exception:
-        return 15
-
-
-def _max_relationships() -> int:
-    from prisma.utils.config import ConfigLoader
-    try:
-        return ConfigLoader().get_kg_config().max_relationships
-    except Exception:
-        return 20
-
-
-def _index_extensions() -> tuple[str, ...]:
+def _normalize_index_extensions(exts: list[str]) -> tuple[str, ...]:
     from prisma.services.knowledge_graph_service import DEFAULT_INDEX_EXTENSIONS
-    from prisma.utils.config import ConfigLoader
-    try:
-        exts = ConfigLoader().get_kg_config().index_extensions
-        if exts:
-            return tuple(e if e.startswith(".") else f".{e}" for e in exts)
-    except Exception:
-        pass
-    return DEFAULT_INDEX_EXTENSIONS
+    if not exts:
+        return DEFAULT_INDEX_EXTENSIONS
+    return tuple(e if e.startswith(".") else f".{e}" for e in exts)
 
 
-def _extraction_concurrency() -> int:
-    from prisma.utils.config import ConfigLoader
-    try:
-        return ConfigLoader().get_kg_config().extraction_concurrency
-    except Exception:
-        return 3
+_loader, _cfg = _load_config()
 
-
-def _token_budget() -> int:
-    from prisma.utils.config import ConfigLoader
-    try:
-        return ConfigLoader().get_kg_config().token_budget
-    except Exception:
-        return 1000
-
-
-_vault = VaultService(vault_root=_resolve_vault_root())
+_vault = VaultService(vault_root=_resolve_vault_root(_loader))
 _kg = KnowledgeGraphService(
     _vault,
-    ollama_model=_ollama_model(),
-    ollama_base_url=_llm_base_url(),
-    provider=_llm_provider(),
-    api_key=_llm_api_key(),
-    context_window_override=_llm_context_window(),
-    max_output_fraction=_max_output_fraction(),
-    index_extensions=_index_extensions(),
-    extraction_concurrency=_extraction_concurrency(),
-    token_budget=_token_budget(),
-    max_entities=_max_entities(),
-    max_relationships=_max_relationships(),
+    ollama_model=_cfg.llm.model,
+    ollama_base_url=_cfg.llm.base_url,
+    provider=_cfg.llm.provider,
+    api_key=_resolve_kg_api_key(_cfg.llm),
+    context_window_override=_cfg.llm.context_window,
+    max_output_fraction=_cfg.kg.max_output_fraction,
+    index_extensions=_normalize_index_extensions(_cfg.kg.index_extensions),
+    extraction_concurrency=_cfg.kg.extraction_concurrency,
+    token_budget=_cfg.kg.token_budget,
+    max_entities=_cfg.kg.max_entities,
+    max_relationships=_cfg.kg.max_relationships,
 )
 
 

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -139,6 +139,27 @@ class LLMConfig(BaseModel):
             return "https://openrouter.ai/api/v1"
         return f"http://{self.host}"
 
+    def resolve_api_key(self) -> str:
+        """Effective API key for this LLM backend. Only meaningful for
+        provider="openrouter" -- ollama/llama_cpp's local OpenAI-compat
+        servers don't check the key at all, so those get the placeholder
+        "ollama" (kept non-empty for the openai SDK's requirement) without
+        even looking at api_key_env. For openrouter, raises if
+        api_key_env isn't set or the named env var is empty -- fail loud
+        on a misconfigured indirection, same contract as
+        ZoteroConfig.resolve_api_key/SourceQuotaConfig.resolve_api_key.
+        Callers that need to degrade instead of crash (kg_app.py, which
+        must still start with a partially-broken LLM config) catch this
+        themselves."""
+        if self.provider != "openrouter":
+            return "ollama"
+        if not self.api_key_env:
+            raise RuntimeError("llm.provider is 'openrouter' but llm.api_key_env is not set")
+        key = os.environ.get(self.api_key_env)
+        if not key:
+            raise RuntimeError(f"llm.api_key_env={self.api_key_env!r} is not set in the environment")
+        return key
+
 
 class ChatConfig(BaseModel):
     """Chat module LLM backend configuration (ADR-014: openai SDK, multi-base_url)."""

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -212,6 +212,32 @@ index_extensions = ["md", ".yaml"]
         with self.assertRaises(ValidationError):
             LLMConfig(provider='anthropic')
 
+    def test_llm_resolve_api_key_ollama_returns_placeholder_ignoring_api_key_env(self):
+        # Local OpenAI-compat servers don't check the key at all -- must not
+        # even look at api_key_env (or raise if it's unset) for this provider.
+        cfg = LLMConfig(provider='ollama')
+        self.assertEqual(cfg.resolve_api_key(), 'ollama')
+
+    def test_llm_resolve_api_key_llama_cpp_returns_placeholder(self):
+        cfg = LLMConfig(provider='llama_cpp')
+        self.assertEqual(cfg.resolve_api_key(), 'ollama')
+
+    def test_llm_resolve_api_key_openrouter_reads_named_env_var(self):
+        cfg = LLMConfig(provider='openrouter', api_key_env='LLM_TEST_KEY_VAR')
+        with patch.dict(os.environ, {'LLM_TEST_KEY_VAR': 'from-env'}):
+            self.assertEqual(cfg.resolve_api_key(), 'from-env')
+
+    def test_llm_resolve_api_key_openrouter_raises_when_api_key_env_unset(self):
+        cfg = LLMConfig(provider='openrouter')
+        with self.assertRaises(RuntimeError):
+            cfg.resolve_api_key()
+
+    def test_llm_resolve_api_key_openrouter_raises_when_env_var_missing(self):
+        cfg = LLMConfig(provider='openrouter', api_key_env='LLM_TEST_KEY_VAR_UNSET')
+        os.environ.pop('LLM_TEST_KEY_VAR_UNSET', None)
+        with self.assertRaises(RuntimeError):
+            cfg.resolve_api_key()
+
     def test_validation_errors(self):
         """Test that Pydantic validation catches invalid configurations."""
         # Test invalid output format


### PR DESCRIPTION
## Summary
- Each of 11 near-identical accessor functions independently instantiated `ConfigLoader()` (re-reading and re-validating the whole TOML each time) and duplicated a fallback literal that also lived in the Pydantic model's own `Field` default (e.g. `kg_app.py`'s `max_output_fraction=0.25` vs `KGConfig.max_output_fraction`'s own `Field(0.25)`) -- six such pairs, only reachable when the file itself fails to load, at which point they could only ever disagree with the model, never agree usefully.
- Now loads once (`_load_config()`, falling back to an in-memory default `PrismaConfig()` on total failure) and reads `_cfg.llm`/`_cfg.kg` directly -- every fallback value is the Pydantic model's own default, single source of truth. 262 -> 179 lines.
- `_llm_api_key`'s one real piece of logic (openrouter's env-var-by-name resolution) moves to `LLMConfig.resolve_api_key()`, matching `ZoteroConfig.resolve_api_key`/`SourceQuotaConfig.resolve_api_key`'s existing contract and making it independently unit-testable for the first time (`kg_app.py` itself still can't be, without side effects, at module import).

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F7).

## Test plan
- [x] `pytest tests/unit -q` -- 720 passed (5 new tests for `LLMConfig.resolve_api_key()`)
- [x] Manually sanity-imported `prisma.server.kg_app` (not covered by the automated suite -- it's process-level side-effecting module code) with both a working and a broken `config.toml`, confirmed it resolves correctly and degrades gracefully in both cases
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs