### PR TITLE
Extract /streams/* routes and _StreamScheduler into streams_routes.py

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -24,7 +24,6 @@ from typing import Optional
 from prisma.server import log_setup as _log_setup
 _LOG_PATHS = _log_setup.configure()
 _log = logging.getLogger("prisma.server")
-_maint_log = logging.getLogger("prisma.maintenance")
 _activity = logging.getLogger("prisma.activity")
 
 def _t(label: str, _t0=[0.0]):
@@ -85,7 +84,7 @@ _t("sync_orchestrator ok")
 
 _t("importing vault_models")
 from prisma.storage.models.vault_models import (
-    Chat, ChatMessage, ChatRole, NodeType, RenderedNode, StreamRunResult, ToolCallRecord,
+    Chat, ChatMessage, ChatRole, NodeType, RenderedNode, ToolCallRecord,
     VaultTreeNode,
 )
 _t("vault_models ok")
@@ -397,58 +396,6 @@ Kept in sync by every reload path (targeted or smart), not just the smart
 one, so a mix of `/reload/zotero` then `/reload` still diffs correctly."""
 
 
-class _StreamScheduler:
-    """Background thread that runs streams when their next_update is past."""
-
-    _CHECK_INTERVAL = 5 * 60  # seconds between scans
-
-    def __init__(self) -> None:
-        self._stop_event = threading.Event()
-        self._thread: threading.Thread | None = None
-
-    def start(self) -> None:
-        self._thread = threading.Thread(target=self._loop, daemon=True, name="stream-scheduler")
-        self._thread.start()
-
-    def stop(self) -> None:
-        self._stop_event.set()
-
-    def _loop(self) -> None:
-        self._stop_event.wait(timeout=30)  # let server finish starting up
-        while not self._stop_event.is_set():
-            self._tick()
-            self._stop_event.wait(timeout=self._CHECK_INTERVAL)
-
-    def _tick(self) -> None:
-        from datetime import datetime
-        from prisma.storage.models.vault_models import StreamStatus
-        try:
-            streams = _vault.list_streams()
-        except Exception as exc:
-            _maint_log.warning("stream-scheduler: list_streams failed: %s", exc)
-            return
-        now = datetime.now()
-        due = [s for s in streams if s.status == StreamStatus.active
-               and s.refresh_frequency.value != "manual"
-               and (s.next_update is None or s.next_update <= now)]
-        _maint_log.info("stream-scheduler: tick — %d streams checked, %d due", len(streams), len(due))
-        for stream in due:
-            _maint_log.info("stream-scheduler: running %r", stream.slug)
-            try:
-                t0 = time.monotonic()
-                result = _run_stream(stream.slug, force=False)
-                elapsed_ms = (time.monotonic() - t0) * 1000
-                _maint_log.info(
-                    "stream-scheduler: %r done — found=%d saved=%d elapsed_ms=%.0f",
-                    stream.slug, result.papers_found, result.papers_saved, elapsed_ms,
-                )
-            except Exception as exc:
-                _maint_log.warning("stream-scheduler: %r failed: %s", stream.slug, exc)
-
-
-_scheduler = _StreamScheduler()
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global _ws_loop
@@ -494,7 +441,8 @@ app.add_middleware(AccessLogMiddleware)
 # value at include_router() time would keep talking to a stale, replaced
 # instance after a reload.
 from prisma.server.sync_routes import build_sync_router  # noqa: E402
-from prisma.server.notes_routes import build_notes_router, render_note  # noqa: E402
+from prisma.server.notes_routes import build_notes_router  # noqa: E402
+from prisma.server.streams_routes import build_streams_router, StreamScheduler  # noqa: E402
 def _update_client_baseline(client_id: str, path: str, content_hash: str, mtime: float) -> None:
     with _client_baseline_lock:
         _client_baseline.setdefault(client_id, {})[path] = (content_hash, mtime)
@@ -518,6 +466,18 @@ app.include_router(build_notes_router(
     mark_stale_fn=lambda: _indexer.mark_stale(),
     broadcast_fn=broadcast,
 ))
+
+app.include_router(build_streams_router(
+    get_vault=lambda: _vault,
+    get_zotero=lambda: _zotero,
+    broadcast_fn=broadcast,
+))
+
+_scheduler = StreamScheduler(
+    get_vault=lambda: _vault,
+    get_zotero=lambda: _zotero,
+    broadcast_fn=broadcast,
+)
 
 _executor = ThreadPoolExecutor(max_workers=2)
 _jobs: dict[str, object] = {}  # review jobs: dict (JobStatus-shaped); dedup jobs: DedupJobState instance
@@ -1568,127 +1528,6 @@ def deep_search(q: str = Query(..., min_length=1)) -> list[DeepSearchResult]:
     # Graph not built — text only
     return [DeepSearchResult(slug=r.slug, title=r.title, excerpt=r.excerpt, score=r.score)
             for r in _text_search(q, top_k=20)]
-
-
-class StreamMeta(BaseModel):
-    slug: str
-    title: str
-    description: Optional[str] = None
-    query: str
-    status: str
-    refresh_frequency: str
-    total_papers: int = 0
-    last_updated: Optional[str] = None
-    next_update: Optional[str] = None
-    tags: list[str] = Field(default_factory=list)
-
-
-def _stream_meta(s) -> StreamMeta:
-    return StreamMeta(
-        slug=s.slug,
-        title=s.title,
-        description=s.description,
-        query=s.query,
-        status=s.status.value,
-        refresh_frequency=s.refresh_frequency.value,
-        total_papers=s.total_papers,
-        last_updated=s.last_updated.isoformat() if s.last_updated else None,
-        next_update=s.next_update.isoformat() if s.next_update else None,
-        tags=s.tags,
-    )
-
-
-@app.get("/streams", response_model=list[StreamMeta])
-def list_streams():
-    return [_stream_meta(s) for s in _vault.list_streams()]
-
-
-@app.get("/streams/{slug}", response_model=StreamMeta)
-def get_stream(slug: str):
-    try:
-        return _stream_meta(_vault.get_stream(slug))
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
-
-
-@app.get("/streams/{slug}/view", response_model=RenderedNode)
-def get_stream_view(slug: str, request: Request, format: str = "html"):
-    return render_note(_vault, slug, request, format)
-
-
-class StreamCreateRequest(BaseModel):
-    title: str
-    query: str
-    description: Optional[str] = None
-    refresh_frequency: str = "weekly"
-    tags: Optional[list[str]] = None
-
-
-@app.post("/streams", response_model=StreamMeta, status_code=201)
-def create_stream(req: StreamCreateRequest):
-    s = _vault.create_stream(
-        title=req.title,
-        query=req.query,
-        description=req.description,
-        refresh_frequency=req.refresh_frequency,
-        tags=req.tags,
-    )
-    # No mark_stale() -- streams/*.yaml is never KG-indexable content (see
-    # KnowledgeGraphService.is_relevant_path), so it would just set "stale"
-    # with nothing ever able to clear it.
-    _activity.info("action=create_stream slug=%s query=%r freq=%s", s.slug, req.query, req.refresh_frequency)
-    return _stream_meta(s)
-
-
-class StreamPatchRequest(BaseModel):
-    title: Optional[str] = None
-    query: Optional[str] = None
-    description: Optional[str] = None
-    status: Optional[str] = None
-    refresh_frequency: Optional[str] = None
-    tags: Optional[list[str]] = None
-
-
-@app.patch("/streams/{slug}", response_model=StreamMeta)
-def patch_stream(slug: str, req: StreamPatchRequest):
-    updates = {k: v for k, v in req.model_dump().items() if v is not None}
-    try:
-        s = _vault.save_stream(slug, **updates)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
-    return _stream_meta(s)
-
-
-@app.delete("/streams/{slug}", status_code=204)
-def delete_stream(slug: str):
-    try:
-        _vault.delete_stream(slug)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
-    # No mark_stale() -- see create_stream's comment above.
-    _activity.info("action=delete_stream slug=%s", slug)
-
-
-def _run_stream(slug: str, force: bool = False) -> StreamRunResult:
-    from prisma.services.stream_runner import run_stream as _runner
-    try:
-        _vault.get_stream(slug)
-    except FileNotFoundError:
-        raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
-    broadcast({"type": "stream_progress", "slug": slug, "status": "running"})
-    result = _runner(slug, _vault, _zotero, force=force, get_stream_logger=_log_setup.get_stream_logger)
-    _activity.info(
-        "action=run_stream slug=%s found=%d saved=%d skipped_llm=%d errors=%d",
-        slug, result.papers_found, result.papers_saved, result.papers_skipped_llm, len(result.errors),
-    )
-    broadcast({"type": "stream_progress", "slug": slug, "status": "done",
-               "found": result.papers_found, "saved": result.papers_saved})
-    return result
-
-
-@app.post("/streams/{slug}/run", response_model=StreamRunResult)
-def run_stream(slug: str, force: bool = Query(False)):
-    return _run_stream(slug, force=force)
 
 
 # ── Zotero routes ─────────────────────────────────────────────────────────────

--- a/prisma/server/streams_routes.py
+++ b/prisma/server/streams_routes.py
@@ -1,0 +1,221 @@
+"""Research stream endpoints (/streams/*) plus the background scheduler that
+runs them on their own schedule.
+
+Built via a factory (`build_streams_router`) taking getter/callback
+callables rather than raw objects, same reasoning as sync_routes.py's
+`build_sync_router`/notes_routes.py's `build_notes_router`: app.py's
+`/reload`-style endpoints rebind its module globals (`global _vault; _vault
+= VaultService(...)`, similarly for `_zotero`) at runtime, so a router (or
+`StreamScheduler`, a long-lived background thread that outlives any single
+request) that captured them by value would keep talking to a stale,
+replaced instance after a reload. `broadcast` is passed in rather than
+imported directly because it closes over app.py-local WebSocket connection
+state (`_ws_loop`/`_ws_clients`) -- importing it here would be a circular
+import.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Callable, Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from prisma.integrations.zotero import ZoteroClient
+from prisma.server import log_setup as _log_setup
+from prisma.server.notes_routes import render_note
+from prisma.services.vault import VaultService
+from prisma.storage.models.vault_models import RenderedNode, StreamRunResult
+
+_activity = logging.getLogger("prisma.activity")
+_maint_log = logging.getLogger("prisma.maintenance")
+
+
+class StreamMeta(BaseModel):
+    slug: str
+    title: str
+    description: Optional[str] = None
+    query: str
+    status: str
+    refresh_frequency: str
+    total_papers: int = 0
+    last_updated: Optional[str] = None
+    next_update: Optional[str] = None
+    tags: list[str] = Field(default_factory=list)
+
+
+class StreamCreateRequest(BaseModel):
+    title: str
+    query: str
+    description: Optional[str] = None
+    refresh_frequency: str = "weekly"
+    tags: Optional[list[str]] = None
+
+
+class StreamPatchRequest(BaseModel):
+    title: Optional[str] = None
+    query: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    refresh_frequency: Optional[str] = None
+    tags: Optional[list[str]] = None
+
+
+def _stream_meta(s) -> StreamMeta:
+    return StreamMeta(
+        slug=s.slug,
+        title=s.title,
+        description=s.description,
+        query=s.query,
+        status=s.status.value,
+        refresh_frequency=s.refresh_frequency.value,
+        total_papers=s.total_papers,
+        last_updated=s.last_updated.isoformat() if s.last_updated else None,
+        next_update=s.next_update.isoformat() if s.next_update else None,
+        tags=s.tags,
+    )
+
+
+def run_stream_and_notify(
+    vault: VaultService, zotero: ZoteroClient, slug: str,
+    broadcast_fn: Callable[..., None], *, force: bool = False,
+) -> StreamRunResult:
+    """Shared by POST /streams/{slug}/run and StreamScheduler's tick -- both
+    need the exact same broadcast-progress-then-run-then-broadcast-result
+    sequence, just triggered by a request vs. a timer."""
+    from prisma.services.stream_runner import run_stream as _runner
+    try:
+        vault.get_stream(slug)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
+    broadcast_fn({"type": "stream_progress", "slug": slug, "status": "running"})
+    result = _runner(slug, vault, zotero, force=force, get_stream_logger=_log_setup.get_stream_logger)
+    _activity.info(
+        "action=run_stream slug=%s found=%d saved=%d skipped_llm=%d errors=%d",
+        slug, result.papers_found, result.papers_saved, result.papers_skipped_llm, len(result.errors),
+    )
+    broadcast_fn({"type": "stream_progress", "slug": slug, "status": "done",
+               "found": result.papers_found, "saved": result.papers_saved})
+    return result
+
+
+class StreamScheduler:
+    """Background thread that runs streams when their next_update is past."""
+
+    _CHECK_INTERVAL = 5 * 60  # seconds between scans
+
+    def __init__(
+        self,
+        get_vault: Callable[[], VaultService],
+        get_zotero: Callable[[], ZoteroClient],
+        broadcast_fn: Callable[..., None],
+    ) -> None:
+        self._get_vault = get_vault
+        self._get_zotero = get_zotero
+        self._broadcast = broadcast_fn
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._loop, daemon=True, name="stream-scheduler")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def _loop(self) -> None:
+        self._stop_event.wait(timeout=30)  # let server finish starting up
+        while not self._stop_event.is_set():
+            self._tick()
+            self._stop_event.wait(timeout=self._CHECK_INTERVAL)
+
+    def _tick(self) -> None:
+        from datetime import datetime
+        from prisma.storage.models.vault_models import StreamStatus
+        vault = self._get_vault()
+        try:
+            streams = vault.list_streams()
+        except Exception as exc:
+            _maint_log.warning("stream-scheduler: list_streams failed: %s", exc)
+            return
+        now = datetime.now()
+        due = [s for s in streams if s.status == StreamStatus.active
+               and s.refresh_frequency.value != "manual"
+               and (s.next_update is None or s.next_update <= now)]
+        _maint_log.info("stream-scheduler: tick — %d streams checked, %d due", len(streams), len(due))
+        for stream in due:
+            _maint_log.info("stream-scheduler: running %r", stream.slug)
+            try:
+                t0 = time.monotonic()
+                result = run_stream_and_notify(vault, self._get_zotero(), stream.slug, self._broadcast, force=False)
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                _maint_log.info(
+                    "stream-scheduler: %r done — found=%d saved=%d elapsed_ms=%.0f",
+                    stream.slug, result.papers_found, result.papers_saved, elapsed_ms,
+                )
+            except Exception as exc:
+                _maint_log.warning("stream-scheduler: %r failed: %s", stream.slug, exc)
+
+
+def build_streams_router(
+    get_vault: Callable[[], VaultService],
+    get_zotero: Callable[[], ZoteroClient],
+    broadcast_fn: Callable[..., None],
+) -> APIRouter:
+    router = APIRouter(prefix="/streams", tags=["streams"])
+
+    @router.get("", response_model=list[StreamMeta])
+    def list_streams():
+        return [_stream_meta(s) for s in get_vault().list_streams()]
+
+    @router.get("/{slug}", response_model=StreamMeta)
+    def get_stream(slug: str):
+        try:
+            return _stream_meta(get_vault().get_stream(slug))
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
+
+    @router.get("/{slug}/view", response_model=RenderedNode)
+    def get_stream_view(slug: str, request: Request, format: str = "html"):
+        return render_note(get_vault(), slug, request, format)
+
+    @router.post("", response_model=StreamMeta, status_code=201)
+    def create_stream(req: StreamCreateRequest):
+        s = get_vault().create_stream(
+            title=req.title,
+            query=req.query,
+            description=req.description,
+            refresh_frequency=req.refresh_frequency,
+            tags=req.tags,
+        )
+        # No mark_stale() -- streams/*.yaml is never KG-indexable content (see
+        # KnowledgeGraphService.is_relevant_path), so it would just set "stale"
+        # with nothing ever able to clear it.
+        _activity.info("action=create_stream slug=%s query=%r freq=%s", s.slug, req.query, req.refresh_frequency)
+        return _stream_meta(s)
+
+    @router.patch("/{slug}", response_model=StreamMeta)
+    def patch_stream(slug: str, req: StreamPatchRequest):
+        updates = {k: v for k, v in req.model_dump().items() if v is not None}
+        try:
+            s = get_vault().save_stream(slug, **updates)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
+        return _stream_meta(s)
+
+    @router.delete("/{slug}", status_code=204)
+    def delete_stream(slug: str):
+        try:
+            get_vault().delete_stream(slug)
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail=f"stream not found: {slug!r}")
+        # No mark_stale() -- see create_stream's comment above.
+        _activity.info("action=delete_stream slug=%s", slug)
+
+    @router.post("/{slug}/run", response_model=StreamRunResult)
+    def run_stream(slug: str, force: bool = Query(False)):
+        return run_stream_and_notify(get_vault(), get_zotero(), slug, broadcast_fn, force=force)
+
+    return router

--- a/tests/unit/server/test_streams_routes.py
+++ b/tests/unit/server/test_streams_routes.py
@@ -1,0 +1,134 @@
+"""Unit tests for prisma.server.streams_routes — built in isolation (a bare
+FastAPI app wrapping just build_streams_router + a tmp_path VaultService),
+not the full prisma.server.app singleton, same approach as
+test_sync_routes.py/test_notes_routes.py.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from prisma.server.streams_routes import build_streams_router
+from prisma.services.vault import VaultService
+
+
+class _Recorder:
+    def __init__(self):
+        self.broadcasts = []
+
+    def broadcast(self, event, exclude_client_id=None):
+        self.broadcasts.append((event, exclude_client_id))
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> VaultService:
+    v = VaultService(tmp_path)
+    v.ensure_dirs()
+    return v
+
+
+@pytest.fixture
+def recorder() -> _Recorder:
+    return _Recorder()
+
+
+@pytest.fixture
+def zotero() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def client(vault, zotero, recorder) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_streams_router(
+        get_vault=lambda: vault,
+        get_zotero=lambda: zotero,
+        broadcast_fn=recorder.broadcast,
+    ))
+    return TestClient(app)
+
+
+def test_list_streams_empty(client):
+    r = client.get("/streams")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_create_stream_then_list(client, vault):
+    r = client.post("/streams", json={"title": "My Stream", "query": "deep learning"})
+    assert r.status_code == 201
+    data = r.json()
+    assert data["slug"] == "my-stream"
+    assert data["query"] == "deep learning"
+    assert data["status"] == "active"
+
+    r2 = client.get("/streams")
+    assert len(r2.json()) == 1
+
+
+def test_get_stream(client, vault):
+    vault.create_stream(title="My Stream", query="q")
+    r = client.get("/streams/my-stream")
+    assert r.status_code == 200
+    assert r.json()["slug"] == "my-stream"
+
+
+def test_get_stream_not_found(client):
+    r = client.get("/streams/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_patch_stream_updates_fields(client, vault):
+    vault.create_stream(title="My Stream", query="q")
+    r = client.patch("/streams/my-stream", json={"status": "paused"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "paused"
+
+
+def test_patch_stream_not_found(client):
+    r = client.patch("/streams/does-not-exist", json={"status": "paused"})
+    assert r.status_code == 404
+
+
+def test_delete_stream(client, vault):
+    vault.create_stream(title="My Stream", query="q")
+    r = client.delete("/streams/my-stream")
+    assert r.status_code == 204
+    assert client.get("/streams/my-stream").status_code == 404
+
+
+def test_delete_stream_not_found(client):
+    r = client.delete("/streams/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_get_stream_view_renders_via_render_note(client, vault):
+    vault.create_stream(title="My Stream", query="q")
+    r = client.get("/streams/my-stream/view")
+    assert r.status_code == 200
+    assert r.json()["slug"] == "my-stream"
+
+
+def test_run_stream_not_found(client):
+    r = client.post("/streams/does-not-exist/run")
+    assert r.status_code == 404
+
+
+def test_run_stream_broadcasts_progress(client, vault, zotero, recorder):
+    # Full run_stream() (via stream_runner) needs real SearchAgent/network --
+    # out of scope for a router-isolation test. A future next_update with
+    # force=False (this route's default) makes stream_runner short-circuit
+    # before touching SearchAgent/ConfigLoader at all, letting this test
+    # confirm the route wires through to run_stream_and_notify (broadcast
+    # fires unconditionally, before that early-return check) without mocking
+    # the network.
+    from datetime import datetime, timedelta
+    vault.create_stream(title="My Stream", query="q")
+    vault.save_stream("my-stream", next_update=datetime.now() + timedelta(days=1))
+
+    r = client.post("/streams/my-stream/run")
+    assert r.status_code == 200
+    assert "not due" in r.json()["errors"][0]
+    assert recorder.broadcasts[0][0] == {"type": "stream_progress", "slug": "my-stream", "status": "running"}

--- a/tests/unit/services/test_stream_scheduler_and_run.py
+++ b/tests/unit/services/test_stream_scheduler_and_run.py
@@ -1,6 +1,7 @@
 """
-Tests for _StreamScheduler._tick() selection logic and _run_stream() behavior.
-All external boundaries (SearchAgent, ConfigLoader, network) are mocked.
+Tests for StreamScheduler._tick() selection logic and run_stream_and_notify()
+behavior (prisma.server.streams_routes). All external boundaries (SearchAgent,
+ConfigLoader, network) are mocked.
 """
 
 import pytest
@@ -10,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from prisma.services.vault import VaultService
 from prisma.storage.models.zotero_models import ZoteroCollection, ZoteroCreator, ZoteroItem
-from prisma.storage.models.vault_models import StreamStatus, RefreshFrequency
+from prisma.storage.models.vault_models import StreamStatus, RefreshFrequency, StreamRunResult
 from prisma.storage.models.agent_models import PaperMetadata, SearchResult
 
 
@@ -37,7 +38,7 @@ def _make_search_result(papers=None) -> SearchResult:
     )
 
 
-# ── _StreamScheduler._tick() ──────────────────────────────────────────────────
+# ── StreamScheduler._tick() ───────────────────────────────────────────────────
 
 class TestStreamSchedulerTick:
     """Tests for which streams _tick() decides to run."""
@@ -49,94 +50,84 @@ class TestStreamSchedulerTick:
         return v
 
     def _make_tick(self, vault):
-        """Return a _tick function bound to the given vault, with _run_stream mocked."""
-        import prisma.server.app as app_mod
-        from prisma.server.app import _StreamScheduler
+        """Return a StreamScheduler bound to the given vault (via a getter,
+        matching the real constructor), with run_stream_and_notify mocked."""
+        from prisma.server.streams_routes import StreamScheduler
 
-        scheduler = _StreamScheduler()
+        scheduler = StreamScheduler(
+            get_vault=lambda: vault,
+            get_zotero=lambda: MagicMock(),
+            broadcast_fn=lambda *a, **kw: None,
+        )
         calls = []
 
-        def fake_run_stream(slug, force=False):
+        def fake_run_stream_and_notify(vault_arg, zotero_arg, slug, broadcast_fn, force=False):
             calls.append(slug)
-            from prisma.server.app import StreamRunResult
             return StreamRunResult(slug=slug, papers_found=0, papers_saved=0,
                                    sources_used=[], sources_skipped=[])
 
-        return scheduler, calls, fake_run_stream
+        return scheduler, calls, fake_run_stream_and_notify
 
     def test_skips_paused_stream(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Paused", query="q")
         vault.save_stream("paused", status="paused")
 
         scheduler, calls, fake_run = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", fake_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", fake_run):
             scheduler._tick()
 
         assert calls == []
 
     def test_skips_archived_stream(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Old", query="q")
         vault.save_stream("old", status="archived")
 
         scheduler, calls, fake_run = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", fake_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", fake_run):
             scheduler._tick()
 
         assert calls == []
 
     def test_skips_manual_frequency(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Manual", query="q", refresh_frequency="manual")
 
         scheduler, calls, fake_run = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", fake_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", fake_run):
             scheduler._tick()
 
         assert calls == []
 
     def test_skips_stream_not_yet_due(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Future", query="q")
         vault.save_stream("future", next_update=datetime.now() + timedelta(hours=2))
 
         scheduler, calls, fake_run = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", fake_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", fake_run):
             scheduler._tick()
 
         assert calls == []
 
     def test_runs_overdue_stream(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Overdue", query="q")
         vault.save_stream("overdue", next_update=datetime.now() - timedelta(hours=1))
 
         scheduler, calls, fake_run = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", fake_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", fake_run):
             scheduler._tick()
 
         assert "overdue" in calls
 
     def test_runs_stream_with_no_next_update(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Never Run", query="q")
         # next_update is None by default — treat as always due
 
         scheduler, calls, fake_run = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", fake_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", fake_run):
             scheduler._tick()
 
         assert "never-run" in calls
 
     def test_runs_only_due_streams_when_mixed(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Due", query="q")
         vault.save_stream("due", next_update=datetime.now() - timedelta(minutes=1))
 
@@ -147,14 +138,12 @@ class TestStreamSchedulerTick:
         vault.save_stream("paused", status="paused")
 
         scheduler, calls, fake_run = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", fake_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", fake_run):
             scheduler._tick()
 
         assert calls == ["due"]
 
     def test_tick_continues_after_run_stream_error(self, vault):
-        import prisma.server.app as app_mod
         vault.create_stream(title="Boom", query="q")
         vault.save_stream("boom", next_update=datetime.now() - timedelta(hours=1))
 
@@ -163,38 +152,33 @@ class TestStreamSchedulerTick:
 
         calls = []
 
-        def failing_run(slug, force=False):
+        def failing_run(vault_arg, zotero_arg, slug, broadcast_fn, force=False):
             calls.append(slug)
             if slug == "boom":
                 raise RuntimeError("network error")
-            from prisma.server.app import StreamRunResult
             return StreamRunResult(slug=slug, papers_found=0, papers_saved=0,
                                    sources_used=[], sources_skipped=[])
 
         scheduler, _, _ = self._make_tick(vault)
-        with patch.object(app_mod, "_vault", vault), \
-             patch.object(app_mod, "_run_stream", failing_run):
+        with patch("prisma.server.streams_routes.run_stream_and_notify", failing_run):
             scheduler._tick()  # must not raise
 
         assert "fine" in calls
 
 
-# ── _run_stream() ─────────────────────────────────────────────────────────────
+# ── run_stream_and_notify() ───────────────────────────────────────────────────
 
 class TestRunStream:
-    """Tests for _run_stream() behavior."""
+    """Tests for run_stream_and_notify() behavior. Unlike the old _run_stream
+    (which read module globals _vault/_zotero off prisma.server.app), this
+    function takes vault/zotero/broadcast_fn as explicit parameters -- no
+    app_mod patching needed for those three."""
 
     @pytest.fixture
     def vault(self, tmp_path):
         v = VaultService(tmp_path)
         v.ensure_dirs()
         return v
-
-    @pytest.fixture
-    def mock_indexer(self):
-        m = MagicMock()
-        m.mark_stale = MagicMock()
-        return m
 
     @pytest.fixture
     def mock_cfg(self):
@@ -214,27 +198,16 @@ class TestRunStream:
         z.add_paper.return_value = MagicMock(key="ITEM1", version=0, collections=[])
         return z
 
-    def _patched_run(self, vault, indexer, cfg, agent_mock, zotero=None):
-        """Return patches for all globals _run_stream touches."""
-        import prisma.server.app as app_mod
-        from prisma.storage.models.api_response_models import LLMRelevanceResult
-
+    def _patched_run(self, cfg, agent_mock):
+        """Return patches for everything run_stream_and_notify's callee
+        (stream_runner.run_stream) reaches for besides vault/zotero (now
+        explicit params, not module globals)."""
         loader_mock = MagicMock()
         loader_mock.return_value.get_search_config.return_value = cfg
 
         agent_cls_mock = MagicMock(return_value=agent_mock)
 
-        if zotero is None:
-            zotero = MagicMock()
-            zotero.is_available.return_value = True
-            zotero.ensure_collection.return_value = ZoteroCollection(key="TESTCOLL", name="Test")
-            zotero.get_collection_items.return_value = []
-            zotero.search_items.return_value = []
-            zotero.find_by_identifier.return_value = None
-            zotero.add_paper.return_value = MagicMock(key="ITEM1", version=0, collections=[])
-
-        # AnalysisAgent makes real Ollama HTTP calls — mock it; all papers are relevant by default
-        from prisma.storage.models.api_response_models import LLMIdentityResult
+        from prisma.storage.models.api_response_models import LLMRelevanceResult, LLMIdentityResult
         analysis_mock = MagicMock()
         analysis_mock.assess_relevance.return_value = LLMRelevanceResult(
             is_relevant=True,
@@ -243,45 +216,41 @@ class TestRunStream:
             reasoning="mock",
             semantic_score=0.9,
         )
-        # check_identity_batch returns one result per candidate — default to not-same
         analysis_mock.check_identity_batch.side_effect = (
             lambda title, abstract, candidates: [
                 LLMIdentityResult(are_same=False, confidence=0.9, reason="mock")
                 for _ in candidates
             ]
         )
-        # batch_relevance_check returns True for each candidate — all relevant by default
         analysis_mock.batch_relevance_check.side_effect = (
             lambda query, candidates: [True for _ in candidates]
         )
         analysis_cls_mock = MagicMock(return_value=analysis_mock)
 
         return (
-            patch.object(app_mod, "_vault", vault),
-            patch.object(app_mod, "_indexer", indexer),
-            patch.object(app_mod, "_zotero", zotero),
             patch("prisma.utils.config.ConfigLoader", loader_mock),
             patch("prisma.agents.search_agent.SearchAgent", agent_cls_mock),
             patch("prisma.agents.analysis_agent.AnalysisAgent", analysis_cls_mock),
         )
 
-    def test_returns_not_due_when_next_update_in_future(self, vault, mock_indexer, mock_cfg):
-        import prisma.server.app as app_mod
+    def _run(self, vault, zotero, slug, force=False):
+        from prisma.server.streams_routes import run_stream_and_notify
+        return run_stream_and_notify(vault, zotero, slug, lambda *a, **kw: None, force=force)
+
+    def test_returns_not_due_when_next_update_in_future(self, vault, mock_cfg, mock_zotero):
         vault.create_stream(title="Soon", query="q")
         vault.save_stream("soon", next_update=datetime.now() + timedelta(hours=1))
 
         agent = MagicMock()
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            result = _run_stream("soon", force=False)
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
+            result = self._run(vault, mock_zotero, "soon", force=False)
 
         assert result.papers_found == 0
         assert any("not due" in e for e in result.errors)
         agent.preflight.assert_not_called()
 
-    def test_force_bypasses_not_due(self, vault, mock_indexer, mock_cfg):
-        import prisma.server.app as app_mod
+    def test_force_bypasses_not_due(self, vault, mock_cfg, mock_zotero):
         vault.create_stream(title="Soon", query="q")
         vault.save_stream("soon", next_update=datetime.now() + timedelta(hours=1))
 
@@ -289,40 +258,37 @@ class TestRunStream:
         agent.preflight.return_value = ["arxiv"]
         agent.search.return_value = _make_search_result()
 
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            result = _run_stream("soon", force=True)
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
+            self._run(vault, mock_zotero, "soon", force=True)
 
         agent.preflight.assert_called_once()
 
-    def test_raises_404_for_missing_stream(self, vault, mock_indexer, mock_cfg):
+    def test_raises_404_for_missing_stream(self, vault, mock_cfg, mock_zotero):
         from fastapi import HTTPException
         agent = MagicMock()
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
             with pytest.raises(HTTPException) as exc_info:
-                _run_stream("does-not-exist")
+                self._run(vault, mock_zotero, "does-not-exist")
         assert exc_info.value.status_code == 404
 
-    def test_returns_early_when_all_sources_fail_preflight(self, vault, mock_indexer, mock_cfg):
+    def test_returns_early_when_all_sources_fail_preflight(self, vault, mock_cfg, mock_zotero):
         vault.create_stream(title="Net", query="q")
 
         agent = MagicMock()
         agent.preflight.return_value = []  # all fail
 
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            result = _run_stream("net", force=True)
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
+            result = self._run(vault, mock_zotero, "net", force=True)
 
         assert result.papers_found == 0
         assert result.papers_saved == 0
         assert any("preflight" in e for e in result.errors)
         agent.search.assert_not_called()
 
-    def test_saves_new_papers_to_zotero(self, vault, mock_indexer, mock_cfg):
+    def test_saves_new_papers_to_zotero(self, vault, mock_cfg):
         vault.create_stream(title="AI", query="artificial intelligence")
 
         # Title shares stems with the query so it clears the stem pre-filter —
@@ -333,7 +299,6 @@ class TestRunStream:
         agent.preflight.return_value = ["arxiv"]
         agent.search.return_value = _make_search_result(papers=[paper])
 
-        import prisma.server.app as app_mod
         zotero = MagicMock()
         zotero.is_available.return_value = True
         zotero.ensure_collection.return_value = ZoteroCollection(key="TESTCOLL", name="AI")
@@ -342,10 +307,9 @@ class TestRunStream:
         zotero.find_by_identifier.return_value = None
         zotero.add_paper.return_value = MagicMock(key="ITEM1", version=0, collections=[])
 
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent, zotero=zotero)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            result = _run_stream("ai", force=True)
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
+            result = self._run(vault, zotero, "ai", force=True)
 
         assert result.papers_found == 1
         assert result.papers_saved == 1
@@ -353,7 +317,7 @@ class TestRunStream:
         zotero.add_paper.assert_called_once()
         zotero.add_item_to_collection.assert_called_once()
 
-    def test_does_not_save_duplicate_papers(self, vault, mock_indexer, mock_cfg):
+    def test_does_not_save_duplicate_papers(self, vault, mock_cfg):
         vault.create_stream(title="AI", query="q")
 
         paper = _make_paper(title="Attention Is All You Need", authors=["Vaswani A"])
@@ -367,22 +331,20 @@ class TestRunStream:
             date="2017", abstract_note=None, doi=None, url=None,
             publication_title=None, tags=[], collections=["TESTCOLL"],
         )
-        import prisma.server.app as app_mod
         zotero = MagicMock()
         zotero.is_available.return_value = True
         zotero.ensure_collection.return_value = ZoteroCollection(key="TESTCOLL", name="AI")
         zotero.get_collection_items.return_value = [existing]
         zotero.search_items.return_value = []
 
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent, zotero=zotero)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            result = _run_stream("ai", force=True)
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
+            result = self._run(vault, zotero, "ai", force=True)
 
         assert result.papers_saved == 0
         zotero.add_paper.assert_not_called()
 
-    def test_updates_stream_metadata_after_run(self, vault, mock_indexer, mock_cfg):
+    def test_updates_stream_metadata_after_run(self, vault, mock_cfg, mock_zotero):
         vault.create_stream(title="Meta", query="q", refresh_frequency="weekly")
 
         paper = _make_paper(title="A Paper", authors=["Doe J"])
@@ -390,10 +352,9 @@ class TestRunStream:
         agent.preflight.return_value = ["arxiv"]
         agent.search.return_value = _make_search_result(papers=[paper])
 
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            _run_stream("meta", force=True)
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
+            self._run(vault, mock_zotero, "meta", force=True)
 
         updated = vault.get_stream("meta")
         assert updated.total_papers == 1
@@ -401,23 +362,7 @@ class TestRunStream:
         assert updated.next_update is not None
         assert updated.next_update > datetime.now()
 
-    def test_does_not_mark_indexer_stale_on_stream_run(self, vault, mock_indexer, mock_cfg):
-        # Stream runs write to Zotero, not the vault — indexer is never marked stale here.
-        vault.create_stream(title="Index", query="q")
-
-        paper = _make_paper(title="New Finding", authors=["Jones B"])
-        agent = MagicMock()
-        agent.preflight.return_value = ["arxiv"]
-        agent.search.return_value = _make_search_result(papers=[paper])
-
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            _run_stream("index", force=True)
-
-        mock_indexer.mark_stale.assert_not_called()
-
-    def test_reports_skipped_sources(self, vault, mock_indexer, mock_cfg):
+    def test_reports_skipped_sources(self, vault, mock_cfg, mock_zotero):
         mock_cfg.sources = ["arxiv", "semanticscholar"]
         vault.create_stream(title="Sources", query="q")
 
@@ -425,10 +370,9 @@ class TestRunStream:
         agent.preflight.return_value = ["arxiv"]  # semanticscholar fails preflight
         agent.search.return_value = _make_search_result()
 
-        patches = self._patched_run(vault, mock_indexer, mock_cfg, agent)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            from prisma.server.app import _run_stream
-            result = _run_stream("sources", force=True)
+        p1, p2, p3 = self._patched_run(mock_cfg, agent)
+        with p1, p2, p3:
+            result = self._run(vault, mock_zotero, "sources", force=True)
 
         assert "semanticscholar" in result.sources_skipped
         assert "arxiv" in result.sources_used


### PR DESCRIPTION
## Summary
Second of app.py's ~14 route domains to split out (F4). Same `build_streams_router(deps) -> APIRouter` factory pattern as `sync_routes.py`/`notes_routes.py`: getter callables for `_vault`/`_zotero` (both rebound at runtime by `/reload/*` endpoints), `broadcast` passed in (closes over app.py-local WebSocket state, importing it would be circular).

- `_StreamScheduler` moves too, as `StreamScheduler` -- it's a long-lived background thread (started once at app startup, outlives any single request), so it needs the exact same getter treatment: a reload happening while the scheduler is mid-loop must not leave it talking to a stale `_vault`/`_zotero` forever.
- `_run_stream` becomes `run_stream_and_notify(vault, zotero, slug, broadcast_fn, *, force)` -- takes `vault`/`zotero` as explicit parameters instead of reading module globals, shared by both `POST /streams/{slug}/run` and the scheduler's tick.
- `get_stream_view` (still in app.py, `GET /streams/{slug}/view`) already called `render_note()` (`notes_routes.py`, extracted last PR) rather than a now-moved function directly, so no cross-file call-site fixup was needed here.
- `app.py`: 2055 -> 1894 lines.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F4, second extraction -- `zotero_routes.py`/`admin_routes.py`/`search_routes.py` still to come).

## Test plan
- [x] `pytest tests/unit -q` -- 749 passed. Rewrote `tests/unit/services/test_stream_scheduler_and_run.py` (previously imported `_StreamScheduler`/`_run_stream` from `prisma.server.app`, now imports `StreamScheduler`/`run_stream_and_notify` from `streams_routes` and patches at their new location; dropped one test whose invariant -- the scheduler never marks the indexer stale -- is now structurally guaranteed since `run_stream_and_notify` has no indexer parameter at all). New `tests/unit/server/test_streams_routes.py`, 11 tests for the router in isolation (previously zero dedicated coverage).
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs