### PR TITLE
Extract /zotero/* routes into prisma/server/zotero_routes.py

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -75,7 +75,6 @@ _t("chroma_service ok")
 _t("importing zotero")
 from prisma.integrations.zotero import ZoteroClient
 from prisma.integrations.zotero.client import ZoteroStatus
-from prisma.storage.models.zotero_models import ZoteroCollection, ZoteroItem
 _t("zotero ok")
 
 _t("importing sync_orchestrator")
@@ -443,6 +442,7 @@ app.add_middleware(AccessLogMiddleware)
 from prisma.server.sync_routes import build_sync_router  # noqa: E402
 from prisma.server.notes_routes import build_notes_router  # noqa: E402
 from prisma.server.streams_routes import build_streams_router, StreamScheduler  # noqa: E402
+from prisma.server.zotero_routes import build_zotero_router  # noqa: E402
 def _update_client_baseline(client_id: str, path: str, content_hash: str, mtime: float) -> None:
     with _client_baseline_lock:
         _client_baseline.setdefault(client_id, {})[path] = (content_hash, mtime)
@@ -478,6 +478,12 @@ _scheduler = StreamScheduler(
     get_zotero=lambda: _zotero,
     broadcast_fn=broadcast,
 )
+
+app.include_router(build_zotero_router(
+    get_vault=lambda: _vault,
+    get_zotero=lambda: _zotero,
+    get_indexer=lambda: _indexer,
+))
 
 _executor = ThreadPoolExecutor(max_workers=2)
 _jobs: dict[str, object] = {}  # review jobs: dict (JobStatus-shaped); dedup jobs: DedupJobState instance
@@ -1528,206 +1534,6 @@ def deep_search(q: str = Query(..., min_length=1)) -> list[DeepSearchResult]:
     # Graph not built — text only
     return [DeepSearchResult(slug=r.slug, title=r.title, excerpt=r.excerpt, score=r.score)
             for r in _text_search(q, top_k=20)]
-
-
-# ── Zotero routes ─────────────────────────────────────────────────────────────
-
-@app.get("/zotero/status", response_model=ZoteroStatus)
-def zotero_status():
-    return _zotero.status()
-
-
-@app.get("/zotero/collections", response_model=list[ZoteroCollection])
-def zotero_collections():
-    try:
-        return _zotero.get_collections()
-    except Exception as e:
-        raise HTTPException(status_code=503, detail=str(e))
-
-
-class ZoteroStatsResponse(BaseModel):
-    total_items: int
-    item_type_counts: dict[str, int]
-    items_without_doi: int
-    items_without_abstract: int
-    items_without_authors: int
-    quality_score: float
-
-
-@app.get("/zotero/stats", response_model=ZoteroStatsResponse)
-def zotero_stats():
-    """Library-wide item-type breakdown and metadata-quality score, computed
-    over the same ZoteroClient.get_all_items() used elsewhere — not a
-    second, independent client (the old CLI's cleanup.py had its own)."""
-    try:
-        items = _zotero.get_all_items()
-    except Exception as e:
-        raise HTTPException(status_code=503, detail=str(e))
-
-    if not items:
-        return ZoteroStatsResponse(
-            total_items=0, item_type_counts={}, items_without_doi=0,
-            items_without_abstract=0, items_without_authors=0, quality_score=100.0,
-        )
-
-    item_type_counts: dict[str, int] = {}
-    items_without_doi = 0
-    items_without_abstract = 0
-    items_without_authors = 0
-    for item in items:
-        item_type_counts[item.item_type] = item_type_counts.get(item.item_type, 0) + 1
-        if not item.doi:
-            items_without_doi += 1
-        if not item.abstract_note:
-            items_without_abstract += 1
-        if not item.authors:
-            items_without_authors += 1
-
-    total = len(items)
-    quality_score = 100 - (
-        (items_without_doi + items_without_abstract + items_without_authors) / (total * 3) * 100
-    )
-    return ZoteroStatsResponse(
-        total_items=total,
-        item_type_counts=item_type_counts,
-        items_without_doi=items_without_doi,
-        items_without_abstract=items_without_abstract,
-        items_without_authors=items_without_authors,
-        quality_score=quality_score,
-    )
-
-
-class SyncPendingResponse(BaseModel):
-    synced: int
-    failed: int
-    pending_before: int
-
-
-@app.post("/zotero/sync-pending", response_model=SyncPendingResponse)
-def zotero_sync_pending():
-    """Flush the offline pending-write queue (data/pending_writes.json) —
-    the API equivalent of the old `prisma sync` CLI command. Actions are
-    queued here by the review pipeline (coordinator.py) when a Zotero write
-    fails while offline; nothing else populates this queue today."""
-    from prisma.storage.pending_queue import PendingWriteQueue
-
-    pending_before = PendingWriteQueue().pending_count
-    if pending_before == 0:
-        return SyncPendingResponse(synced=0, failed=0, pending_before=0)
-    if not connectivity.is_online:
-        raise HTTPException(status_code=503, detail="offline — cannot sync right now")
-
-    synced, failed = PendingWriteQueue().flush(_zotero)
-    return SyncPendingResponse(synced=synced, failed=failed, pending_before=pending_before)
-
-
-@app.get("/zotero/items", response_model=list[ZoteroItem])
-def zotero_items(collection: Optional[str] = Query(None), q: Optional[str] = Query(None)):
-    """When both are given, get_collection_items(key, query=q) passes q
-    straight through to Zotero's own server-side `q` search (matches across
-    title/creators/abstract/etc., not just a client-side title substring)
-    scoped to the collection in one API call."""
-    try:
-        if collection:
-            return _zotero.get_collection_items(collection, query=q or None)
-        if q:
-            return _zotero.search_items(q)
-        return _zotero.get_all_items()
-    except Exception as e:
-        raise HTTPException(status_code=503, detail=str(e))
-
-
-def _fetch_pdf_from_url(url: str | None, doi: str | None) -> bytes | None:
-    import re
-    import urllib.request
-
-    candidates: list[str] = []
-    if url:
-        if re.search(r"arxiv\.org/abs/(\S+)", url):
-            arxiv_id = re.search(r"arxiv\.org/abs/([^\s?#]+)", url).group(1)
-            candidates.append(f"https://arxiv.org/pdf/{arxiv_id}")
-        elif url.lower().endswith(".pdf"):
-            candidates.append(url)
-    if doi and "arxiv" in doi.lower():
-        arxiv_id = re.sub(r".*arxiv[./]", "", doi, flags=re.IGNORECASE)
-        candidates.append(f"https://arxiv.org/pdf/{arxiv_id}")
-
-    for pdf_url in candidates:
-        try:
-            req = urllib.request.Request(pdf_url, headers={"User-Agent": "Prisma/1.0"})
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                data = resp.read()
-            if data[:4] == b"%PDF":
-                return data
-        except Exception:
-            continue
-    return None
-
-
-def _pdf_bytes_to_md(data: bytes) -> str:
-    try:
-        from docu_craft.renderers.pdf_md import pdf_to_md
-        return pdf_to_md(data)
-    except Exception:
-        return ""
-
-
-@app.post("/zotero/import/{key}", response_model=RenderedNode, status_code=201)
-def zotero_import(key: str):
-    from prisma.utils.text import make_citekey
-    item = _zotero.get_item(key)
-    if item is None:
-        raise HTTPException(status_code=404, detail=f"Zotero item not found: {key!r}")
-
-    # Return existing import if already in vault
-    for path in _vault.iter_files():
-        raw = path.read_text(encoding="utf-8")
-        from prisma.services.vault import _parse_frontmatter
-        fm, _ = _parse_frontmatter(raw)
-        if fm.get("zotero_key") == key:
-            from prisma.services.vault import _file_slug
-            slug = _file_slug(path.stem)
-            source = _vault.get_source(slug)
-            html, broken_links, broken_citations = vault_render(source.body, _vault)
-            return RenderedNode(
-                slug=source.slug, title=source.title, node_type=source.node_type,
-                html=html, broken_links=broken_links, broken_citations=broken_citations,
-            )
-
-    pdf_bytes = _zotero.get_pdf_bytes(key)
-    if pdf_bytes is None:
-        pdf_bytes = _fetch_pdf_from_url(item.url, item.doi)
-
-    if pdf_bytes:
-        body = _pdf_bytes_to_md(pdf_bytes)
-    else:
-        lines = []
-        if item.abstract_note:
-            lines.append(item.abstract_note)
-            lines.append("")
-        if item.publication_title:
-            lines.append(f"**{item.publication_title}**")
-        if item.authors:
-            lines.append(", ".join(item.authors))
-        if item.doi:
-            lines.append(f"DOI: {item.doi}")
-        if item.url:
-            lines.append(f"URL: {item.url}")
-        body = "\n".join(lines)
-
-    citekey = make_citekey(item.authors, item.year, item.title)
-    source = _vault.create_source_from_citekey(
-        citekey, item.title, body,
-        zotero_key=item.key, authors=item.authors, tags=[t.tag for t in item.tags],
-        year=item.year, doi=item.doi, url=item.url,
-    )
-    _indexer.mark_stale()
-    _activity.info("action=import_zotero key=%s slug=%s title=%r", key, source.slug, source.title)
-    html, broken_links, broken_citations = vault_render(source.body, _vault)
-    return RenderedNode(
-        slug=source.slug, title=source.title, node_type=source.node_type,
-        html=html, broken_links=broken_links, broken_citations=broken_citations,
-    )
 
 
 class DeduplicateResult(BaseModel):

--- a/prisma/server/zotero_routes.py
+++ b/prisma/server/zotero_routes.py
@@ -1,0 +1,232 @@
+"""Zotero library endpoints (/zotero/*).
+
+Built via a factory (`build_zotero_router`) taking getter callables rather
+than raw objects, same reasoning as sync_routes.py's `build_sync_router`:
+app.py's `/reload`-style endpoints rebind its module globals (`global
+_zotero; _zotero = _build_zotero()`, similarly for `_vault`/`_indexer`) at
+runtime, so a router that captured them by value at include_router() time
+would keep talking to a stale, replaced instance after a reload.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from prisma.connectivity import monitor as connectivity
+from prisma.integrations.zotero.client import ZoteroStatus
+from prisma.integrations.zotero import ZoteroClient
+from prisma.services.knowledge_graph_client import KnowledgeGraphClient
+from prisma.services.renderer import render as vault_render
+from prisma.services.vault import VaultService
+from prisma.storage.models.vault_models import RenderedNode
+from prisma.storage.models.zotero_models import ZoteroCollection, ZoteroItem
+
+_activity = logging.getLogger("prisma.activity")
+
+
+class ZoteroStatsResponse(BaseModel):
+    total_items: int
+    item_type_counts: dict[str, int]
+    items_without_doi: int
+    items_without_abstract: int
+    items_without_authors: int
+    quality_score: float
+
+
+class SyncPendingResponse(BaseModel):
+    synced: int
+    failed: int
+    pending_before: int
+
+
+def _fetch_pdf_from_url(url: str | None, doi: str | None) -> bytes | None:
+    import re
+    import urllib.request
+
+    candidates: list[str] = []
+    if url:
+        if re.search(r"arxiv\.org/abs/(\S+)", url):
+            arxiv_id = re.search(r"arxiv\.org/abs/([^\s?#]+)", url).group(1)
+            candidates.append(f"https://arxiv.org/pdf/{arxiv_id}")
+        elif url.lower().endswith(".pdf"):
+            candidates.append(url)
+    if doi and "arxiv" in doi.lower():
+        arxiv_id = re.sub(r".*arxiv[./]", "", doi, flags=re.IGNORECASE)
+        candidates.append(f"https://arxiv.org/pdf/{arxiv_id}")
+
+    for pdf_url in candidates:
+        try:
+            req = urllib.request.Request(pdf_url, headers={"User-Agent": "Prisma/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                data = resp.read()
+            if data[:4] == b"%PDF":
+                return data
+        except Exception:
+            continue
+    return None
+
+
+def _pdf_bytes_to_md(data: bytes) -> str:
+    try:
+        from docu_craft.renderers.pdf_md import pdf_to_md
+        return pdf_to_md(data)
+    except Exception:
+        return ""
+
+
+def build_zotero_router(
+    get_vault: Callable[[], VaultService],
+    get_zotero: Callable[[], ZoteroClient],
+    get_indexer: Callable[[], KnowledgeGraphClient],
+) -> APIRouter:
+    router = APIRouter(prefix="/zotero", tags=["zotero"])
+
+    @router.get("/status", response_model=ZoteroStatus)
+    def zotero_status():
+        return get_zotero().status()
+
+    @router.get("/collections", response_model=list[ZoteroCollection])
+    def zotero_collections():
+        try:
+            return get_zotero().get_collections()
+        except Exception as e:
+            raise HTTPException(status_code=503, detail=str(e))
+
+    @router.get("/stats", response_model=ZoteroStatsResponse)
+    def zotero_stats():
+        """Library-wide item-type breakdown and metadata-quality score, computed
+        over the same ZoteroClient.get_all_items() used elsewhere — not a
+        second, independent client (the old CLI's cleanup.py had its own)."""
+        try:
+            items = get_zotero().get_all_items()
+        except Exception as e:
+            raise HTTPException(status_code=503, detail=str(e))
+
+        if not items:
+            return ZoteroStatsResponse(
+                total_items=0, item_type_counts={}, items_without_doi=0,
+                items_without_abstract=0, items_without_authors=0, quality_score=100.0,
+            )
+
+        item_type_counts: dict[str, int] = {}
+        items_without_doi = 0
+        items_without_abstract = 0
+        items_without_authors = 0
+        for item in items:
+            item_type_counts[item.item_type] = item_type_counts.get(item.item_type, 0) + 1
+            if not item.doi:
+                items_without_doi += 1
+            if not item.abstract_note:
+                items_without_abstract += 1
+            if not item.authors:
+                items_without_authors += 1
+
+        total = len(items)
+        quality_score = 100 - (
+            (items_without_doi + items_without_abstract + items_without_authors) / (total * 3) * 100
+        )
+        return ZoteroStatsResponse(
+            total_items=total,
+            item_type_counts=item_type_counts,
+            items_without_doi=items_without_doi,
+            items_without_abstract=items_without_abstract,
+            items_without_authors=items_without_authors,
+            quality_score=quality_score,
+        )
+
+    @router.post("/sync-pending", response_model=SyncPendingResponse)
+    def zotero_sync_pending():
+        """Flush the offline pending-write queue (data/pending_writes.json) —
+        the API equivalent of the old `prisma sync` CLI command. Actions are
+        queued here by the review pipeline (coordinator.py) when a Zotero write
+        fails while offline; nothing else populates this queue today."""
+        from prisma.storage.pending_queue import PendingWriteQueue
+
+        pending_before = PendingWriteQueue().pending_count
+        if pending_before == 0:
+            return SyncPendingResponse(synced=0, failed=0, pending_before=0)
+        if not connectivity.is_online:
+            raise HTTPException(status_code=503, detail="offline — cannot sync right now")
+
+        synced, failed = PendingWriteQueue().flush(get_zotero())
+        return SyncPendingResponse(synced=synced, failed=failed, pending_before=pending_before)
+
+    @router.get("/items", response_model=list[ZoteroItem])
+    def zotero_items(collection: Optional[str] = Query(None), q: Optional[str] = Query(None)):
+        """When both are given, get_collection_items(key, query=q) passes q
+        straight through to Zotero's own server-side `q` search (matches across
+        title/creators/abstract/etc., not just a client-side title substring)
+        scoped to the collection in one API call."""
+        zotero = get_zotero()
+        try:
+            if collection:
+                return zotero.get_collection_items(collection, query=q or None)
+            if q:
+                return zotero.search_items(q)
+            return zotero.get_all_items()
+        except Exception as e:
+            raise HTTPException(status_code=503, detail=str(e))
+
+    @router.post("/import/{key}", response_model=RenderedNode, status_code=201)
+    def zotero_import(key: str):
+        from prisma.utils.text import make_citekey
+        vault = get_vault()
+        zotero = get_zotero()
+        item = zotero.get_item(key)
+        if item is None:
+            raise HTTPException(status_code=404, detail=f"Zotero item not found: {key!r}")
+
+        # Return existing import if already in vault
+        for path in vault.iter_files():
+            raw = path.read_text(encoding="utf-8")
+            from prisma.services.vault import _parse_frontmatter
+            fm, _ = _parse_frontmatter(raw)
+            if fm.get("zotero_key") == key:
+                from prisma.services.vault import _file_slug
+                slug = _file_slug(path.stem)
+                source = vault.get_source(slug)
+                html, broken_links, broken_citations = vault_render(source.body, vault)
+                return RenderedNode(
+                    slug=source.slug, title=source.title, node_type=source.node_type,
+                    html=html, broken_links=broken_links, broken_citations=broken_citations,
+                )
+
+        pdf_bytes = zotero.get_pdf_bytes(key)
+        if pdf_bytes is None:
+            pdf_bytes = _fetch_pdf_from_url(item.url, item.doi)
+
+        if pdf_bytes:
+            body = _pdf_bytes_to_md(pdf_bytes)
+        else:
+            lines = []
+            if item.abstract_note:
+                lines.append(item.abstract_note)
+                lines.append("")
+            if item.publication_title:
+                lines.append(f"**{item.publication_title}**")
+            if item.authors:
+                lines.append(", ".join(item.authors))
+            if item.doi:
+                lines.append(f"DOI: {item.doi}")
+            if item.url:
+                lines.append(f"URL: {item.url}")
+            body = "\n".join(lines)
+
+        citekey = make_citekey(item.authors, item.year, item.title)
+        source = vault.create_source_from_citekey(
+            citekey, item.title, body,
+            zotero_key=item.key, authors=item.authors, tags=[t.tag for t in item.tags],
+            year=item.year, doi=item.doi, url=item.url,
+        )
+        get_indexer().mark_stale()
+        _activity.info("action=import_zotero key=%s slug=%s title=%r", key, source.slug, source.title)
+        html, broken_links, broken_citations = vault_render(source.body, vault)
+        return RenderedNode(
+            slug=source.slug, title=source.title, node_type=source.node_type,
+            html=html, broken_links=broken_links, broken_citations=broken_citations,
+        )
+
+    return router

--- a/tests/unit/server/test_zotero_routes.py
+++ b/tests/unit/server/test_zotero_routes.py
@@ -1,12 +1,25 @@
 """Unit tests for the two API routes added when the CLI was minimized
 (2026-07-27): GET /zotero/stats and POST /zotero/sync-pending replace the
 old `prisma zotero stats` and `prisma sync` CLI commands.
+
+The tests below this point (isolated router section) instead build
+zotero_routes.py's router in isolation (bare FastAPI app + a tmp_path
+VaultService), same approach as test_notes_routes.py/test_streams_routes.py
+-- appropriate here since zotero_import writes real files, and this
+module-level `client` fixture talks to the full app.py singleton's real
+(potentially non-tmp) _vault.
 """
 
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from prisma.server.app import app
-from prisma.storage.models.zotero_models import ZoteroItem, ZoteroCreator
+from prisma.server.zotero_routes import build_zotero_router
+from prisma.services.vault import VaultService
+from prisma.storage.models.zotero_models import ZoteroCreator, ZoteroItem, ZoteroTag
 
 client = TestClient(app, client=("127.0.0.1", 12345))
 
@@ -105,3 +118,108 @@ def test_sync_pending_online_flushes_queue(monkeypatch):
     r = client.post("/zotero/sync-pending")
     assert r.status_code == 200
     assert r.json() == {"synced": 2, "failed": 0, "pending_before": 2}
+
+
+# ── Isolated router tests (build_zotero_router directly) ─────────────────────
+# /zotero/status, /zotero/collections, and /zotero/import/{key} had zero test
+# coverage anywhere before this router extraction -- import in particular has
+# real branching logic (existing-import dedup, PDF-vs-abstract-fallback body,
+# citekey creation) worth covering now that it's isolable from the full app.
+
+@pytest.fixture
+def vault(tmp_path) -> VaultService:
+    v = VaultService(tmp_path)
+    v.ensure_dirs()
+    return v
+
+
+@pytest.fixture
+def zotero() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def indexer() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def isolated_client(vault, zotero, indexer) -> TestClient:
+    isolated_app = FastAPI()
+    isolated_app.include_router(build_zotero_router(
+        get_vault=lambda: vault,
+        get_zotero=lambda: zotero,
+        get_indexer=lambda: indexer,
+    ))
+    return TestClient(isolated_app)
+
+
+def _zotero_item(**overrides) -> ZoteroItem:
+    defaults = dict(
+        key="K1", title="A Great Paper", item_type="journalArticle",
+        creators=[ZoteroCreator(creator_type="author", name="Jane Smith")],
+        date="2024", abstract_note="an abstract", doi="10.1/xyz",
+        url="https://example.com/paper", publication_title="Journal of Things",
+        tags=[ZoteroTag(tag="ml")], collections=[],
+    )
+    defaults.update(overrides)
+    return ZoteroItem(**defaults)
+
+
+def test_zotero_status(isolated_client, zotero):
+    from prisma.integrations.zotero.client import ZoteroStatus
+    zotero.status.return_value = ZoteroStatus(mode="web_api", available=True, reachable=True)
+    r = isolated_client.get("/zotero/status")
+    assert r.status_code == 200
+    assert r.json() == {"mode": "web_api", "available": True, "reachable": True}
+
+
+def test_zotero_collections_success(isolated_client, zotero):
+    from prisma.storage.models.zotero_models import ZoteroCollection
+    zotero.get_collections.return_value = [ZoteroCollection(key="C1", name="My Collection")]
+    r = isolated_client.get("/zotero/collections")
+    assert r.status_code == 200
+    assert r.json()[0]["name"] == "My Collection"
+
+
+def test_zotero_collections_failure_returns_503(isolated_client, zotero):
+    zotero.get_collections.side_effect = RuntimeError("network down")
+    r = isolated_client.get("/zotero/collections")
+    assert r.status_code == 503
+
+
+def test_zotero_import_404_when_item_not_found(isolated_client, zotero):
+    zotero.get_item.return_value = None
+    r = isolated_client.post("/zotero/import/DOES-NOT-EXIST")
+    assert r.status_code == 404
+
+
+def test_zotero_import_returns_existing_source_if_already_imported(isolated_client, vault, zotero):
+    # Already in the vault (zotero_key frontmatter match) -- must not
+    # re-create, just render and return the existing source.
+    existing = vault.create_source_from_citekey(
+        "smith2024", "Already Here", "body text",
+        zotero_key="K1", authors=["Jane Smith"], tags=[],
+    )
+    zotero.get_item.return_value = _zotero_item(key="K1")
+
+    r = isolated_client.post("/zotero/import/K1")
+    assert r.status_code == 201
+    assert r.json()["slug"] == existing.slug
+    zotero.get_pdf_bytes.assert_not_called()
+
+
+def test_zotero_import_creates_source_from_abstract_when_no_pdf(isolated_client, vault, zotero, indexer):
+    zotero.get_item.return_value = _zotero_item(key="K2")
+    zotero.get_pdf_bytes.return_value = None
+
+    r = isolated_client.post("/zotero/import/K2")
+    assert r.status_code == 201
+    data = r.json()
+    assert data["slug"] == "smith2024"  # make_citekey: first author's last name + year
+    assert "an abstract" in data["html"]
+    indexer.mark_stale.assert_called_once()
+
+    source = vault.get_source(data["slug"])
+    assert source.zotero_key == "K2"
+    assert source.doi == "10.1/xyz"


### PR DESCRIPTION
## Summary
Third of app.py's ~14 route domains to split out (F4). Same `build_zotero_router(deps) -> APIRouter` factory pattern as `sync_routes.py`/`notes_routes.py`/`streams_routes.py`: getter callables for `_vault`/`_zotero`/`_indexer` (all rebound at runtime by `/reload/*` endpoints).

- Moves all 6 `/zotero` routes (`status`, `collections`, `stats`, `sync-pending`, `items`, `import/{key}`) plus their request/response models (`ZoteroStatsResponse`, `SyncPendingResponse`) and the two PDF-fetch helpers (`_fetch_pdf_from_url`, `_pdf_bytes_to_md`) that only `zotero_import` used.
- The existing `tests/unit/server/test_zotero_routes.py` (full-app-singleton style, monkeypatching `app_module._zotero`) needed **no changes** -- the closure getters mean `app_module._zotero` is still the thing that actually answers requests, just reached one level indirected through the router now.
- Extended it with 6 new tests for `/zotero/status`, `/zotero/collections`, and `/zotero/import/{key}` -- the latter had zero coverage anywhere despite real branching logic (existing-import dedup, PDF-vs-abstract-fallback body, citekey creation) -- built via `build_zotero_router` in isolation (bare FastAPI app + tmp_path `VaultService`), matching `test_notes_routes.py`'s approach.
- `app.py`: 1894 -> 1700 lines.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F4, third extraction -- `admin_routes.py`/`search_routes.py` still to come).

## Test plan
- [x] `pytest tests/unit -q` -- 755 passed (6 new tests)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs