### PR TITLE
Validate SearchConfig.sources against SOURCE_NAMES instead of a hand-copied list

### DIFF
--- a/prisma/integrations/sources/__init__.py
+++ b/prisma/integrations/sources/__init__.py
@@ -18,7 +18,18 @@ from .openlibrary import OpenLibrarySource
 from .pubmed import PubMedSource
 from .semantic_scholar import SemanticScholarSource
 
-__all__ = ["Source", "SourceSearchResult", "build_sources"]
+__all__ = ["Source", "SourceSearchResult", "SOURCE_NAMES", "build_sources"]
+
+# The set of names build_sources() actually returns -- kept beside it (not
+# derived by calling build_sources(), which constructs real Source
+# instances/rate limiters/resolves API keys, too heavy to run just to
+# validate a config string) so SearchConfig.validate_sources
+# (utils/config.py) has a single, lightweight source of truth instead of
+# its own hardcoded copy of this same name list. Update both together when
+# adding a source.
+SOURCE_NAMES: frozenset[str] = frozenset({
+    "arxiv", "semanticscholar", "openlibrary", "googlebooks", "pubmed", "ieee_xplore",
+})
 
 
 def _override(config: SearchConfig, name: str) -> SourceQuotaConfig:

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -282,10 +282,17 @@ class SearchConfig(BaseModel):
     @field_validator('sources')
     @classmethod
     def validate_sources(cls, v):
-        valid_sources = ['arxiv', 'zotero', 'pubmed', 'google_scholar', 'semanticscholar', 'openlibrary', 'googlebooks', 'ieee_xplore']
+        # Deferred import -- integrations.sources imports SearchConfig itself
+        # (for build_sources()'s type hint), so this must stay a call-time
+        # import, not a module-level one, to avoid a circular import.
+        from ..integrations.sources import SOURCE_NAMES
+        # 'zotero' isn't a discovery Source (not in SOURCE_NAMES) -- it's the
+        # bookmark layer, explicitly handled as a no-op in
+        # SearchAgent.search()'s dispatch, not silently dropped.
+        valid_sources = SOURCE_NAMES | {"zotero"}
         for source in v:
             if source not in valid_sources:
-                raise ValueError(f'source "{source}" not in valid sources: {valid_sources}')
+                raise ValueError(f'source "{source}" not in valid sources: {sorted(valid_sources)}')
         return v
 
 

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -261,7 +261,33 @@ index_extensions = ["md", ".yaml"]
         with self.assertRaises(ValidationError):
             from prisma.utils.config import SearchConfig
             SearchConfig(default_limit=-1)
-    
+
+    def test_search_config_accepts_real_discovery_sources(self):
+        from prisma.utils.config import SearchConfig
+        cfg = SearchConfig(sources=['arxiv', 'pubmed', 'ieee_xplore'])
+        self.assertEqual(cfg.sources, ['arxiv', 'pubmed', 'ieee_xplore'])
+
+    def test_search_config_accepts_zotero_as_a_special_case(self):
+        # zotero isn't a discovery Source (not in build_sources()'s keys) --
+        # it's the bookmark layer, explicitly handled as a no-op in
+        # SearchAgent.search()'s dispatch. Must stay valid regardless.
+        from prisma.utils.config import SearchConfig
+        cfg = SearchConfig(sources=['arxiv', 'zotero'])
+        self.assertIn('zotero', cfg.sources)
+
+    def test_search_config_rejects_google_scholar(self):
+        # google_scholar has no source module and no special-case handling
+        # anywhere -- previously accepted then silently no-op'd via
+        # SearchAgent's "not yet implemented" warning branch.
+        from prisma.utils.config import SearchConfig
+        with self.assertRaises(ValidationError):
+            SearchConfig(sources=['google_scholar'])
+
+    def test_search_config_rejects_unknown_source(self):
+        from prisma.utils.config import SearchConfig
+        with self.assertRaises(ValidationError):
+            SearchConfig(sources=['not-a-real-source'])
+
     def test_zotero_credentials_check(self):
         """Test Zotero credentials validation."""
         # Test with a clean config loader (no config file)

--- a/tests/unit/integrations/sources/test_registry.py
+++ b/tests/unit/integrations/sources/test_registry.py
@@ -1,9 +1,13 @@
-"""Consistency checks across the three places a source name has to agree:
-build_sources()'s registry, SOURCE_REGISTRY (quality metadata), and
-SearchConfig.valid_sources. A mismatch here silently degrades a source to
-the ONE_STAR default quality (get_source_quality's fallback) instead of
-raising -- this is exactly the class of bug the semanticscholar/
-semantic_scholar naming mismatch was (fixed 2026-07-29)."""
+"""Consistency checks across the two places a source name has to agree:
+build_sources()'s registry and SOURCE_REGISTRY (quality metadata).
+(SearchConfig.validate_sources used to be a third, hand-maintained copy of
+this same name list -- it now imports SOURCE_NAMES from
+integrations.sources instead, so it can't drift on its own; the third
+check below just confirms that wiring still holds.) A mismatch here
+silently degrades a source to the ONE_STAR default quality
+(get_source_quality's fallback) instead of raising -- this is exactly the
+class of bug the semanticscholar/semantic_scholar naming mismatch was
+(fixed 2026-07-29)."""
 
 from prisma.integrations.sources import build_sources
 from prisma.storage.models.source_quality import SOURCE_REGISTRY, SourceQuality, get_source_quality


### PR DESCRIPTION
## Summary
- `SearchConfig.validate_sources` carried its own hardcoded whitelist, duplicating (and free to drift from) `build_sources()`'s real keys. Extension already required editing `build_sources()` *and* this list -- `sources/__init__.py`'s own docstring claimed "one module plus one entry in `build_sources()`", no longer true.
- It also accepted `'google_scholar'`, which has no source module and no special-case handling anywhere -- silently hit `SearchAgent`'s "not yet implemented" warning at search time instead of being rejected up front at config-load time.
- New `SOURCE_NAMES` frozenset lives beside `build_sources()` in the same file (not called-and-discarded -- `build_sources()` constructs real Source instances/rate limiters/resolves API keys, too heavy to run just to validate a config string). `SearchConfig.validate_sources` imports it (deferred, to avoid the circular import -- `integrations.sources` itself imports `SearchConfig` for `build_sources()`'s type hint) instead of keeping its own copy.
- `'zotero'` stays valid as an explicit special case -- it isn't a discovery Source, but is deliberately handled as a no-op in `SearchAgent.search()`'s dispatch, not silently dropped like `google_scholar` was.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F8) -- the last small item from the Python side. Only F4 (splitting `app.py` into routers, ~2300 lines) remains.

## Test plan
- [x] `pytest tests/unit -q` -- 724 passed (4 new tests: valid discovery sources, `zotero` special-cased, `google_scholar` now rejected, unknown names rejected)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs