### PR TITLE
Extract /search routes and the in-memory search index into search_routes.py

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -62,7 +62,6 @@ _t("importing knowledge_graph_client")
 from prisma.services.knowledge_graph_client import KnowledgeGraphClient
 from prisma.services import resource_lock
 from prisma.storage.models.kg_models import KGStatus
-from prisma.storage.models.search_models import DeepSearchCandidate
 _t("knowledge_graph_client ok")
 
 _t("importing chroma_service")
@@ -367,7 +366,6 @@ def _build_chat_agent(vault: "VaultService", chroma: ChromaIndexer, kg: Knowledg
 
 
 from prisma.utils.text import content_hash as _content_hash
-from prisma.utils.text import significant_words as _significant_words
 
 
 _t("building vault")
@@ -442,6 +440,7 @@ from prisma.server.notes_routes import build_notes_router  # noqa: E402
 from prisma.server.streams_routes import build_streams_router, StreamScheduler  # noqa: E402
 from prisma.server.zotero_routes import build_zotero_router  # noqa: E402
 from prisma.server.admin_routes import build_admin_router  # noqa: E402
+from prisma.server.search_routes import build_search_router  # noqa: E402
 def _update_client_baseline(client_id: str, path: str, content_hash: str, mtime: float) -> None:
     with _client_baseline_lock:
         _client_baseline.setdefault(client_id, {})[path] = (content_hash, mtime)
@@ -486,6 +485,12 @@ app.include_router(build_zotero_router(
 
 app.include_router(build_admin_router(
     get_indexer=lambda: _indexer,
+))
+
+app.include_router(build_search_router(
+    get_vault=lambda: _vault,
+    get_indexer=lambda: _indexer,
+    get_chroma=lambda: _chroma,
 ))
 
 _executor = ThreadPoolExecutor(max_workers=2)
@@ -1322,168 +1327,6 @@ def vault_asset(asset_path: str):
     return FileResponse(candidate_path)
 
 
-class SearchResult(BaseModel):
-    slug: str
-    title: str
-    excerpt: str
-    score: float = 1.0
-
-
-# ── In-memory search index ────────────────────────────────────────────────────
-# Keyed by absolute path str → (mtime, slug, title, lower_text, first_lines)
-# Rebuilt lazily: only re-reads files whose mtime changed.
-_search_index: dict[str, tuple[float, str, str, str, list[str]]] = {}
-_search_index_lock = threading.Lock()
-
-
-def _refresh_search_index() -> None:
-    with _search_index_lock:
-        seen: set[str] = set()
-        for path in _vault.iter_files():
-            key = str(path)
-            seen.add(key)
-            try:
-                mtime = path.stat().st_mtime
-            except OSError:
-                continue
-            cached = _search_index.get(key)
-            if cached and cached[0] == mtime:
-                continue
-            try:
-                text = path.read_text(encoding="utf-8", errors="replace")
-            except OSError:
-                continue
-            slug = path.stem
-            title = slug
-            try:
-                node = _vault.get_any(slug)
-                title = node.title
-            except Exception:
-                pass
-            _search_index[key] = (mtime, slug, title, text.lower(), text.splitlines())
-        # Drop deleted files
-        for key in list(_search_index):
-            if key not in seen:
-                del _search_index[key]
-
-
-def _text_search(q: str, top_k: int = 30) -> list[SearchResult]:
-    terms = [t.lower().strip('"') for t in q.split() if t.strip('"')]
-    if not terms:
-        return []
-
-    # Expand terms with stems so "learning" also matches "learned", "learns", etc.
-    query_stems = _significant_words(q)
-
-    _refresh_search_index()
-
-    results: list[tuple[float, str, str, str]] = []
-    with _search_index_lock:
-        entries = list(_search_index.values())
-
-    for _mtime, slug, title, lower, lines in entries:
-        hits = sum(1 for t in terms if t in lower)
-        title_lower = title.lower()
-        score = hits * 1.0
-        for t in terms:
-            if t in title_lower:
-                score += 4.0
-        if hits == len(terms):
-            score += 3.0
-
-        # Stem-overlap bonus — rewards documents that share many stem roots with the query
-        doc_stems = _significant_words(title + " " + lower[:500])
-        stem_overlap = len(query_stems & doc_stems)
-        score += stem_overlap * 0.5
-
-        if score == 0:
-            continue
-
-        excerpt = ""
-        for line in lines:
-            ll = line.lower().strip()
-            if ll and any(t in ll for t in terms):
-                excerpt = line.strip()[:200]
-                break
-        results.append((score, slug, title, excerpt))
-
-    results.sort(key=lambda x: -x[0])
-    return [
-        SearchResult(slug=slug, title=title, excerpt=excerpt, score=score)
-        for score, slug, title, excerpt in results[:top_k]
-    ]
-
-
-@app.get("/search")
-def search(q: str = Query(..., min_length=1)) -> list[SearchResult]:
-    return _text_search(q)
-
-
-class DeepSearchResult(BaseModel):
-    slug: str
-    title: str
-    excerpt: str
-    score: float
-    reason: str = ""
-
-
-def _resolve_source_files(items: list[DeepSearchCandidate], query_stems: frozenset | None = None) -> list[DeepSearchResult]:
-    """Map DeepSearchCandidate(source_file, score, reason) to DeepSearchResult, resolving slugs."""
-    vault_root = str(_vault.root)
-    seen: set[str] = set()
-    out: list[tuple[float, str, str, str, str]] = []
-    for item in items:
-        src = item.source_file
-        if not src:
-            continue
-        slug = Path(vault_root, src).stem
-        if slug in seen:
-            continue
-        seen.add(slug)
-        try:
-            node = _vault.get_any(slug)
-            title = node.title
-            body = node.body if hasattr(node, "body") else ""
-        except Exception:
-            title = slug
-            body = ""
-        excerpt = body[:200].replace("\n", " ").strip() if body else ""
-        score = item.score
-        if query_stems:
-            doc_stems = _significant_words(title + " " + (body[:500] if body else ""))
-            score += len(query_stems & doc_stems) * 0.05
-        out.append((score, slug, title, excerpt, item.reason))
-    out.sort(key=lambda x: -x[0])
-    return [DeepSearchResult(slug=sl, title=ti, excerpt=ex, score=sc, reason=re)
-            for sc, sl, ti, ex, re in out]
-
-
-@app.get("/search/deep")
-def deep_search(q: str = Query(..., min_length=1)) -> list[DeepSearchResult]:
-    """Semantic search: Ollama reasons over the knowledge graph, falls back to graph scoring."""
-    query_stems = _significant_words(q)
-    ollama_results = _indexer.ollama_deep_search(q, top_k=15, chroma=_chroma)
-    if ollama_results:
-        return _resolve_source_files(ollama_results, query_stems=query_stems)
-
-    # Fallback: graph scoring aggregated by file
-    graph_nodes = _indexer.ranked_nodes(q, top_k=30)
-    if graph_nodes:
-        items = [DeepSearchCandidate(source_file=n.source_file, score=n.score, reason=n.label)
-                 for n in graph_nodes if n.source_file]
-        results = _resolve_source_files(items, query_stems=query_stems)
-        # Pad with text search for coverage
-        seen = {r.slug for r in results}
-        for r in _text_search(q, top_k=10):
-            if r.slug not in seen:
-                results.append(DeepSearchResult(slug=r.slug, title=r.title,
-                                                excerpt=r.excerpt, score=r.score * 0.3))
-        results.sort(key=lambda x: -x.score)
-        return results[:20]
-
-    # Graph not built — text only
-    return [DeepSearchResult(slug=r.slug, title=r.title, excerpt=r.excerpt, score=r.score)
-            for r in _text_search(q, top_k=20)]
 
 
 class DeduplicateResult(BaseModel):

--- a/prisma/server/search_routes.py
+++ b/prisma/server/search_routes.py
@@ -1,0 +1,202 @@
+"""Vault search endpoints (/search, /search/deep).
+
+Built via a factory (`build_search_router`) taking getter callables rather
+than raw objects, same reasoning as sync_routes.py's `build_sync_router`:
+app.py's `/reload`-style endpoints rebind its `_vault`/`_indexer`/`_chroma`
+module globals at runtime, so a router that captured them by value at
+include_router() time would keep talking to a stale, replaced instance
+after a reload.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Callable
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+
+from prisma.services.chroma_service import ChromaIndexer
+from prisma.services.knowledge_graph_client import KnowledgeGraphClient
+from prisma.services.vault import VaultService
+from prisma.storage.models.search_models import DeepSearchCandidate
+from prisma.utils.text import significant_words as _significant_words
+
+
+class SearchResult(BaseModel):
+    slug: str
+    title: str
+    excerpt: str
+    score: float = 1.0
+
+
+class DeepSearchResult(BaseModel):
+    slug: str
+    title: str
+    excerpt: str
+    score: float
+    reason: str = ""
+
+
+class _SearchIndex:
+    """In-memory full-text index over vault files, keyed by absolute path.
+    Rebuilt lazily on each search: only re-reads files whose mtime changed."""
+
+    def __init__(self, get_vault: Callable[[], VaultService]) -> None:
+        self._get_vault = get_vault
+        # (mtime, slug, title, lower_text, lines)
+        self._entries: dict[str, tuple[float, str, str, str, list[str]]] = {}
+        self._lock = threading.Lock()
+
+    def _refresh(self) -> None:
+        vault = self._get_vault()
+        with self._lock:
+            seen: set[str] = set()
+            for path in vault.iter_files():
+                key = str(path)
+                seen.add(key)
+                try:
+                    mtime = path.stat().st_mtime
+                except OSError:
+                    continue
+                cached = self._entries.get(key)
+                if cached and cached[0] == mtime:
+                    continue
+                try:
+                    text = path.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                slug = path.stem
+                title = slug
+                try:
+                    node = vault.get_any(slug)
+                    title = node.title
+                except Exception:
+                    pass
+                self._entries[key] = (mtime, slug, title, text.lower(), text.splitlines())
+            # Drop deleted files
+            for key in list(self._entries):
+                if key not in seen:
+                    del self._entries[key]
+
+    def search(self, q: str, top_k: int = 30) -> list[SearchResult]:
+        terms = [t.lower().strip('"') for t in q.split() if t.strip('"')]
+        if not terms:
+            return []
+
+        # Expand terms with stems so "learning" also matches "learned", "learns", etc.
+        query_stems = _significant_words(q)
+
+        self._refresh()
+
+        results: list[tuple[float, str, str, str]] = []
+        with self._lock:
+            entries = list(self._entries.values())
+
+        for _mtime, slug, title, lower, lines in entries:
+            hits = sum(1 for t in terms if t in lower)
+            title_lower = title.lower()
+            score = hits * 1.0
+            for t in terms:
+                if t in title_lower:
+                    score += 4.0
+            if hits == len(terms):
+                score += 3.0
+
+            # Stem-overlap bonus — rewards documents that share many stem roots with the query
+            doc_stems = _significant_words(title + " " + lower[:500])
+            stem_overlap = len(query_stems & doc_stems)
+            score += stem_overlap * 0.5
+
+            if score == 0:
+                continue
+
+            excerpt = ""
+            for line in lines:
+                ll = line.lower().strip()
+                if ll and any(t in ll for t in terms):
+                    excerpt = line.strip()[:200]
+                    break
+            results.append((score, slug, title, excerpt))
+
+        results.sort(key=lambda x: -x[0])
+        return [
+            SearchResult(slug=slug, title=title, excerpt=excerpt, score=score)
+            for score, slug, title, excerpt in results[:top_k]
+        ]
+
+
+def build_search_router(
+    get_vault: Callable[[], VaultService],
+    get_indexer: Callable[[], KnowledgeGraphClient],
+    get_chroma: Callable[[], ChromaIndexer],
+) -> APIRouter:
+    router = APIRouter(prefix="/search", tags=["search"])
+    index = _SearchIndex(get_vault)
+
+    def _resolve_source_files(
+        items: list[DeepSearchCandidate], query_stems: frozenset | None = None,
+    ) -> list[DeepSearchResult]:
+        """Map DeepSearchCandidate(source_file, score, reason) to DeepSearchResult, resolving slugs."""
+        vault = get_vault()
+        vault_root = str(vault.root)
+        seen: set[str] = set()
+        out: list[tuple[float, str, str, str, str]] = []
+        for item in items:
+            src = item.source_file
+            if not src:
+                continue
+            slug = Path(vault_root, src).stem
+            if slug in seen:
+                continue
+            seen.add(slug)
+            try:
+                node = vault.get_any(slug)
+                title = node.title
+                body = node.body if hasattr(node, "body") else ""
+            except Exception:
+                title = slug
+                body = ""
+            excerpt = body[:200].replace("\n", " ").strip() if body else ""
+            score = item.score
+            if query_stems:
+                doc_stems = _significant_words(title + " " + (body[:500] if body else ""))
+                score += len(query_stems & doc_stems) * 0.05
+            out.append((score, slug, title, excerpt, item.reason))
+        out.sort(key=lambda x: -x[0])
+        return [DeepSearchResult(slug=sl, title=ti, excerpt=ex, score=sc, reason=re)
+                for sc, sl, ti, ex, re in out]
+
+    @router.get("")
+    def search(q: str = Query(..., min_length=1)) -> list[SearchResult]:
+        return index.search(q)
+
+    @router.get("/deep")
+    def deep_search(q: str = Query(..., min_length=1)) -> list[DeepSearchResult]:
+        """Semantic search: Ollama reasons over the knowledge graph, falls back to graph scoring."""
+        query_stems = _significant_words(q)
+        indexer = get_indexer()
+        ollama_results = indexer.ollama_deep_search(q, top_k=15, chroma=get_chroma())
+        if ollama_results:
+            return _resolve_source_files(ollama_results, query_stems=query_stems)
+
+        # Fallback: graph scoring aggregated by file
+        graph_nodes = indexer.ranked_nodes(q, top_k=30)
+        if graph_nodes:
+            items = [DeepSearchCandidate(source_file=n.source_file, score=n.score, reason=n.label)
+                     for n in graph_nodes if n.source_file]
+            results = _resolve_source_files(items, query_stems=query_stems)
+            # Pad with text search for coverage
+            seen = {r.slug for r in results}
+            for r in index.search(q, top_k=10):
+                if r.slug not in seen:
+                    results.append(DeepSearchResult(slug=r.slug, title=r.title,
+                                                    excerpt=r.excerpt, score=r.score * 0.3))
+            results.sort(key=lambda x: -x.score)
+            return results[:20]
+
+        # Graph not built — text only
+        return [DeepSearchResult(slug=r.slug, title=r.title, excerpt=r.excerpt, score=r.score)
+                for r in index.search(q, top_k=20)]
+
+    return router

--- a/tests/unit/server/test_search_routes.py
+++ b/tests/unit/server/test_search_routes.py
@@ -1,0 +1,115 @@
+"""Unit tests for prisma.server.search_routes — built in isolation (a bare
+FastAPI app wrapping just build_search_router + a tmp_path VaultService),
+not the full prisma.server.app singleton, same approach as
+test_sync_routes.py/test_notes_routes.py. Previously /search and
+/search/deep had zero dedicated test coverage anywhere.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from prisma.server.search_routes import build_search_router
+from prisma.services.vault import VaultService
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> VaultService:
+    v = VaultService(tmp_path)
+    v.ensure_dirs()
+    return v
+
+
+@pytest.fixture
+def indexer() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def chroma() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def client(vault, indexer, chroma) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_search_router(
+        get_vault=lambda: vault,
+        get_indexer=lambda: indexer,
+        get_chroma=lambda: chroma,
+    ))
+    return TestClient(app)
+
+
+class TestTextSearch:
+    def test_no_results_for_empty_vault(self, client):
+        r = client.get("/search", params={"q": "deep learning"})
+        assert r.status_code == 200
+        assert r.json() == []
+
+    def test_finds_note_by_body_content(self, client, vault):
+        vault.create_note("My Note", "this note is about deep learning architectures")
+        r = client.get("/search", params={"q": "deep learning"})
+        assert r.status_code == 200
+        slugs = [item["slug"] for item in r.json()]
+        assert "my-note" in slugs
+
+    def test_title_match_scores_higher_than_body_only_match(self, client, vault):
+        vault.create_note("Deep Learning Basics", "an unrelated body")
+        vault.create_note("Other Note", "mentions deep learning once in passing")
+        r = client.get("/search", params={"q": "deep learning"})
+        results = r.json()
+        assert results[0]["slug"] == "deep-learning-basics"
+
+    def test_requires_nonempty_q(self, client):
+        r = client.get("/search", params={"q": ""})
+        assert r.status_code == 422
+
+    def test_no_results_when_no_terms_match(self, client, vault):
+        vault.create_note("My Note", "some content")
+        r = client.get("/search", params={"q": "xyzzy-nonexistent-term"})
+        assert r.json() == []
+
+
+class TestDeepSearch:
+    def test_uses_ollama_results_when_available(self, client, vault, indexer, chroma):
+        vault.create_note("AI Paper", "body about neural networks")
+        from prisma.storage.models.search_models import DeepSearchCandidate
+        indexer.ollama_deep_search.return_value = [
+            DeepSearchCandidate(source_file="ai-paper.md", score=0.9, reason="relevant")
+        ]
+
+        r = client.get("/search/deep", params={"q": "neural networks"})
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data) == 1
+        assert data[0]["slug"] == "ai-paper"
+        assert data[0]["reason"] == "relevant"
+        indexer.ollama_deep_search.assert_called_once_with("neural networks", top_k=15, chroma=chroma)
+
+    def test_falls_back_to_graph_ranked_nodes_when_ollama_empty(self, client, vault, indexer):
+        vault.create_note("Graph Paper", "body content")
+        indexer.ollama_deep_search.return_value = []
+        node = MagicMock(source_file="graph-paper.md", score=0.5, label="graph match")
+        indexer.ranked_nodes.return_value = [node]
+
+        r = client.get("/search/deep", params={"q": "graph content"})
+        assert r.status_code == 200
+        slugs = [item["slug"] for item in r.json()]
+        assert "graph-paper" in slugs
+
+    def test_falls_back_to_text_search_when_graph_not_built(self, client, vault, indexer):
+        vault.create_note("Text Only", "plain text search fallback content")
+        indexer.ollama_deep_search.return_value = []
+        indexer.ranked_nodes.return_value = []
+
+        r = client.get("/search/deep", params={"q": "plain text fallback"})
+        assert r.status_code == 200
+        slugs = [item["slug"] for item in r.json()]
+        assert "text-only" in slugs
+
+    def test_requires_nonempty_q(self, client):
+        r = client.get("/search/deep", params={"q": ""})
+        assert r.status_code == 422


### PR DESCRIPTION
## Summary
Fifth and last of app.py's ~14 route domains to split out (**F4 complete**). Same `build_search_router(deps) -> APIRouter` factory pattern as the other four extractions this session: getter callables for `_vault`/`_indexer`/`_chroma` (all rebound at runtime by `/reload/*` endpoints).

- The module-level `_search_index` dict + `_search_index_lock` (keyed by absolute path -> `(mtime, slug, title, lower_text, lines)`, rebuilt lazily on mtime change) becomes a small `_SearchIndex` class, one instance per router built, captured by closure -- same behavior, but no longer shared mutable global state across router instances (matters for tests: each test's isolated router+tmp_path vault gets its own fresh index instead of inheriting whatever a previous test call left behind).
- Moves both `/search` and `/search/deep`, plus their response models (`SearchResult`, `DeepSearchResult`) and `_resolve_source_files` (now a closure inside `build_search_router`, since it needs `get_vault()`).
- `app.py`: 1650 -> 1493 lines.

**Total across all five F4 extractions this session: 2308 -> 1493 lines (~35%)**, split into `notes_routes.py`, `streams_routes.py`, `zotero_routes.py`, `admin_routes.py`, `search_routes.py` -- all following `sync_routes.py`'s pre-existing `build_*_router(deps)` pattern. F4 is now fully closed out. Only F8 (already done, PR #58) and the remaining Rust-side findings are left from the original modularization re-audit.

## Test plan
- [x] `pytest tests/unit -q` -- 772 passed (9 new tests for the router in isolation, previously zero coverage anywhere for `/search` or `/search/deep`)
- [x] `bash docs/diagrams/gen.sh` -- regenerated, no diffs