### PR TITLE
Extract /notes/* routes into prisma/server/notes_routes.py

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -57,7 +57,6 @@ _t("vault ok")
 
 _t("importing renderer")
 from prisma.services.renderer import render as vault_render
-from prisma.services.asset_rewrite import asset_prefix, rewrite_html
 _t("renderer ok")
 
 _t("importing knowledge_graph_client")
@@ -87,7 +86,7 @@ _t("sync_orchestrator ok")
 _t("importing vault_models")
 from prisma.storage.models.vault_models import (
     Chat, ChatMessage, ChatRole, NodeType, RenderedNode, StreamRunResult, ToolCallRecord,
-    VaultListing, VaultTreeNode,
+    VaultTreeNode,
 )
 _t("vault_models ok")
 
@@ -495,6 +494,7 @@ app.add_middleware(AccessLogMiddleware)
 # value at include_router() time would keep talking to a stale, replaced
 # instance after a reload.
 from prisma.server.sync_routes import build_sync_router  # noqa: E402
+from prisma.server.notes_routes import build_notes_router, render_note  # noqa: E402
 def _update_client_baseline(client_id: str, path: str, content_hash: str, mtime: float) -> None:
     with _client_baseline_lock:
         _client_baseline.setdefault(client_id, {})[path] = (content_hash, mtime)
@@ -511,6 +511,12 @@ app.include_router(build_sync_router(
     mark_stale_fn=lambda path: _indexer.mark_stale(path),
     update_baseline_fn=_update_client_baseline,
     clear_baseline_fn=_clear_client_baseline,
+))
+
+app.include_router(build_notes_router(
+    get_vault=lambda: _vault,
+    mark_stale_fn=lambda: _indexer.mark_stale(),
+    broadcast_fn=broadcast,
 ))
 
 _executor = ThreadPoolExecutor(max_workers=2)
@@ -1379,74 +1385,6 @@ def create_dir(req: CreateDirRequest):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@app.get("/notes", response_model=VaultListing)
-def list_notes(node_type: Optional[NodeType] = Query(None)):
-    return _vault.list_nodes(node_type)
-
-
-@app.get("/notes/{slug}", response_model=RenderedNode)
-def get_note(slug: str, request: Request, format: str = "html"):
-    from prisma.storage.models.vault_models import Stream
-    try:
-        node = _vault.get_any(slug)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"node not found: {slug!r}")
-    body = node.body if hasattr(node, "body") else ""
-    original_ext = getattr(node, "original_ext", None)
-    node_path = getattr(node, "path", None)
-    has_md = False
-
-    if original_ext == ".html":
-        html_path = node_path if (node_path and node_path.suffix == ".html") else None
-        if html_path is None and node_path is not None:
-            companion = node_path.with_suffix(".html")
-            if companion.exists():
-                html_path = companion
-
-        if html_path is not None:
-            has_md = bool(_vault.get_md_body(html_path))
-
-        if format == "md" and html_path is not None and has_md:
-            md_body = _vault.get_md_body(html_path) or ""
-            html, broken_links, broken_citations = vault_render(md_body, _vault)
-            prefix = asset_prefix(_vault.root, html_path, str(request.base_url))
-            html = rewrite_html(html, prefix, mode="markdown")
-            original_ext = None  # render as plain markdown, no iframe
-        else:
-            import re as _re
-            if html_path is not None and node_path and node_path.suffix != ".html":
-                body = html_path.read_text(encoding="utf-8")
-            styles = "".join(_re.findall(r"<style[^>]*>.*?</style>", body, _re.DOTALL | _re.IGNORECASE))
-            m = _re.search(r"<body[^>]*>(.*?)</body>", body, _re.DOTALL | _re.IGNORECASE)
-            html = (styles + "\n" + m.group(1).strip()) if m else body
-            if html_path is not None:
-                prefix = asset_prefix(_vault.root, html_path, str(request.base_url))
-                html = rewrite_html(html, prefix, mode="fragment")
-            broken_links, broken_citations = [], []
-    else:
-        html, broken_links, broken_citations = vault_render(body, _vault)
-
-    rn = RenderedNode(
-        slug=slug,
-        title=node.title,
-        node_type=node.node_type,
-        html=html,
-        broken_links=broken_links,
-        broken_citations=broken_citations,
-        original_ext=original_ext,
-        has_md=has_md,
-    )
-    if isinstance(node, Stream):
-        rn.stream_status = node.status
-        rn.refresh_frequency = node.refresh_frequency
-        rn.total_papers = node.total_papers
-        rn.last_updated = node.last_updated
-        rn.next_update = node.next_update
-        rn.query = node.query
-        rn.collection_key = node.collection_key
-    return rn
-
-
 _ALLOWED_ASSET_EXTS = {
     ".css", ".js", ".map",
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico",
@@ -1466,111 +1404,6 @@ def vault_asset(asset_path: str):
     if not candidate_path.is_file():
         raise HTTPException(status_code=404, detail="not found")
     return FileResponse(candidate_path)
-
-
-@app.get("/notes/{slug}/view")
-def view_html(slug: str, request: Request):
-    from fastapi.responses import HTMLResponse
-    path = _vault.find_companion(slug)
-    if path is None:
-        # Standalone .html file (no .md companion)
-        found = _vault.find_file(slug)
-        if found is not None and found.suffix == ".html":
-            path = found
-    if path is None:
-        raise HTTPException(status_code=404, detail=f"no HTML file for {slug!r}")
-    body = path.read_text(encoding="utf-8")
-    prefix = asset_prefix(_vault.root, path, str(request.base_url))
-    body = rewrite_html(body, prefix, mode="full")
-    interceptor = (
-        "<script>"
-        "document.addEventListener('click',function(e){"
-        "var a=e.target.closest('a');if(!a)return;"
-        "var h=a.getAttribute('href')||'';"
-        "if(h.startsWith('http://')||h.startsWith('https://')){"
-        "e.preventDefault();"
-        "window.parent.postMessage({type:'open-url',url:h},'*');"
-        "}"
-        "});"
-        "</script>"
-    )
-    body = body.replace("</body>", interceptor + "</body>", 1)
-    if "</body>" not in body:
-        body += interceptor
-    return HTMLResponse(content=body)
-
-
-class GenerateMdResponse(BaseModel):
-    generated: bool
-    slug: str
-
-
-@app.post("/notes/{slug}/md", status_code=202, response_model=GenerateMdResponse)
-def generate_md_format(slug: str):
-    try:
-        node = _vault.get_any(slug)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"node not found: {slug!r}")
-    html_path = getattr(node, "path", None)
-    if html_path is None or html_path.suffix != ".html":
-        raise HTTPException(status_code=400, detail="node has no HTML format")
-    generated = _vault.ensure_md_format(html_path)
-    return {"generated": generated, "slug": slug}
-
-
-class SetTypeRequest(BaseModel):
-    node_type: NodeType
-
-@app.patch("/notes/{slug}/type")
-def set_note_type(slug: str, body: SetTypeRequest):
-    try:
-        _vault.set_node_type(slug, body.node_type)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"node not found: {slug!r}")
-    return {"slug": slug, "node_type": body.node_type.value}
-
-
-@app.get("/notes/{slug}/original")
-def get_original(slug: str):
-    from fastapi.responses import FileResponse
-    path = _vault.find_companion(slug)
-    if path is None:
-        raise HTTPException(status_code=404, detail=f"no companion file for source {slug!r}")
-    return FileResponse(str(path))
-
-
-class NoteCreateRequest(BaseModel):
-    title: str
-    body: str = ""
-    tags: Optional[list[str]] = None
-
-
-@app.post("/notes", response_model=RenderedNode, status_code=201)
-def create_note(req: NoteCreateRequest):
-    note = _vault.create_note(req.title, req.body, req.tags)
-    _indexer.mark_stale()
-    _activity.info("action=create_note slug=%s title=%r", note.slug, note.title)
-    broadcast({"type": "vault_change", "action": "create", "slug": note.slug})
-    html, broken_links, broken_citations = vault_render(note.body, _vault)
-    return RenderedNode(slug=note.slug, title=note.title, node_type=note.node_type,
-                        html=html, broken_links=broken_links, broken_citations=broken_citations)
-
-
-class NoteSaveRequest(BaseModel):
-    body: str
-
-
-@app.put("/notes/{slug}", response_model=RenderedNode)
-def save_note(slug: str, req: NoteSaveRequest):
-    try:
-        note = _vault.save_note(slug, req.body)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"note not found: {slug!r}")
-    _indexer.mark_stale()
-    broadcast({"type": "vault_change", "action": "save", "slug": slug})
-    html, broken_links, broken_citations = vault_render(note.body, _vault)
-    return RenderedNode(slug=note.slug, title=note.title, node_type=note.node_type,
-                        html=html, broken_links=broken_links, broken_citations=broken_citations)
 
 
 class SearchResult(BaseModel):
@@ -1780,7 +1613,7 @@ def get_stream(slug: str):
 
 @app.get("/streams/{slug}/view", response_model=RenderedNode)
 def get_stream_view(slug: str, request: Request, format: str = "html"):
-    return get_note(slug, request, format)
+    return render_note(_vault, slug, request, format)
 
 
 class StreamCreateRequest(BaseModel):

--- a/prisma/server/notes_routes.py
+++ b/prisma/server/notes_routes.py
@@ -1,0 +1,213 @@
+"""Note/source CRUD endpoints (/notes/*).
+
+Built via a factory (`build_notes_router`) taking getter/callback callables
+rather than raw objects, same reasoning as sync_routes.py's
+`build_sync_router`: app.py's `/reload`-style endpoints rebind its module
+globals (`global _vault; _vault = VaultService(...)`, similarly for
+`_indexer`) at runtime, so a router that captured them by value at
+include_router() time would keep talking to a stale, replaced instance
+after a reload. `broadcast` is passed in rather than imported directly
+because it closes over app.py-local WebSocket connection state
+(`_ws_loop`/`_ws_clients`) -- importing it here would be a circular import.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from prisma.services.asset_rewrite import asset_prefix, rewrite_html
+from prisma.services.renderer import render as vault_render
+from prisma.services.vault import VaultService
+from prisma.storage.models.vault_models import NodeType, RenderedNode, Stream, VaultListing
+
+_activity = logging.getLogger("prisma.activity")
+
+
+class GenerateMdResponse(BaseModel):
+    generated: bool
+    slug: str
+
+
+class SetTypeRequest(BaseModel):
+    node_type: NodeType
+
+
+class NoteCreateRequest(BaseModel):
+    title: str
+    body: str = ""
+    tags: Optional[list[str]] = None
+
+
+class NoteSaveRequest(BaseModel):
+    body: str
+
+
+def render_note(vault: VaultService, slug: str, request: Request, format: str = "html") -> RenderedNode:
+    """Core of GET /notes/{slug} -- also called directly by
+    GET /streams/{slug}/view (app.py), which reuses this exact rendering
+    logic since a Stream is itself a vault node with the same .md/.html
+    shape as a note or source."""
+    try:
+        node = vault.get_any(slug)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"node not found: {slug!r}")
+    body = node.body if hasattr(node, "body") else ""
+    original_ext = getattr(node, "original_ext", None)
+    node_path = getattr(node, "path", None)
+    has_md = False
+
+    if original_ext == ".html":
+        html_path = node_path if (node_path and node_path.suffix == ".html") else None
+        if html_path is None and node_path is not None:
+            companion = node_path.with_suffix(".html")
+            if companion.exists():
+                html_path = companion
+
+        if html_path is not None:
+            has_md = bool(vault.get_md_body(html_path))
+
+        if format == "md" and html_path is not None and has_md:
+            md_body = vault.get_md_body(html_path) or ""
+            html, broken_links, broken_citations = vault_render(md_body, vault)
+            prefix = asset_prefix(vault.root, html_path, str(request.base_url))
+            html = rewrite_html(html, prefix, mode="markdown")
+            original_ext = None  # render as plain markdown, no iframe
+        else:
+            import re as _re
+            if html_path is not None and node_path and node_path.suffix != ".html":
+                body = html_path.read_text(encoding="utf-8")
+            styles = "".join(_re.findall(r"<style[^>]*>.*?</style>", body, _re.DOTALL | _re.IGNORECASE))
+            m = _re.search(r"<body[^>]*>(.*?)</body>", body, _re.DOTALL | _re.IGNORECASE)
+            html = (styles + "\n" + m.group(1).strip()) if m else body
+            if html_path is not None:
+                prefix = asset_prefix(vault.root, html_path, str(request.base_url))
+                html = rewrite_html(html, prefix, mode="fragment")
+            broken_links, broken_citations = [], []
+    else:
+        html, broken_links, broken_citations = vault_render(body, vault)
+
+    rn = RenderedNode(
+        slug=slug,
+        title=node.title,
+        node_type=node.node_type,
+        html=html,
+        broken_links=broken_links,
+        broken_citations=broken_citations,
+        original_ext=original_ext,
+        has_md=has_md,
+    )
+    if isinstance(node, Stream):
+        rn.stream_status = node.status
+        rn.refresh_frequency = node.refresh_frequency
+        rn.total_papers = node.total_papers
+        rn.last_updated = node.last_updated
+        rn.next_update = node.next_update
+        rn.query = node.query
+        rn.collection_key = node.collection_key
+    return rn
+
+
+def build_notes_router(
+    get_vault: Callable[[], VaultService],
+    mark_stale_fn: Callable[[], None],
+    broadcast_fn: Callable[..., None],
+) -> APIRouter:
+    router = APIRouter(prefix="/notes", tags=["notes"])
+
+    @router.get("", response_model=VaultListing)
+    def list_notes(node_type: Optional[NodeType] = Query(None)):
+        return get_vault().list_nodes(node_type)
+
+    @router.get("/{slug}", response_model=RenderedNode)
+    def get_note(slug: str, request: Request, format: str = "html"):
+        return render_note(get_vault(), slug, request, format)
+
+    @router.get("/{slug}/view")
+    def view_html(slug: str, request: Request):
+        from fastapi.responses import HTMLResponse
+        vault = get_vault()
+        path = vault.find_companion(slug)
+        if path is None:
+            # Standalone .html file (no .md companion)
+            found = vault.find_file(slug)
+            if found is not None and found.suffix == ".html":
+                path = found
+        if path is None:
+            raise HTTPException(status_code=404, detail=f"no HTML file for {slug!r}")
+        body = path.read_text(encoding="utf-8")
+        prefix = asset_prefix(vault.root, path, str(request.base_url))
+        body = rewrite_html(body, prefix, mode="full")
+        interceptor = (
+            "<script>"
+            "document.addEventListener('click',function(e){"
+            "var a=e.target.closest('a');if(!a)return;"
+            "var h=a.getAttribute('href')||'';"
+            "if(h.startsWith('http://')||h.startsWith('https://')){"
+            "e.preventDefault();"
+            "window.parent.postMessage({type:'open-url',url:h},'*');"
+            "}"
+            "});"
+            "</script>"
+        )
+        body = body.replace("</body>", interceptor + "</body>", 1)
+        if "</body>" not in body:
+            body += interceptor
+        return HTMLResponse(content=body)
+
+    @router.post("/{slug}/md", status_code=202, response_model=GenerateMdResponse)
+    def generate_md_format(slug: str):
+        vault = get_vault()
+        try:
+            node = vault.get_any(slug)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail=f"node not found: {slug!r}")
+        html_path = getattr(node, "path", None)
+        if html_path is None or html_path.suffix != ".html":
+            raise HTTPException(status_code=400, detail="node has no HTML format")
+        generated = vault.ensure_md_format(html_path)
+        return {"generated": generated, "slug": slug}
+
+    @router.patch("/{slug}/type")
+    def set_note_type(slug: str, body: SetTypeRequest):
+        try:
+            get_vault().set_node_type(slug, body.node_type)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail=f"node not found: {slug!r}")
+        return {"slug": slug, "node_type": body.node_type.value}
+
+    @router.get("/{slug}/original")
+    def get_original(slug: str):
+        from fastapi.responses import FileResponse
+        path = get_vault().find_companion(slug)
+        if path is None:
+            raise HTTPException(status_code=404, detail=f"no companion file for source {slug!r}")
+        return FileResponse(str(path))
+
+    @router.post("", response_model=RenderedNode, status_code=201)
+    def create_note(req: NoteCreateRequest):
+        vault = get_vault()
+        note = vault.create_note(req.title, req.body, req.tags)
+        mark_stale_fn()
+        _activity.info("action=create_note slug=%s title=%r", note.slug, note.title)
+        broadcast_fn({"type": "vault_change", "action": "create", "slug": note.slug})
+        html, broken_links, broken_citations = vault_render(note.body, vault)
+        return RenderedNode(slug=note.slug, title=note.title, node_type=note.node_type,
+                            html=html, broken_links=broken_links, broken_citations=broken_citations)
+
+    @router.put("/{slug}", response_model=RenderedNode)
+    def save_note(slug: str, req: NoteSaveRequest):
+        vault = get_vault()
+        try:
+            note = vault.save_note(slug, req.body)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail=f"note not found: {slug!r}")
+        mark_stale_fn()
+        broadcast_fn({"type": "vault_change", "action": "save", "slug": slug})
+        html, broken_links, broken_citations = vault_render(note.body, vault)
+        return RenderedNode(slug=note.slug, title=note.title, node_type=note.node_type,
+                            html=html, broken_links=broken_links, broken_citations=broken_citations)
+
+    return router

--- a/tests/unit/server/test_notes_routes.py
+++ b/tests/unit/server/test_notes_routes.py
@@ -1,0 +1,173 @@
+"""Unit tests for prisma.server.notes_routes — built in isolation (a bare
+FastAPI app wrapping just build_notes_router + a tmp_path VaultService), not
+the full prisma.server.app singleton, same approach as test_sync_routes.py.
+"""
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from prisma.server.notes_routes import build_notes_router
+from prisma.services.vault import VaultService
+from prisma.storage.models.vault_models import NodeType
+
+
+class _Recorder:
+    def __init__(self):
+        self.broadcasts = []
+        self.mark_stale_calls = 0
+
+    def broadcast(self, event, exclude_client_id=None):
+        self.broadcasts.append((event, exclude_client_id))
+
+    def mark_stale(self):
+        self.mark_stale_calls += 1
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> VaultService:
+    v = VaultService(tmp_path)
+    v.ensure_dirs()
+    return v
+
+
+@pytest.fixture
+def recorder() -> _Recorder:
+    return _Recorder()
+
+
+@pytest.fixture
+def client(vault, recorder) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_notes_router(
+        get_vault=lambda: vault,
+        mark_stale_fn=recorder.mark_stale,
+        broadcast_fn=recorder.broadcast,
+    ))
+    return TestClient(app)
+
+
+def _make_html_source(vault: VaultService, slug: str, html: str = "<html><body>hi</body></html>") -> None:
+    """A .md node with an attached .html companion (find_companion()'s
+    pattern) -- the .md is primary, .html is the extra file alongside it.
+    Different from a bare .html-only source with no .md yet (see
+    test_generate_md_format_creates_companion), where find_file()/get_any()
+    resolve the .html itself as the node's canonical file instead."""
+    d = vault.default_dirs[NodeType.source]
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{slug}.html").write_text(html, encoding="utf-8")
+    (d / f"{slug}.md").write_text('---\ntype: source\ntitle: Test Source\n---\n\n', encoding="utf-8")
+
+
+def test_list_notes_empty(client):
+    r = client.get("/notes")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["notes"] == []
+
+
+def test_create_note_then_list(client, vault, recorder):
+    r = client.post("/notes", json={"title": "My Note", "body": "hello world"})
+    assert r.status_code == 201
+    data = r.json()
+    assert data["slug"] == "my-note"
+    assert data["title"] == "My Note"
+    assert recorder.mark_stale_calls == 1
+    assert recorder.broadcasts[0][0]["action"] == "create"
+
+    r2 = client.get("/notes")
+    assert len(r2.json()["notes"]) == 1
+
+
+def test_get_note_not_found(client):
+    r = client.get("/notes/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_get_note_renders_markdown_body(client, vault):
+    vault.create_note("Deep Learning", "# Heading\n\nsome body text")
+    r = client.get("/notes/deep-learning")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["slug"] == "deep-learning"
+    assert "Heading" in data["html"] or "body text" in data["html"]
+
+
+def test_save_note_updates_body(client, vault, recorder):
+    vault.create_note("My Note", "original body")
+    r = client.put("/notes/my-note", json={"body": "updated body"})
+    assert r.status_code == 200
+    assert recorder.mark_stale_calls == 1
+    assert recorder.broadcasts[-1][0]["action"] == "save"
+
+
+def test_save_note_not_found(client):
+    r = client.put("/notes/does-not-exist", json={"body": "x"})
+    assert r.status_code == 404
+
+
+def test_set_note_type(client, vault):
+    vault.create_note("My Note", "body")
+    r = client.patch("/notes/my-note/type", json={"node_type": "source"})
+    assert r.status_code == 200
+    assert r.json()["node_type"] == "source"
+
+
+def test_set_note_type_not_found(client):
+    r = client.patch("/notes/does-not-exist/type", json={"node_type": "source"})
+    assert r.status_code == 404
+
+
+def test_get_original_returns_companion_file(client, vault):
+    _make_html_source(vault, "my-source")
+    r = client.get("/notes/my-source/original")
+    assert r.status_code == 200
+    assert "hi" in r.text
+
+
+def test_get_original_not_found(client):
+    r = client.get("/notes/does-not-exist/original")
+    assert r.status_code == 404
+
+
+def test_view_html_renders_and_rewrites_assets(client, vault):
+    _make_html_source(vault, "my-source", html='<html><body><img src="fig.png"></body></html>')
+    r = client.get("/notes/my-source/view")
+    assert r.status_code == 200
+    assert "/vault/assets/" in r.text
+    assert "fig.png" in r.text
+
+
+def test_view_html_not_found(client):
+    r = client.get("/notes/does-not-exist/view")
+    assert r.status_code == 404
+
+
+def test_generate_md_format_creates_companion(client, vault):
+    # generate_md_format only makes sense for a node whose canonical file is
+    # still bare .html with no .md companion yet -- once a .md companion
+    # exists, find_file()/get_any() resolve to the .md as primary instead
+    # (see _make_html_source's docstring-equivalent note below).
+    d = vault.default_dirs[NodeType.source]
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "my-source.html").write_text("<html><body>content</body></html>", encoding="utf-8")
+    r = client.post("/notes/my-source/md")
+    assert r.status_code == 202
+    # Whether `generated` comes back True depends on docu_craft's own HTML->MD
+    # conversion succeeding for this snippet -- not this route's concern to
+    # assert on; what matters here is the route correctly reaches
+    # vault.ensure_md_format() and returns its result, not a specific value.
+    assert r.json()["slug"] == "my-source"
+    assert isinstance(r.json()["generated"], bool)
+
+
+def test_generate_md_format_rejects_non_html_node(client, vault):
+    vault.create_note("My Note", "body")
+    r = client.post("/notes/my-note/md")
+    assert r.status_code == 400
+
+
+def test_generate_md_format_not_found(client):
+    r = client.post("/notes/does-not-exist/md")
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary
First of app.py's ~14 route domains to split out (F4 -- app.py was 2308 lines / 59 routes, all transport+wiring+domain logic in one module).

- Follows `sync_routes.py`'s existing `build_*_router(deps) -> APIRouter` pattern: getter callables for `_vault`/`_indexer` (both rebound at runtime by `/reload/*` endpoints -- a router that captured them by value at `include_router()` time would keep talking to a stale instance), `broadcast` passed in rather than imported (it closes over app.py-local WebSocket state, importing it would be circular).
- Moves all 8 `/notes` routes plus their request/response models (`GenerateMdResponse`, `SetTypeRequest`, `NoteCreateRequest`, `NoteSaveRequest`).
- `get_note`'s body is extracted into a standalone `render_note()` function -- `GET /streams/{slug}/view` (still in app.py) called `get_note()` directly as a plain function (a Stream is itself a vault node with the same .md/.html shape as a note or source), so that call site now calls `render_note()` with the same signature instead.
- `app.py`: 2222 -> 2055 lines.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F4, first extraction -- `streams_routes.py`/`zotero_routes.py`/`admin_routes.py`/`search_routes.py` still to come).

## Test plan
- [x] `pytest tests/unit -q` -- 739 passed (15 new tests for `notes_routes.py` in isolation -- bare FastAPI app + `build_notes_router` + tmp_path `VaultService`, same approach as `test_sync_routes.py` -- previously these routes had zero dedicated coverage, only reachable through the full `app.py` singleton)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs