### PR TITLE
Extract /admin/kg/* routes into prisma/server/admin_routes.py

### DIFF
--- a/prisma/server/admin_routes.py
+++ b/prisma/server/admin_routes.py
@@ -1,0 +1,73 @@
+"""Knowledge-graph admin/diagnostic endpoints (/admin/kg/*).
+
+Built via a factory (`build_admin_router`) taking a getter callable rather
+than the raw object, same reasoning as sync_routes.py's `build_sync_router`:
+app.py's `/reload/indexer` endpoint rebinds its `_indexer` module global at
+runtime, so a router that captured it by value at include_router() time
+would keep talking to a stale, replaced instance after a reload.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+
+from prisma.services.knowledge_graph_client import KnowledgeGraphClient
+from prisma.storage.models.kg_models import DeadLetterEntry, EntitiesForFileResponse
+from prisma.storage.models.search_models import GraphSearchResult
+
+
+class AdminStatusResponse(BaseModel):
+    status: str
+
+
+class AdminRemovedResponse(BaseModel):
+    removed: int
+
+
+def build_admin_router(get_indexer: Callable[[], KnowledgeGraphClient]) -> APIRouter:
+    router = APIRouter(prefix="/admin/kg", tags=["admin"])
+
+    @router.post("/taint", response_model=AdminStatusResponse)
+    def admin_kg_taint():
+        """Mark the index stale so the next cycle re-indexes changed files."""
+        get_indexer().mark_stale()
+        return {"status": "stale"}
+
+    @router.post("/drop", response_model=AdminStatusResponse)
+    def admin_kg_drop():
+        """Drop the entire Kùzu graph and tracked manifest, forcing a full reindex from scratch."""
+        get_indexer().drop_index()
+        return {"status": "dropped"}
+
+    @router.get("/dead-letters", response_model=list[DeadLetterEntry])
+    def admin_kg_list_dead_letters():
+        """List failed-extraction ("dead letter") records without discarding
+        them — see what failed and why before deciding to clear it."""
+        return get_indexer().list_dead_letters()
+
+    @router.delete("/dead-letters", response_model=AdminRemovedResponse)
+    def admin_kg_clear_dead_letters():
+        """Discard recorded dead-letter records so the next incremental cycle
+        retries them fresh. Returns the number cleared."""
+        removed = get_indexer().clear_dead_letters()
+        return {"removed": removed}
+
+    @router.get("/entities", response_model=EntitiesForFileResponse)
+    def admin_kg_entities(path: str = Query(...)):
+        """Raw entities and relationship edges the knowledge graph extracted
+        from one specific vault-relative file path — for inspecting extraction
+        quality directly (unlike /search or /search/deep, which only ever
+        return file-level scores, never the underlying nodes)."""
+        return get_indexer().entities_for_file(path)
+
+    @router.get("/search", response_model=list[GraphSearchResult])
+    def admin_kg_search(q: str = Query(..., min_length=1), top_k: int = Query(20)):
+        """Raw graph query — keyword match over Entity nodes only, bypassing
+        Ollama reasoning and ChromaDB entirely (unlike /search/deep). Isolates
+        the KG layer for diagnosis: a bad /search/deep result could be
+        extraction, ranking, or the LLM's fault — this narrows it down."""
+        return get_indexer().search(q, top_k=top_k)
+
+    return router

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -61,10 +61,8 @@ _t("renderer ok")
 _t("importing knowledge_graph_client")
 from prisma.services.knowledge_graph_client import KnowledgeGraphClient
 from prisma.services import resource_lock
-from prisma.storage.models.kg_models import (
-    DeadLetterEntry, EntitiesForFileResponse, KGStatus,
-)
-from prisma.storage.models.search_models import DeepSearchCandidate, GraphSearchResult
+from prisma.storage.models.kg_models import KGStatus
+from prisma.storage.models.search_models import DeepSearchCandidate
 _t("knowledge_graph_client ok")
 
 _t("importing chroma_service")
@@ -443,6 +441,7 @@ from prisma.server.sync_routes import build_sync_router  # noqa: E402
 from prisma.server.notes_routes import build_notes_router  # noqa: E402
 from prisma.server.streams_routes import build_streams_router, StreamScheduler  # noqa: E402
 from prisma.server.zotero_routes import build_zotero_router  # noqa: E402
+from prisma.server.admin_routes import build_admin_router  # noqa: E402
 def _update_client_baseline(client_id: str, path: str, content_hash: str, mtime: float) -> None:
     with _client_baseline_lock:
         _client_baseline.setdefault(client_id, {})[path] = (content_hash, mtime)
@@ -482,6 +481,10 @@ _scheduler = StreamScheduler(
 app.include_router(build_zotero_router(
     get_vault=lambda: _vault,
     get_zotero=lambda: _zotero,
+    get_indexer=lambda: _indexer,
+))
+
+app.include_router(build_admin_router(
     get_indexer=lambda: _indexer,
 ))
 
@@ -957,59 +960,6 @@ def get_logs(
 # never calls any of these (confirmed: it only ever reads status()'s
 # knowledge_graph fields), they're for direct/curl admin use.
 
-class AdminStatusResponse(BaseModel):
-    status: str
-
-
-class AdminRemovedResponse(BaseModel):
-    removed: int
-
-
-@app.post("/admin/kg/taint", response_model=AdminStatusResponse)
-def admin_kg_taint():
-    """Mark the index stale so the next cycle re-indexes changed files."""
-    _indexer.mark_stale()
-    return {"status": "stale"}
-
-
-@app.post("/admin/kg/drop", response_model=AdminStatusResponse)
-def admin_kg_drop():
-    """Drop the entire Kùzu graph and tracked manifest, forcing a full reindex from scratch."""
-    _indexer.drop_index()
-    return {"status": "dropped"}
-
-
-@app.get("/admin/kg/dead-letters", response_model=list[DeadLetterEntry])
-def admin_kg_list_dead_letters():
-    """List failed-extraction ("dead letter") records without discarding
-    them — see what failed and why before deciding to clear it."""
-    return _indexer.list_dead_letters()
-
-
-@app.delete("/admin/kg/dead-letters", response_model=AdminRemovedResponse)
-def admin_kg_clear_dead_letters():
-    """Discard recorded dead-letter records so the next incremental cycle
-    retries them fresh. Returns the number cleared."""
-    removed = _indexer.clear_dead_letters()
-    return {"removed": removed}
-
-
-@app.get("/admin/kg/entities", response_model=EntitiesForFileResponse)
-def admin_kg_entities(path: str = Query(...)):
-    """Raw entities and relationship edges the knowledge graph extracted
-    from one specific vault-relative file path — for inspecting extraction
-    quality directly (unlike /search or /search/deep, which only ever
-    return file-level scores, never the underlying nodes)."""
-    return _indexer.entities_for_file(path)
-
-
-@app.get("/admin/kg/search", response_model=list[GraphSearchResult])
-def admin_kg_search(q: str = Query(..., min_length=1), top_k: int = Query(20)):
-    """Raw graph query — keyword match over Entity nodes only, bypassing
-    Ollama reasoning and ChromaDB entirely (unlike /search/deep). Isolates
-    the KG layer for diagnosis: a bad /search/deep result could be
-    extraction, ranking, or the LLM's fault — this narrows it down."""
-    return _indexer.search(q, top_k=top_k)
 
 
 @app.post("/render", response_model=RenderResponse)

--- a/tests/unit/server/test_admin_routes.py
+++ b/tests/unit/server/test_admin_routes.py
@@ -1,0 +1,77 @@
+"""Unit tests for prisma.server.admin_routes — built in isolation (a bare
+FastAPI app wrapping just build_admin_router + a MagicMock indexer), not
+the full prisma.server.app singleton, same approach as
+test_sync_routes.py/test_notes_routes.py. Previously these 6 routes had
+zero dedicated test coverage anywhere.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from prisma.server.admin_routes import build_admin_router
+
+
+@pytest.fixture
+def indexer() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def client(indexer) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_admin_router(get_indexer=lambda: indexer))
+    return TestClient(app)
+
+
+def test_taint_marks_index_stale(client, indexer):
+    r = client.post("/admin/kg/taint")
+    assert r.status_code == 200
+    assert r.json() == {"status": "stale"}
+    indexer.mark_stale.assert_called_once_with()
+
+
+def test_drop_drops_index(client, indexer):
+    r = client.post("/admin/kg/drop")
+    assert r.status_code == 200
+    assert r.json() == {"status": "dropped"}
+    indexer.drop_index.assert_called_once()
+
+
+def test_list_dead_letters(client, indexer):
+    indexer.list_dead_letters.return_value = []
+    r = client.get("/admin/kg/dead-letters")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_clear_dead_letters_returns_removed_count(client, indexer):
+    indexer.clear_dead_letters.return_value = 3
+    r = client.delete("/admin/kg/dead-letters")
+    assert r.status_code == 200
+    assert r.json() == {"removed": 3}
+
+
+def test_entities_for_file(client, indexer):
+    indexer.entities_for_file.return_value = {"entities": [], "edges": [], "extracted_by": None}
+    r = client.get("/admin/kg/entities", params={"path": "notes/foo.md"})
+    assert r.status_code == 200
+    indexer.entities_for_file.assert_called_once_with("notes/foo.md")
+
+
+def test_entities_requires_path_param(client):
+    r = client.get("/admin/kg/entities")
+    assert r.status_code == 422
+
+
+def test_search_passes_query_and_top_k(client, indexer):
+    indexer.search.return_value = []
+    r = client.get("/admin/kg/search", params={"q": "neural networks", "top_k": 5})
+    assert r.status_code == 200
+    indexer.search.assert_called_once_with("neural networks", top_k=5)
+
+
+def test_search_requires_nonempty_q(client):
+    r = client.get("/admin/kg/search", params={"q": ""})
+    assert r.status_code == 422


### PR DESCRIPTION
## Summary
Fourth of app.py's ~14 route domains to split out (F4). Same `build_admin_router(deps) -> APIRouter` factory pattern as `sync_routes.py`/`notes_routes.py`/`streams_routes.py`/`zotero_routes.py`: a getter callable for `_indexer` (rebound at runtime by `/reload/indexer`).

- Moves all 6 `/admin/kg/*` routes (`taint`, `drop`, `dead-letters` GET/DELETE, `entities`, `search`) plus their two response models (`AdminStatusResponse`, `AdminRemovedResponse`) -- all thin delegations to `KnowledgeGraphClient`, no other app.py state involved.
- `app.py`: 1700 -> 1650 lines.

Found during a modularization re-audit against `docs/software-engineering-quality-aspects.md` (F4, fourth extraction -- `search_routes.py` is the last one).

## Test plan
- [x] `pytest tests/unit -q` -- 763 passed (8 new tests for the router in isolation, previously zero coverage anywhere)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs