### PR TITLE
fix: adopt and sweep an exception-handling policy (TODO #2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -958,19 +958,44 @@ to be one legitimate use case) turned out to make the fix "delete three of them,
 "reconcile four of them" -- worth checking whether apparent duplication is actually
 convergent-on-purpose before planning a refactor around keeping all of it.
 
-## 2. Inconsistent exception handling (medium — needs a policy, then a sweep)
+## 2. Inconsistent exception handling — RESOLVED 2026-07-30
 
-`prisma/` (core package only) has **220** `except Exception` blocks, of which **27**
-are bare `except Exception: pass` with no logging at all — e.g.
-`server/app.py:125`, `:174`, `:179`, `:496`. Others in the same file log properly with
-context (`server/app.py:239`, `:257`, `:714` — `_log.warning("...: %s", exc)`). No
-visible policy for which failures are safe to swallow silently vs. which need at
-least a log line; this looks like different sessions handling errors differently
-rather than a deliberate design.
+Was: `prisma/` (core package only) had **220** `except Exception` blocks (150 by
+2026-07-30, after F1/F2/F4's deletions/consolidation shrank the total independently),
+of which several were bare `except Exception: pass` with no logging at all, or used
+raw `print()` instead of the module's own logger right next to sibling blocks that
+did it correctly. No visible policy for which failures are safe to swallow silently
+vs. which need at least a log line; this looked like different sessions handling
+errors differently rather than a deliberate design.
 
-**Fix size:** medium. Needs a decision first (e.g. "swallow only for known-optional
-best-effort paths, and even then log at debug level") then a mechanical sweep — not
-a redesign, but touches most files in the package.
+**Policy adopted:** every `except Exception` block must do one of — (a) re-raise/
+propagate, (b) log with context at a level matching real impact (`warning`/`error`
+for anything masking a real failure — a broken config silently falling back to
+defaults, a file vanishing from a listing, a save silently not persisting — `debug`
+for genuinely optional best-effort paths where the fallback value itself is the
+answer, e.g. a reachability probe, a nice-to-have status hint), or (c) stay silent
+only where a comment explains why logging doesn't apply (e.g. a bootstrap patch that
+runs before `logging` itself is even importable) or where the failure is already
+surfaced to the caller through a different channel (an API response field, a job's
+own `errors` list) and a duplicate operator-facing log would just be noise.
+
+**Sweep result:** of 150 `except Exception` blocks, 15 already re-raised and 76
+already logged properly (both left untouched); 15 bare `except: pass` and 7
+`print()`-only blocks were converted to real logging; ~30 more that swallowed with
+no logging at all (returned a silent default, appended to a list with no log line,
+etc.) also got a logging call added, mostly `_log.warning`. `coordinator.py` kept
+its existing `self.debug`-gated `print()` calls as-is (a distinct, deliberate,
+pervasive convention throughout that file — converting it to `logging` wholesale
+would be a bigger, separate cleanup) but gained an unconditional `logger.warning`/
+`logger.exception` alongside each swallow, so failures are visible in real logs even
+with `debug=False`, not just in interactive/debug mode. 3 sites stayed silent on
+purpose, each with a comment explaining why (the pre-logging-setup `entry_points`
+patch in `server/app.py`; the CLI's `_wsl_windows_ip()` best-effort fallback, where
+the placeholder return value is itself the visible signal, printed straight to the
+user; and `/status`'s config-error probe, whose error is already returned in the API
+response body). 7 `analysis_agent.py` sites that looked silent by a naive grep
+already route through `self._log_ollama(..., error=...)`, which logs internally —
+false positives, left untouched.
 
 ## 3. Duplicated test suites — RESOLVED 2026-07-26, opposite direction than originally planned
 
@@ -1015,16 +1040,22 @@ true from when the note was written — the intended migration direction and the
 silently diverge. And "no byte-identical match" isn't the same as "not a duplicate" — near-duplicates
 written in a different style still count and are easy to miss with a pure `diff`/`md5sum` sweep.
 
-## 4. `server/app.py` is oversized for what the architecture doc describes (real refactor, lower priority)
+## 4. `server/app.py` is oversized for what the architecture doc describes — RESOLVED 2026-07-30
 
-1,692 lines, ~48 routes. The architecture doc describes `app.py` as "API process —
-REST + WebSocket, no UI mount," implying a thin routing layer, but route handlers
-appear to carry business logic inline rather than delegating to `services/`
-(spot-checked; not exhaustively verified line-by-line — worth a follow-up pass
-specifically diffing route-handler bodies against what `services/` already exposes).
-Also contains a startup-timing helper using a mutable-default-arg static-variable
-trick (`_t(label, _t0=[0.0])`, line 30) — works, but is the kind of clever-but-obscure
-pattern a future contributor will trip over.
+Was 1,692 lines (2,308 by the time this was actually tackled, having grown further
+in the meantime), ~48 routes, route handlers carrying business logic inline instead
+of a thin routing layer. Fixed as part of the 2026-07-30 modularization re-audit's F4
+finding: extracted `notes_routes.py`, `streams_routes.py`, `zotero_routes.py`,
+`admin_routes.py`, `search_routes.py` (5 separate PRs, #59-63), each a
+`build_*_router(deps) -> APIRouter` factory matching the pre-existing
+`sync_routes.py` convention, taking getter callables so `/reload/*` endpoints
+rebinding `_vault`/`_indexer`/`_chroma` module globals don't leave a router talking
+to a stale instance. `app.py`: 2,308 → 1,493 lines (~35%). Every extraction got
+dedicated isolated-router tests (bare FastAPI app + the factory + tmp_path
+`VaultService`/mocks) for routes that had zero prior coverage.
+
+The `_t(label, _t0=[0.0])` mutable-default-arg startup-timing trick mentioned in the
+original note is still there — cosmetic, not touched by this pass.
 
 **Fix size:** real refactor, but lower priority than #1–#3 — it's a maintainability
 smell, not something a demo audience will see directly.
@@ -1143,12 +1174,13 @@ Recommended order (each is independently shippable):
    direction than originally planned — see #3's own resolved note above).
 2. ~~Consolidate the Zotero client hierarchy (#1)~~ — **done 2026-07-27**, by removal
    rather than the originally-planned refactor — see #1's own resolved note above.
-3. Establish and sweep an exception-handling policy (#2) — mechanical once decided.
-4. `app.py` route/service-boundary cleanup (#4) — do last, lower external visibility.
+3. ~~Establish and sweep an exception-handling policy (#2)~~ — **done 2026-07-30** —
+   see #2's own resolved note above.
+4. ~~`app.py` route/service-boundary cleanup (#4)~~ — **done 2026-07-30**, as part of
+   the same re-audit's F4 finding — see #4's own resolved note above.
 
-This does **not** require "a good programmer to come in and rewrite it" — it needs 3-4
-focused cleanup passes in the order above. #1 and #3 are now both done; #2 and #4
-remain.
+This does **not** require "a good programmer to come in and rewrite it" — it needed
+4 focused cleanup passes in the order above. All four are now done.
 
 ## Deferred feature: vault unlock over LAN instead of an at-rest key (2026-07-22)
 

--- a/prisma/agents/search_agent.py
+++ b/prisma/agents/search_agent.py
@@ -41,7 +41,8 @@ class SearchAgent:
             self.prefer_high_quality: bool = cfg.prefer_high_quality
             self.require_academic_validation: bool = cfg.require_academic_validation
             self._sources: Dict[str, Source] = build_sources(cfg)
-        except Exception:
+        except Exception as exc:
+            logger.warning("search config load failed, falling back to hardcoded defaults: %s", exc)
             self.default_sources = ["semanticscholar", "arxiv"]
             self.min_confidence_score = 0.5
             self.prefer_high_quality = True

--- a/prisma/cli/prisma_cli.py
+++ b/prisma/cli/prisma_cli.py
@@ -51,7 +51,7 @@ def _wsl_windows_ip() -> str:
             if line.startswith('default'):
                 return line.split()[2]
     except Exception:
-        pass
+        pass  # best-effort only -- the '<windows-host-ip>' placeholder below is itself the visible fallback signal, printed straight to the user
     return '<windows-host-ip>'
 
 

--- a/prisma/coordinator.py
+++ b/prisma/coordinator.py
@@ -3,6 +3,7 @@ Prisma Coordinator - Main orchestration logic for literature reviews.
 MVP: Fast, simple, working implementation.
 """
 
+import logging
 from pathlib import Path
 from typing import Dict, List, Any
 import time
@@ -15,6 +16,8 @@ from .connectivity import monitor as connectivity
 from .storage.models.agent_models import CoordinatorResult, PipelineMetadata
 from .storage.pending_queue import PendingWriteQueue
 from .utils.config import config
+
+logger = logging.getLogger(__name__)
 
 
 class PrismaCoordinator:
@@ -36,6 +39,7 @@ class PrismaCoordinator:
                 if debug:
                     print("[DEBUG] Zotero agent initialized for auto-saving")
             except Exception as e:
+                logger.warning("failed to initialize Zotero agent, auto-save disabled: %s", e)
                 if debug:
                     print(f"[DEBUG] Failed to initialize Zotero agent: {e}")
 
@@ -138,6 +142,7 @@ class PrismaCoordinator:
                             
                 except Exception as e:
                     # If relevance assessment fails, keep the paper for safety
+                    logger.warning("relevance assessment failed for %r, keeping paper: %s", paper.title[:50], e)
                     relevant_papers.append(paper)
                     if self.debug:
                         print(f"[DEBUG] ⚠️ Relevance assessment failed for {paper.title[:50]}, keeping paper: {e}")
@@ -187,6 +192,7 @@ class PrismaCoordinator:
                                 print(f"[DEBUG] 📚 Duplicate found in Zotero: {paper.title[:50]}...")
                 except Exception as e:
                     # If duplicate checking fails, treat all as new for safety
+                    logger.warning("duplicate checking failed, treating all as new: %s", e)
                     new_papers = relevant_papers
                     if self.debug:
                         print(f"[DEBUG] ⚠️ Duplicate checking failed, treating all as new: {e}")
@@ -218,6 +224,7 @@ class PrismaCoordinator:
                     if self.debug and saved_papers_count > 0:
                         print(f"[DEBUG] Saved {saved_papers_count} high-quality papers to Zotero")
                 except Exception as e:
+                    logger.warning("failed to save papers to Zotero: %s", e)
                     warnings.append(f"Failed to save papers to Zotero: {str(e)}")
                     if self.debug:
                         print(f"[DEBUG] Zotero save error: {e}")
@@ -289,10 +296,11 @@ class PrismaCoordinator:
             )
             
         except Exception as e:
+            logger.exception("review pipeline failed")
             if self.debug:
                 import traceback
                 traceback.print_exc()
-            
+
             errors.append(str(e))
             return CoordinatorResult(
                 success=False,
@@ -357,6 +365,7 @@ class PrismaCoordinator:
             
         except Exception as e:
             # If search fails, assume no duplicate for safety
+            logger.warning("zotero duplicate check failed, assuming not a duplicate: %s", e)
             if self.debug:
                 print(f"[DEBUG] Error checking duplicate: {e}")
             return False
@@ -437,6 +446,7 @@ class PrismaCoordinator:
                     print(f"[DEBUG] Successfully saved {saved_count} items via unified interface")
                 return saved_count if saved_count is not None else len(zotero_items)
             except Exception as e:
+                logger.warning("failed to save items to Zotero via unified interface: %s", e)
                 if self.debug:
                     print(f"[DEBUG] Failed to save items to Zotero: {e}")
                 return 0

--- a/prisma/integrations/zotero/client.py
+++ b/prisma/integrations/zotero/client.py
@@ -66,7 +66,8 @@ def check_web_api_reachable(
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return resp.status == 200
-    except Exception:
+    except Exception as exc:
+        logger.debug("zotero web API reachability check failed: %s", exc)
         return False
 
 

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -6,6 +6,9 @@ def _ep_safe(**kw):
     try:
         return _ep_orig(**kw)
     except Exception:
+        # No logger yet -- this patch runs before `logging` (let alone this
+        # module's own imports) is even set up, and it's a narrow, known
+        # Python 3.14 bug workaround, not a real runtime failure path.
         return []
 _imeta.entry_points = _ep_safe
 
@@ -110,7 +113,8 @@ async def _ws_broadcast(event: dict, exclude_client_id: str | None = None) -> No
             continue
         try:
             await ws.send_text(msg)
-        except Exception:
+        except Exception as exc:
+            _log.debug("dropping disconnected ws client: %s", exc)
             dead.add(ws)
     if dead:
         with _ws_clients_lock:
@@ -297,7 +301,8 @@ def _resolve_vault_root() -> Path:
     from prisma.utils.config import ConfigLoader
     try:
         return ConfigLoader().get_vault_root()
-    except Exception:
+    except Exception as exc:
+        _log.warning("config load failed, falling back to ~/prisma-vault: %s", exc)
         return Path.home() / "prisma-vault"
 
 
@@ -305,10 +310,11 @@ def _build_zotero() -> ZoteroClient:
     from prisma.utils.config import ConfigLoader
     try:
         return ZoteroClient.from_config(ConfigLoader().config)
-    except Exception:
+    except Exception as exc:
         # Fall back to an unconfigured client rather than crashing startup --
         # is_available()/status() degrade gracefully on missing/bad credentials,
         # no separate "offline mode" construction path needed.
+        _log.warning("zotero client config failed, falling back to unconfigured client: %s", exc)
         from prisma.integrations.zotero.client import ZoteroAPIConfig
         return ZoteroClient(ZoteroAPIConfig(api_key="", library_id="", library_type="user"))
 
@@ -331,7 +337,8 @@ def _build_chroma(vault: "VaultService") -> ChromaIndexer:
         return ChromaIndexer(vault, embedding_model=rcfg.embedding_model,
                               ollama_base_url=rcfg.ollama_base_url, provider=rcfg.provider,
                               chroma_port=rcfg.chroma_port)
-    except Exception:
+    except Exception as exc:
+        _log.warning("retrieval config load failed, falling back to ChromaIndexer defaults: %s", exc)
         return ChromaIndexer(vault)
 
 
@@ -344,13 +351,13 @@ def _chat_blocked_reason(chroma: ChromaIndexer, kg: KnowledgeGraphClient) -> str
     try:
         if kg.status().state == "indexing":
             return "the knowledge graph is currently indexing your vault"
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.debug("kg status probe failed, skipping this reason: %s", exc)
     try:
         if chroma.status().current_activity:
             return "the semantic search index is currently updating"
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.debug("chroma status probe failed, skipping this reason: %s", exc)
     return None
 
 
@@ -572,8 +579,8 @@ def _run_review(job_id: str, req: ReviewRequest) -> None:
             try:
                 html, _, _ = vault_render(Path(result.output_file).read_text(encoding="utf-8"), _vault)
                 content_html = html
-            except Exception:
-                pass
+            except Exception as exc:
+                _log.warning("review job=%s: rendering output_file to HTML failed: %s", job_id, exc)
 
         _jobs[job_id].update(
             status="done" if result.success else "error",
@@ -584,6 +591,7 @@ def _run_review(job_id: str, req: ReviewRequest) -> None:
             errors=result.errors,
         )
     except Exception as exc:
+        _log.exception("review job=%s failed", job_id)
         _jobs[job_id].update(status="error", errors=[str(exc)])
 
 
@@ -804,8 +812,8 @@ async def websocket_endpoint(ws: WebSocket, client_id: str | None = Query(None))
         # the client) now always initiates this.
         try:
             await ws.send_text(json.dumps({"type": "request_manifest"}))
-        except Exception:
-            pass
+        except Exception as exc:
+            _log.debug("client_id=%s disconnected before request_manifest could be sent: %s", client_id, exc)
 
     try:
         while True:
@@ -889,14 +897,15 @@ def status():
             chats=len(listing.chats),
             streams=len(listing.streams),
         )
-    except Exception:
+    except Exception as exc:
+        _log.warning("vault.list_nodes() failed, reporting zeroed stats: %s", exc)
         vault_stats = VaultStats(root=str(_vault.root), notes=0, sources=0, chats=0, streams=0)
 
     zotero_info = None
     try:
         zotero_info = _zotero.status()
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.debug("zotero status probe failed: %s", exc)
 
     return {
         "online": connectivity.is_online,

--- a/prisma/server/kg_app.py
+++ b/prisma/server/kg_app.py
@@ -52,7 +52,8 @@ def _load_config():
     try:
         loader = ConfigLoader()
         return loader, loader.config
-    except Exception:
+    except Exception as exc:
+        _log.warning("config load failed, falling back to in-memory defaults: %s", exc)
         return None, PrismaConfig()
 
 
@@ -60,8 +61,8 @@ def _resolve_vault_root(loader) -> Path:
     if loader is not None:
         try:
             return loader.get_vault_root()
-        except Exception:
-            pass
+        except Exception as exc:
+            _log.warning("get_vault_root() failed, falling back to ~/prisma-vault: %s", exc)
     return Path.home() / "prisma-vault"
 
 

--- a/prisma/server/search_routes.py
+++ b/prisma/server/search_routes.py
@@ -9,6 +9,7 @@ after a reload.
 """
 from __future__ import annotations
 
+import logging
 import threading
 from pathlib import Path
 from typing import Callable
@@ -21,6 +22,8 @@ from prisma.services.knowledge_graph_client import KnowledgeGraphClient
 from prisma.services.vault import VaultService
 from prisma.storage.models.search_models import DeepSearchCandidate
 from prisma.utils.text import significant_words as _significant_words
+
+_log = logging.getLogger("prisma.search")
 
 
 class SearchResult(BaseModel):
@@ -71,8 +74,8 @@ class _SearchIndex:
                 try:
                     node = vault.get_any(slug)
                     title = node.title
-                except Exception:
-                    pass
+                except Exception as exc:
+                    _log.debug("falling back to slug as title for %s: %s", slug, exc)
                 self._entries[key] = (mtime, slug, title, text.lower(), text.splitlines())
             # Drop deleted files
             for key in list(self._entries):
@@ -154,7 +157,8 @@ def build_search_router(
                 node = vault.get_any(slug)
                 title = node.title
                 body = node.body if hasattr(node, "body") else ""
-            except Exception:
+            except Exception as exc:
+                _log.debug("falling back to slug as title for %s: %s", slug, exc)
                 title = slug
                 body = ""
             excerpt = body[:200].replace("\n", " ").strip() if body else ""

--- a/prisma/server/supervisor.py
+++ b/prisma/server/supervisor.py
@@ -88,7 +88,8 @@ def _read_raw_config() -> dict:
         if path.exists():
             try:
                 return tomllib.loads(path.read_text()) or {}
-            except Exception:
+            except Exception as exc:
+                log.warning("failed to parse %s, falling back to defaults: %s", path, exc)
                 return {}
     return {}
 
@@ -98,8 +99,8 @@ def _resolve_vault_root() -> Path:
         root = _read_raw_config().get("vault_root", "").strip()
         if root:
             return Path(root).expanduser().resolve()
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("vault_root resolution failed, falling back to ~/prisma-vault: %s", exc)
     return Path.home() / "prisma-vault"
 
 
@@ -114,7 +115,8 @@ def _ollama_base_url() -> str:
     try:
         host = _read_raw_config().get("llm", {}).get("host", "localhost:11434")
         return f"http://{host}"
-    except Exception:
+    except Exception as exc:
+        log.warning("llm.host resolution failed, falling back to localhost:11434: %s", exc)
         return "http://localhost:11434"
 
 
@@ -135,7 +137,8 @@ def _query_ollama_resident_mb(base_url: str, timeout: float = 2.0) -> dict[str, 
         with urllib.request.urlopen(f"{base_url}/api/ps", timeout=timeout) as resp:
             data = json.loads(resp.read())
         return {m["name"]: int(m.get("size_vram", 0)) // (1024 * 1024) for m in data.get("models", [])}
-    except Exception:
+    except Exception as exc:
+        log.debug("could not reach ollama %s/api/ps: %s", base_url, exc)
         return None
 
 
@@ -152,7 +155,8 @@ def _load_vram_profiles() -> dict[str, int]:
     try:
         path = _model_vram_profile_path()
         return json.loads(path.read_text()) if path.exists() else {}
-    except Exception:
+    except Exception as exc:
+        log.warning("failed to load vram profiles, starting from empty: %s", exc)
         return {}
 
 
@@ -437,8 +441,8 @@ def _load_compute_pools() -> tuple[
                 capacity, affinity, pool_models, model_concurrency, pool_vram_budget, model_vram,
                 model_background_limit, pool_provider,
             )
-    except Exception:
-        pass
+    except Exception as exc:
+        log.warning("compute_pools config parse failed, falling back to a single default pool: %s", exc)
     return (
         {"default": 1}, {"default"}, {"default": set()}, {"default": {}}, {"default": None}, {"default": {}},
         {"default": {}}, {"default": "ollama"},
@@ -462,8 +466,8 @@ def _die_with_parent() -> None:
         PR_SET_PDEATHSIG = 1
         libc = ctypes.CDLL("libc.so.6", use_errno=True)
         libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM)
-    except Exception:
-        pass  # non-Linux, or prctl unavailable — best effort only
+    except Exception as exc:
+        log.debug("PR_SET_PDEATHSIG unavailable (non-Linux, or prctl missing): %s", exc)
 
 
 class Worker:
@@ -543,7 +547,8 @@ def _pid_alive(pid: int) -> bool:
         return False
     except PermissionError:
         return True  # exists, just not ours to signal
-    except Exception:
+    except Exception as exc:
+        log.debug("pid=%s liveness check raised, assuming alive (fail safe): %s", pid, exc)
         return True  # unknown — fail safe, don't release something we're unsure about
 
 
@@ -1056,7 +1061,8 @@ def _make_handler(supervisor: Supervisor):
                 return {}
             try:
                 return json.loads(self.rfile.read(length))
-            except Exception:
+            except Exception as exc:
+                log.debug("malformed JSON body on control API request: %s", exc)
                 return {}
 
         def do_GET(self) -> None:

--- a/prisma/server/web_app.py
+++ b/prisma/server/web_app.py
@@ -91,13 +91,16 @@ def _ui_watcher() -> None:
             with _ui_dev_lock:
                 _ui_dev_state["building"] = True
             _log.info("ui/src changed — rebuilding")
-            subprocess.run(["npm", "run", "build"], cwd=_ui_dir, capture_output=True)
-            with _ui_dev_lock:
-                _ui_dev_state["version"] += 1
-                _ui_dev_state["building"] = False
-            _log.info("ui rebuild done (version %d)", _ui_dev_state["version"])
-        except Exception:
-            pass
+            try:
+                subprocess.run(["npm", "run", "build"], cwd=_ui_dir, capture_output=True)
+                with _ui_dev_lock:
+                    _ui_dev_state["version"] += 1
+                _log.info("ui rebuild done (version %d)", _ui_dev_state["version"])
+            finally:
+                with _ui_dev_lock:
+                    _ui_dev_state["building"] = False
+        except Exception as exc:
+            _log.warning("ui watcher iteration failed: %s", exc)
 
 
 if _ui_src.exists():

--- a/prisma/server/zotero_routes.py
+++ b/prisma/server/zotero_routes.py
@@ -25,6 +25,7 @@ from prisma.storage.models.vault_models import RenderedNode
 from prisma.storage.models.zotero_models import ZoteroCollection, ZoteroItem
 
 _activity = logging.getLogger("prisma.activity")
+_log = logging.getLogger("prisma.zotero_routes")
 
 
 class ZoteroStatsResponse(BaseModel):
@@ -64,7 +65,8 @@ def _fetch_pdf_from_url(url: str | None, doi: str | None) -> bytes | None:
                 data = resp.read()
             if data[:4] == b"%PDF":
                 return data
-        except Exception:
+        except Exception as exc:
+            _log.debug("pdf candidate %s failed, trying next: %s", pdf_url, exc)
             continue
     return None
 
@@ -73,7 +75,8 @@ def _pdf_bytes_to_md(data: bytes) -> str:
     try:
         from docu_craft.renderers.pdf_md import pdf_to_md
         return pdf_to_md(data)
-    except Exception:
+    except Exception as exc:
+        _log.warning("pdf_to_md conversion failed, importing with empty body: %s", exc)
         return ""
 
 

--- a/prisma/services/chroma_service.py
+++ b/prisma/services/chroma_service.py
@@ -149,7 +149,8 @@ class ChromaIndexer:
         try:
             self._ensure_client()
             chunks = self._collection.count()
-        except Exception:
+        except Exception as exc:
+            _log.debug("chroma status: chunk count unavailable: %s", exc)
             chunks = -1
         with self._lock:
             files = len(self._manifest)
@@ -186,7 +187,8 @@ class ChromaIndexer:
             total = self._collection.count()
             if total == 0:
                 return []
-        except Exception:
+        except Exception as exc:
+            _log.warning("chroma query: collection unavailable, returning no results: %s", exc)
             return []
         with resource_lock.lease(self._supervisor_host, self._supervisor_port, holder=_RESOURCE_HOLDER, model=self._model) as granted:
             embeddings = _embed_texts([question], self._model, self._base_url, self._provider) if granted else None
@@ -236,7 +238,8 @@ class ChromaIndexer:
         if self._manifest_path.exists():
             try:
                 self._manifest = json.loads(self._manifest_path.read_text(encoding="utf-8"))
-            except Exception:
+            except Exception as exc:
+                _log.warning("failed to load chroma manifest, starting from empty (will re-embed): %s", exc)
                 self._manifest = {}
 
     def _loop(self) -> None:
@@ -386,5 +389,5 @@ class ChromaIndexer:
             data = dict(self._manifest)
         try:
             self._manifest_path.write_text(json.dumps(data), encoding="utf-8")
-        except Exception:
-            pass
+        except Exception as exc:
+            _log.warning("failed to save chroma manifest to %s (will re-embed unnecessarily on restart): %s", self._manifest_path, exc)

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -1504,7 +1504,8 @@ def _frontmatter(body: str) -> dict:
     import yaml
     try:
         return yaml.safe_load(body[3:end]) or {}
-    except Exception:
+    except Exception as exc:
+        _log.debug("malformed frontmatter, treating as empty: %s", exc)
         return {}
 
 

--- a/prisma/services/vault.py
+++ b/prisma/services/vault.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import threading
 from datetime import datetime
@@ -12,6 +13,8 @@ from prisma.storage.models.vault_models import (
     Chat, ChatMessage, ChatRole, Note, NodeType, Source, Stream, StreamStatus,
     RefreshFrequency, ToolCallRecord, VaultListing, VaultNodeMeta, VaultTreeNode,
 )
+
+_log = logging.getLogger("prisma.vault")
 
 # Recognised companion file extensions stored alongside a .md source node.
 COMPANION_EXTS = (".pdf", ".html", ".htm", ".svg", ".epub", ".docx")
@@ -601,7 +604,8 @@ class VaultService:
             _dc_render(source=html_path, format="md", output=tmp)
             md_content = tmp.read_text(encoding="utf-8")
             tmp.unlink(missing_ok=True)
-        except Exception:
+        except Exception as exc:
+            _log.warning("docu_craft render failed for %s, no .md companion generated: %s", html_path, exc)
             return False
         fm.setdefault("type", "note")
         companion.write_text(_render_frontmatter(fm) + md_content, encoding="utf-8")
@@ -712,8 +716,8 @@ class VaultService:
         for path in streams_dir.glob("*.yaml"):
             try:
                 result.append(self.get_stream(_file_slug(path.stem)))
-            except Exception:
-                pass
+            except Exception as exc:
+                _log.warning("skipping unreadable stream %s: %s", path, exc)
         result.sort(key=lambda s: s.modified_at, reverse=True)
         return result
 
@@ -816,8 +820,8 @@ class VaultService:
                         modified_at=datetime.fromtimestamp(path.stat().st_mtime),
                         stream_status=stream_status,
                     ))
-                except Exception:
-                    pass
+                except Exception as exc:
+                    _log.warning("skipping unreadable stream %s in vault tree: %s", entry.path, exc)
             elif name.endswith(".md") or name.endswith(".html"):
                 try:
                     path = Path(entry.path)
@@ -865,8 +869,8 @@ class VaultService:
                             modified_at=datetime.fromtimestamp(path.stat().st_mtime),
                             stream_status=stream_status,
                         ))
-                except Exception:
-                    pass
+                except Exception as exc:
+                    _log.warning("skipping unreadable file %s in vault tree: %s", entry.path, exc)
         return nodes
 
     # ── Node operations ───────────────────────────────────────────────────────

--- a/prisma/utils/config.py
+++ b/prisma/utils/config.py
@@ -508,8 +508,8 @@ class ConfigLoader:
             config = PrismaConfig(**user_data)
             return config
         except Exception as e:
-            print(f"[ERROR] Configuration validation failed: {e}")
-            print("[WARNING] Using default configuration")
+            logger.error(f"Configuration validation failed: {e}")
+            logger.warning("Using default configuration")
             return PrismaConfig()
     
     def get(self, key_path: str, default: Any = None) -> Any:


### PR DESCRIPTION
## Summary

TODO.md's #2 flagged that `prisma/` had no visible policy for which `except Exception` failures were safe to swallow silently vs. which needed at least a log line — 220 blocks at audit time (150 by the time this landed, after F1/F2/F4 shrank the total independently), with different sessions clearly handling errors differently rather than by deliberate design.

**Policy adopted** (documented in TODO.md's now-resolved #2 section): every `except Exception` block must do one of:
- re-raise/propagate, or
- log with context at a level matching real impact (`warning`/`error` when the swallow masks a real failure — a broken config silently defaulting, a file vanishing from a listing, a save silently not persisting; `debug` for genuinely optional best-effort paths where the fallback value is itself the answer, e.g. a reachability probe), or
- stay silent only with a comment explaining why (pre-`logging`-setup bootstrap code, or a failure already surfaced to the caller through a different channel — an API response field, a job's own `errors` list).

**Sweep result:** of 150 `except Exception` blocks, 15 already re-raised and 76 already logged properly (untouched). 15 bare `except: pass` and 7 `print()`-only blocks converted to real logging. ~30 more that swallowed silently (returned a default, appended to a list with no log line, etc.) gained a logging call, mostly `_log.warning`. `coordinator.py` kept its existing `self.debug`-gated `print()` calls as-is (a distinct, pervasive convention across that whole file — converting it to `logging` wholesale would be its own separate cleanup), but every swallow there also gained an unconditional `logger.warning`/`logger.exception` call, so failures are visible in real logs even with `debug=False`. 3 sites stayed silent on purpose, each with a comment explaining why. 7 `analysis_agent.py` sites that looked silent by a naive grep already route through `self._log_ollama(..., error=...)`, which logs internally — false positives, left untouched.

**Also fixed:** TODO.md's #4 (`server/app.py` oversized) marked RESOLVED — already closed by the 2026-07-30 F4 router-extraction PRs (#59-63, `app.py` 2308→1493 lines), just hadn't been marked done in the doc yet.

## Test plan

- [x] `pytest tests/unit -q` — 772 passed
- [x] `bash docs/diagrams/gen.sh` — ran clean, no diagram content actually changed (this is a logging-only sweep, no architecture change)