### PR TITLE
feat: build ADR-017 chat claim attribution (footnotes 1-3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1373,34 +1373,41 @@ has tray/background OS-integration via Tauri, which this can build on.
   at-rest is still deferred to a future session (as of 2026-07-24), so a
   locked/encrypted vault's interaction with sync is still unresolved.
 
-## Chat claim attribution / footnotes (2026-07-26, see ADR-017)
+## Chat claim attribution / footnotes (2026-07-26, see ADR-017) — 1-3 done 2026-07-31
 
 Design settled: distinguishing which claims in an assistant turn are traceable to a specific
 vault document vs. the model's own inference — mirroring academic citation practice ("what is
 self-made is not confused with what belongs to others"). Ontology done
 (`docs/ontologia.md` Axiom 16, `docs/concepts/footnote.md`); data model done
 (`FootnoteRelation`, `Footnote`, `ChatMessage.footnotes` in `storage/models/vault_models.py`,
-replacing the unused `sources_cited` field). Rendering convention: inline superscript marker
-in the turn's text (`word¹`), footnote list appended at the end of the turn.
+replacing the unused `sources_cited` field).
 
-**Not yet built — remaining checklist:**
+**Point 5 turned out to be a stale-doc false alarm, not a real blocker**: `docs/ontologia.md`
+said Chat API routes weren't implemented yet, but `POST /chat` (and the rest of `/chats/*`) was
+already live and working by the time this was picked back up — the doc just hadn't been updated
+since ADR-017 was written. Fixed alongside this.
 
-- [ ] `ChatAgent` prompting: get the model to self-segment its own response into per-claim
-  spans and self-report `relation` (`citation` / `attribution` / `relational` / `ai-inference`)
-  and `sources` at generation time. No prompting strategy designed yet — this is the actual
-  hard part; ADR-014's tool-marker convention (`SEARCH_VAULT:`/`GRAPH_CONTEXT:` in
-  `chat_tools.py`) is the closest existing precedent for getting this model to reliably emit a
-  structured side-channel, worth evaluating as a starting point rather than inventing a new
-  mechanism.
-- [ ] Wire `relation = relational` footnotes to actually originate from
-  `ChatToolbox._graph_context`'s results specifically (currently no connection between tool
-  output and footnote generation exists — the tool returns `ToolResult.raw`, but nothing maps
-  that into a `Footnote`).
-- [ ] UI rendering: superscript markers in message content, footnote list at the end of each
-  assistant turn, each entry showing `relation` + linked `Note`/`Source` title (not yet
-  designed — no mockup, no component).
-- [ ] `faithfulness_checked` verification — checking a footnoted claim against what its
-  `sources` actually say. Explicitly deferred as a separate, harder problem in ADR-017; not
-  scoped yet (could be a background job, could be synchronous at generation time — undecided).
-- [ ] Depends on Chat API routes existing at all (`docs/ontologia.md`'s "Not yet implemented"
-  still lists these as unbuilt) — this can't be wired end-to-end until that lands.
+- [x] `ChatAgent` prompting (`services/chat_tools.py::system_prompt_footnote_section`,
+  `agents/chat_agent.py::_extract_footnotes`): reused the existing tool-marker convention
+  (ADR-014) rather than inventing something new — the model writes `[^N]` inline at the point of
+  each claim, then a single trailing `FOOTNOTES_JSON: [...]` line listing each marker's
+  `relation`/`sources`. Only the *last* `FOOTNOTES_JSON:` match is used (in case the model
+  discusses the format itself), and a missing/malformed line degrades to "no footnotes" rather
+  than breaking the turn — self-reports are less reliable than a tool-call marker, so this had
+  to be defensive in a way the tool loop didn't need to be.
+- [x] `relation=relational` wired to `ChatToolbox._graph_context`: `GraphQueryResult` gained a
+  `sources: list[str]` field (`knowledge_graph_service.py::query()` already had the per-result
+  `source_file`s internally, just flattened into prose text and discarded before — now also
+  slugified and kept). `_graph_context`'s tool-result text now prepends an explicit
+  `Sources: slug-a, slug-b` line so the model has an unambiguous list to copy rather than having
+  to parse slugs back out of prose.
+- [x] UI rendering (`ui/src/routes/+page.svelte`): `renderContentSegments()` splits a turn's
+  content on `[^N]` into text/marker segments rendered as plain text / `<sup>` — deliberately
+  NOT `{@html}` on model-generated text, consistent with this codebase already treating tool
+  results as untrusted (`services/injection_defense.py`). A footnote list renders below the
+  turn, each entry showing the `relation` (colored badge) and its `sources` (as buttons that
+  call the existing `openNode()`). No live-LLM-in-browser verification done — `npm run build`
+  and `svelte-check` are clean, but nobody's actually watched a real model produce `[^N]`
+  markers in this UI yet.
+- [ ] `faithfulness_checked` verification — still explicitly deferred as a separate, harder
+  problem (ADR-017's own stance, not scoped here). Not part of this pass.

--- a/docs/concepts/footnote.md
+++ b/docs/concepts/footnote.md
@@ -55,7 +55,12 @@ linked [Note](note.md)/[Source](source.md)(s).
 
 ## Not yet implemented
 
-The data model (`Footnote`, `FootnoteRelation`) is defined; `ChatAgent` does not yet segment
-its own output into per-claim spans or self-report `relation`/`sources` at generation time.
+Built (2026-07-31): the data model, `ChatAgent` self-segmenting its output into per-claim `[^N]`
+markers and self-reporting `relation`/`sources` via a trailing `FOOTNOTES_JSON:` line,
+`relation=relational` sourcing from `ChatToolbox._graph_context`, and UI rendering.
+
 Automated `faithfulness_checked` verification (checking a footnoted claim against what its
 source(s) actually say) is a further, harder, and separately deferred problem — see ADR-017.
+Also unaddressed: an LLM can mis-self-report (e.g. label something `citation` that isn't one) —
+`faithfulness_checked` is the intended future hook for eventually catching that, not something
+this build guarantees today.

--- a/docs/ontologia.md
+++ b/docs/ontologia.md
@@ -174,8 +174,7 @@ Concepts that belong to the domain and are defined here, but whose code support 
 
 - **SmartTag** — defined in ontology; not yet applied during stream runs or import.
 - **PaperSummary per stream item** — produced during `prisma review`; not yet generated per-item during stream runs.
-- **Chat** — data model defined; chat API routes not yet implemented.
-- **Footnote / claim attribution** — data model defined (`Footnote`, `FootnoteRelation`), Axiom 16 and ADR-017 written; `ChatAgent` does not yet segment its own output into per-claim spans or self-report `relation`/`sources` at generation time. `faithfulness_checked` verification is unbuilt.
+- **Footnote / claim attribution** — data model defined (`Footnote`, `FootnoteRelation`), Axiom 16 and ADR-017 written; `ChatAgent` self-segmentation, `ChatToolbox._graph_context` wiring, and UI rendering are built (2026-07-31, see ADR-017). `faithfulness_checked` verification is still unbuilt, deliberately deferred as a separate problem.
 - **ChromaDB / semantic search** — integrated (ADR-009); see `services/chroma_service.py`, wired into `/search/deep`.
 - **Async rewrite** — `PrismaCoordinator` and agents are synchronous; `ThreadPoolExecutor` offloads blocking I/O. Full async rewrite deferred.
 - **Encryption at rest** — vault files are plaintext. `fscrypt` / `gocryptfs` / `age` deferred.

--- a/docs/wiki/adr/ADR-017-claim-attribution-and-footnote-model.md
+++ b/docs/wiki/adr/ADR-017-claim-attribution-and-footnote-model.md
@@ -2,12 +2,31 @@
 
 **Date:** 2026-07-27
 **Author:** CServinL
-**Status:** Proposed — data model built (`Footnote`/`FootnoteRelation` in
-`storage/models/vault_models.py`), ontology settled (Axiom 16,
-`docs/concepts/footnote.md`). `ChatAgent` does not yet segment its own
-output into per-claim spans or self-report `relation`/`sources` at
-generation time — see `TODO.md`'s "Chat claim attribution / footnotes"
-section for the remaining implementation checklist.
+**Status:** Implemented (2026-07-31) — data model, ontology (Axiom 16,
+`docs/concepts/footnote.md`), `ChatAgent` self-segmentation/self-report,
+`ChatToolbox._graph_context` wiring, and UI rendering are all built. Only
+`faithfulness_checked` verification remains unbuilt, per this ADR's own
+"Negative consequences" section below — deliberately deferred as a
+separate, harder problem, not an oversight.
+
+### Implementation notes (added 2026-07-31, not part of the original decision)
+
+- The self-report mechanism reuses ADR-014's tool-marker convention rather
+  than inventing something new: the model writes `[^N]` inline at each
+  claim, then a single trailing `FOOTNOTES_JSON: [...]` line with each
+  marker's `relation`/`sources`. Parsing is defensive throughout (bad JSON,
+  an unknown `relation`, or a missing line all degrade to "no footnotes,"
+  never break the turn) — a self-report is inherently less reliable than a
+  tool-call marker, since nothing forces the model to emit it correctly.
+- `GraphQueryResult` gained a `sources: list[str]` field so `relational`
+  footnotes have real data to draw from — the underlying per-document
+  `source_file`s already existed inside `KnowledgeGraphService.query()`,
+  they were just being flattened into prose text and discarded before
+  reaching the caller.
+- UI content is split into text/marker segments and rendered without
+  `{@html}`, even for the model's own final reply — consistent with this
+  codebase already treating tool results as untrusted content
+  (`services/injection_defense.py`).
 
 ## Context
 
@@ -118,9 +137,16 @@ actual source).
   `faithfulness_checked` is the intended (currently unbuilt) hook for
   eventually catching it — a real, harder, separately-deferred problem, not
   a guarantee this design provides today.
-- `ChatMessage.sources_cited`'s shape is replaced, not extended — acceptable
-  here since Chat API routes aren't implemented yet (per `docs/ontologia.md`'s
-  "Not yet implemented" section), so there is no live caller to migrate.
+- `ChatMessage.sources_cited`'s shape is replaced, not extended — this was
+  written assuming there was no live caller to migrate (Chat API routes
+  were believed not yet implemented, per `docs/ontologia.md`'s stale "Not
+  yet implemented" claim at the time). **Correction, 2026-07-31**: by the
+  time this was actually built, `/chat` was live and `ui/src/routes/
+  +page.svelte` already had a working chat UI using the old
+  `sources_cited: string[]` field name — so there *was* a live caller,
+  just not one anyone had gone back to check for. Migrated as part of this
+  same implementation pass (`ChatTurn.sources_cited` → `ChatTurn.footnotes`
+  in the frontend), not a separate follow-up.
 
 ## Related
 

--- a/prisma/agents/chat_agent.py
+++ b/prisma/agents/chat_agent.py
@@ -10,12 +10,22 @@ same spirit as Graphify's old max_retry_depth.
 """
 from __future__ import annotations
 
+import json
 import logging
 from typing import Callable, Literal
 
+from pydantic import ValidationError
+
 from prisma.services.chat_llm import ChatLLM
-from prisma.services.chat_tools import TOOL_CALL_RE, TOOLS, ChatToolbox, system_prompt_tool_section
-from prisma.storage.models.vault_models import ChatMessage, ChatRole, Note, ToolCallRecord
+from prisma.services.chat_tools import (
+    FOOTNOTES_LINE_RE,
+    TOOL_CALL_RE,
+    TOOLS,
+    ChatToolbox,
+    system_prompt_footnote_section,
+    system_prompt_tool_section,
+)
+from prisma.storage.models.vault_models import ChatMessage, ChatRole, Footnote, Note, ToolCallRecord
 
 _log = logging.getLogger("prisma.chat_agent")
 
@@ -50,6 +60,35 @@ _TOOL_NAME_BY_MARKER = {t.marker: t.name for t in TOOLS}
 
 def _estimate_tokens(text: str) -> int:
     return len(text) // 4  # same rough char/4 heuristic used by semchunk elsewhere in this codebase
+
+
+def _extract_footnotes(reply: str) -> tuple[str, list[Footnote]]:
+    """ADR-017: split the model's FOOTNOTES_JSON self-report off the visible
+    reply text. Defensive throughout -- an LLM self-report can be malformed
+    (invalid JSON, an unknown relation value, a non-list) in ways a tool
+    call marker can't be, and a bad self-report must degrade to "no
+    footnotes," never break the turn. Only the *last* match is used, in
+    case the model discusses the format itself earlier in its answer."""
+    matches = list(FOOTNOTES_LINE_RE.finditer(reply))
+    if not matches:
+        return reply.strip(), []
+    last = matches[-1]
+    content = (reply[: last.start()] + reply[last.end():]).strip()
+    try:
+        raw_items = json.loads(last.group(1))
+    except (json.JSONDecodeError, ValueError) as exc:
+        _log.warning("chat footnotes: malformed FOOTNOTES_JSON, dropping: %s", exc)
+        return content, []
+    if not isinstance(raw_items, list):
+        _log.warning("chat footnotes: FOOTNOTES_JSON was not a JSON array, dropping")
+        return content, []
+    footnotes: list[Footnote] = []
+    for item in raw_items:
+        try:
+            footnotes.append(Footnote.model_validate(item))
+        except ValidationError as exc:
+            _log.warning("chat footnotes: skipping malformed entry %r: %s", item, exc)
+    return content, footnotes
 
 
 class ChatAgent:
@@ -140,7 +179,10 @@ class ChatAgent:
                 )
             match = TOOL_CALL_RE.search(reply)
             if not match:
-                return ChatMessage(role=ChatRole.assistant, content=reply.strip(), tool_calls=tool_calls)
+                content, footnotes = _extract_footnotes(reply)
+                return ChatMessage(
+                    role=ChatRole.assistant, content=content, tool_calls=tool_calls, footnotes=footnotes,
+                )
 
             marker, query = match.group(1), match.group(2).strip()
             tool_calls.append(ToolCallRecord(tool=_TOOL_NAME_BY_MARKER[marker], args={"query": query}))
@@ -171,7 +213,7 @@ class ChatAgent:
         return used, self._max_history_tokens
 
     def _full_system_prompt(self, excerpt_notes: list[Note]) -> str:
-        parts = [self._system_prompt, system_prompt_tool_section()]
+        parts = [self._system_prompt, system_prompt_tool_section(), system_prompt_footnote_section()]
         if excerpt_notes:
             parts.append(self._excerpt_context_block(excerpt_notes))
         return "\n\n".join(parts)

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -83,7 +83,7 @@ _t("sync_orchestrator ok")
 
 _t("importing vault_models")
 from prisma.storage.models.vault_models import (
-    Chat, ChatMessage, ChatRole, NodeType, RenderedNode, ToolCallRecord,
+    Chat, ChatMessage, ChatRole, Footnote, NodeType, RenderedNode, ToolCallRecord,
     VaultTreeNode,
 )
 _t("vault_models ok")
@@ -530,6 +530,7 @@ class ChatResponse(BaseModel):
     chat_slug: str
     reply: str
     tool_calls: list[ToolCallRecord]
+    footnotes: list[Footnote] = []
 
 
 class CreateChatRequest(BaseModel):
@@ -1073,6 +1074,7 @@ def chat(req: ChatRequest):
     _activity.info("action=chat slug=%s tool_calls=%d", chat_node.slug, len(assistant_msg.tool_calls))
     return ChatResponse(
         chat_slug=chat_node.slug, reply=assistant_msg.content, tool_calls=assistant_msg.tool_calls,
+        footnotes=assistant_msg.footnotes,
     )
 
 

--- a/prisma/services/chat_tools.py
+++ b/prisma/services/chat_tools.py
@@ -14,6 +14,7 @@ god_nodes, surprising_connections, suggest_questions, deferred for later.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 from pydantic import BaseModel
 
@@ -60,6 +61,14 @@ TOOL_CALL_RE = re.compile(
     re.MULTILINE,
 )
 
+# ADR-017 claim attribution. Same pattern-based convention as tool calls
+# (ADR-014's appendix found free-text markers more reliable than native
+# function-calling on today's local model) -- a single trailing line rather
+# than a new per-line marker, since footnote data is naturally a list, not
+# a single value. Only the *last* match is used (ChatAgent.respond) in case
+# the model discusses the format itself earlier in its answer.
+FOOTNOTES_LINE_RE = re.compile(r"^FOOTNOTES_JSON:\s*(.+)$", re.MULTILINE)
+
 
 def system_prompt_tool_section() -> str:
     lines = [
@@ -77,6 +86,54 @@ def system_prompt_tool_section() -> str:
         "any tool line."
     )
     return "\n".join(lines)
+
+
+def system_prompt_footnote_section() -> str:
+    """ADR-017: mark, per claim, whether it's traceable to a specific vault
+    document or is the model's own inference -- mirroring academic citation
+    practice. See docs/concepts/footnote.md for the full field reference;
+    this is the operational instruction, not the design rationale."""
+    return "\n".join([
+        "For every substantive claim in your answer (not filler like "
+        '"Sure, here\'s what I found"), mark where it came from, so the '
+        "reader can tell what traces to a document vs. what is your own "
+        "reasoning:",
+        "",
+        "- Right after a claim that traces to a document, write an inline "
+        "marker in this exact format: [^N] where N is the next unused "
+        "number, starting at 1 (e.g. \"...uses self-attention[^1].\"). Do "
+        "this whether it's a direct quote, a paraphrase of one document, "
+        "or a claim that connects/synthesizes two or more documents.",
+        "- Right after a claim that is your own reasoning, generalization, "
+        "or general knowledge -- NOT traceable to any specific document "
+        "you were given -- also mark it with the next [^N], but it will "
+        "get relation \"ai-inference\" below. You do not need to mark "
+        "filler or purely conversational sentences, only actual claims.",
+        "- Only cite documents you actually saw in a tool result in this "
+        "conversation (their exact slug, shown as the `path=` of an "
+        "<untrusted_source> block, or in a GRAPH_CONTEXT tool result's "
+        "\"Sources:\" line). Never invent a slug.",
+        "",
+        "After your answer, on its own final line, list every [^N] marker "
+        "you used as a single-line JSON array, exactly in this format:",
+        "",
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "citation", '
+        '"sources": ["slug-a"]}, {"index": 2, "relation": "relational", '
+        '"sources": ["slug-b", "slug-c"]}, {"index": 3, '
+        '"relation": "ai-inference", "sources": []}]',
+        "",
+        "relation is one of:",
+        "- citation — direct quote or close paraphrase, exactly one source",
+        "- attribution — paraphrased/synthesized from one source, exactly "
+        "one source",
+        "- relational — connects or synthesizes across sources, two or "
+        "more sources (this is what a GRAPH_CONTEXT result usually is)",
+        "- ai-inference — your own reasoning, no document behind it, "
+        "sources must be an empty list",
+        "",
+        "If you added no [^N] markers at all, still write "
+        '"FOOTNOTES_JSON: []" as the last line -- do not omit it.',
+    ])
 
 
 class ChatToolbox:
@@ -106,13 +163,26 @@ class ChatToolbox:
             except OSError:
                 excerpt = ""
             items.append({"source_file": h.source_file, "score": h.score, "text": excerpt})
+        # Wrapped under the vault slug (not the raw source_file path) --
+        # this is exactly the identifier a footnote's `sources` list
+        # expects (ADR-017), so the model can copy it verbatim rather than
+        # having to derive a slug from a path itself.
         wrapped = "\n\n".join(
-            wrap_untrusted(i["source_file"], i["text"]) for i in items if i["text"]
+            wrap_untrusted(Path(i["source_file"]).stem, i["text"]) for i in items if i["text"]
         )
         return ToolResult(text=wrapped, raw=items)
 
     def _graph_context(self, query: str, budget: int = 1500) -> ToolResult:
         results = self._kg.query(query, budget=budget)
         text = results[0].text if results else ""
-        wrapped = wrap_untrusted("knowledge-graph", text) if text else ""
+        sources = results[0].sources if results else []
+        if text:
+            # `relational` footnotes need 2+ sources (see FootnoteRelation
+            # docs) -- listing them explicitly, not just relying on the
+            # slugs already mentioned in `text`'s prose lines, gives the
+            # model an unambiguous list to copy into FOOTNOTES_JSON.
+            header = f"Sources: {', '.join(sources)}\n\n" if sources else ""
+            wrapped = wrap_untrusted("knowledge-graph", header + text)
+        else:
+            wrapped = ""
         return ToolResult(text=wrapped, raw=[r.model_dump() for r in results])

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -1476,7 +1476,17 @@ class KnowledgeGraphService:
         if not results:
             return []
         text = "\n".join(f"- {r.source_file} (score={r.score:.1f})" for r in results)
-        return [GraphQueryResult(text=text[: budget * 4])]
+        # Dedup while preserving rank order -- multiple entities from the
+        # same document are common, but a footnote's `sources` list should
+        # name each document once.
+        sources: list[str] = []
+        seen: set[str] = set()
+        for r in results:
+            slug = Path(r.source_file).stem
+            if slug not in seen:
+                seen.add(slug)
+                sources.append(slug)
+        return [GraphQueryResult(text=text[: budget * 4], sources=sources)]
 
     def ollama_deep_search(self, question: str, top_k: int = 10, chroma=None) -> list[DeepSearchCandidate]:
         relevant_nodes = self.ranked_nodes(question, top_k=30)

--- a/prisma/storage/models/kg_models.py
+++ b/prisma/storage/models/kg_models.py
@@ -98,6 +98,11 @@ class RankedNode(BaseModel):
 
 class GraphQueryResult(BaseModel):
     text: str
+    # Vault node slugs the answer synthesizes across -- surfaced so chat's
+    # footnote attribution (ADR-017) can label GRAPH_CONTEXT-derived claims
+    # `relation=relational` with the real documents involved, instead of
+    # having no source list for cross-document graph answers at all.
+    sources: list[str] = []
 
 
 class OllamaReadyResponse(BaseModel):

--- a/tests/unit/agents/test_chat_agent.py
+++ b/tests/unit/agents/test_chat_agent.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from prisma.agents.chat_agent import MAX_TOOL_ITERATIONS, ChatAgent
+from prisma.agents.chat_agent import MAX_TOOL_ITERATIONS, ChatAgent, _extract_footnotes
 from prisma.services.chat_tools import ToolResult
 from prisma.storage.models.vault_models import ChatMessage, ChatRole, Note
 
@@ -300,3 +300,117 @@ def test_context_usage_includes_excerpt_notes_in_the_count():
     without_excerpt, _ = agent.context_usage(history=[])
 
     assert with_excerpt > without_excerpt
+
+
+# ── _extract_footnotes() — ADR-017 claim attribution self-report ─────────────
+
+def test_extract_footnotes_parses_a_well_formed_report():
+    reply = (
+        'Transformers use self-attention[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "citation", "sources": ["attention-paper"]}]'
+    )
+
+    content, footnotes = _extract_footnotes(reply)
+
+    assert content == "Transformers use self-attention[^1]."
+    assert len(footnotes) == 1
+    assert footnotes[0].index == 1
+    assert footnotes[0].relation == "citation"
+    assert footnotes[0].sources == ["attention-paper"]
+
+
+def test_extract_footnotes_strips_the_line_even_when_list_is_empty():
+    reply = "Just chatting, no claims here.\nFOOTNOTES_JSON: []"
+
+    content, footnotes = _extract_footnotes(reply)
+
+    assert content == "Just chatting, no claims here."
+    assert footnotes == []
+
+
+def test_extract_footnotes_returns_unchanged_when_line_missing():
+    # A model that ignores the instruction entirely must not lose its
+    # answer -- this is the single most important fallback in the whole
+    # feature, since footnoting is new prompting complexity layered on an
+    # existing, already-working chat loop.
+    reply = "No footnote line at all here."
+
+    content, footnotes = _extract_footnotes(reply)
+
+    assert content == "No footnote line at all here."
+    assert footnotes == []
+
+
+def test_extract_footnotes_drops_all_on_malformed_json_but_keeps_content():
+    reply = "Some answer.\nFOOTNOTES_JSON: {not valid json"
+
+    content, footnotes = _extract_footnotes(reply)
+
+    assert content == "Some answer."
+    assert footnotes == []
+
+
+def test_extract_footnotes_skips_only_the_malformed_entry():
+    reply = (
+        "Two claims here.\n"
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "citation", "sources": ["a"]}, '
+        '{"index": 2, "relation": "not-a-real-relation", "sources": ["b"]}]'
+    )
+
+    content, footnotes = _extract_footnotes(reply)
+
+    assert content == "Two claims here."
+    assert len(footnotes) == 1
+    assert footnotes[0].index == 1
+
+
+def test_extract_footnotes_uses_the_last_match_if_model_discusses_format_first():
+    reply = (
+        'I will use FOOTNOTES_JSON: [] as my format.\n'
+        "The actual answer[^1].\n"
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "ai-inference", "sources": []}]'
+    )
+
+    content, footnotes = _extract_footnotes(reply)
+
+    assert "The actual answer[^1]." in content
+    assert len(footnotes) == 1
+    assert footnotes[0].relation == "ai-inference"
+
+
+def test_respond_final_answer_populates_footnotes():
+    llm = MagicMock()
+    llm.complete.return_value = (
+        'Kùzu was chosen for its embedded mode[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["kg-decision"]}]'
+    )
+    agent = _agent(llm=llm)
+
+    reply = agent.respond(history=[], user_text="why Kùzu?")
+
+    assert reply.content == "Kùzu was chosen for its embedded mode[^1]."
+    assert len(reply.footnotes) == 1
+    assert reply.footnotes[0].sources == ["kg-decision"]
+
+
+def test_respond_final_answer_with_no_footnotes_line_has_empty_footnotes():
+    llm = MagicMock()
+    llm.complete.return_value = "A plain answer with no sourcing."
+    agent = _agent(llm=llm)
+
+    reply = agent.respond(history=[], user_text="hello")
+
+    assert reply.footnotes == []
+
+
+def test_system_prompt_includes_footnote_instructions():
+    llm = MagicMock()
+    llm.complete.return_value = "ok"
+    agent = _agent(llm=llm)
+
+    agent.respond(history=[], user_text="hello")
+
+    sent_messages = llm.complete.call_args[0][0]
+    system_content = sent_messages[0]["content"]
+    assert "FOOTNOTES_JSON" in system_content
+    assert "ai-inference" in system_content

--- a/tests/unit/server/test_chat_route.py
+++ b/tests/unit/server/test_chat_route.py
@@ -1,0 +1,77 @@
+"""Unit tests for app.py's POST /chat route -- in particular that footnotes
+(ADR-017) flow all the way from ChatAgent.respond() through to the API
+response, since this route has no isolated-router test file yet (unlike
+notes_routes.py etc.) -- it still lives directly in app.py.
+"""
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from prisma.server.app import app
+from prisma.storage.models.vault_models import Chat, ChatMessage, ChatRole, Footnote, NodeType
+
+client = TestClient(app, client=("127.0.0.1", 12345))
+
+
+def _chat(slug: str = "test-chat") -> Chat:
+    return Chat(slug=slug, title="Test Chat", node_type=NodeType.chat, path=Path(f"/tmp/{slug}.md"), messages=[])
+
+
+def test_chat_route_returns_footnotes_from_assistant_message(monkeypatch):
+    from prisma.server import app as app_module
+
+    vault = MagicMock()
+    vault.get_chat.return_value = _chat()
+    monkeypatch.setattr(app_module, "_vault", vault)
+
+    assistant_msg = ChatMessage(
+        role=ChatRole.assistant,
+        content="Kùzu was chosen for its embedded mode[^1].",
+        footnotes=[Footnote(index=1, relation="attribution", sources=["kg-decision"])],
+    )
+    chat_agent = MagicMock()
+    chat_agent.respond.return_value = assistant_msg
+    chat_agent.model = "test-model"
+    monkeypatch.setattr(app_module, "_chat_agent", chat_agent)
+
+    r = client.post("/chat", json={"message": "why Kùzu?", "chat_slug": "test-chat"})
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["reply"] == "Kùzu was chosen for its embedded mode[^1]."
+    assert data["footnotes"] == [
+        {"index": 1, "relation": "attribution", "sources": ["kg-decision"],
+         "claim_text": None, "faithfulness_checked": None},
+    ]
+    vault.append_messages.assert_called_once()
+
+
+def test_chat_route_footnotes_default_to_empty_list(monkeypatch):
+    from prisma.server import app as app_module
+
+    vault = MagicMock()
+    vault.get_chat.return_value = _chat()
+    monkeypatch.setattr(app_module, "_vault", vault)
+
+    chat_agent = MagicMock()
+    chat_agent.respond.return_value = ChatMessage(role=ChatRole.assistant, content="A plain answer.")
+    chat_agent.model = "test-model"
+    monkeypatch.setattr(app_module, "_chat_agent", chat_agent)
+
+    r = client.post("/chat", json={"message": "hello", "chat_slug": "test-chat"})
+
+    assert r.status_code == 200
+    assert r.json()["footnotes"] == []
+
+
+def test_chat_route_404_when_chat_not_found(monkeypatch):
+    from prisma.server import app as app_module
+
+    vault = MagicMock()
+    vault.get_chat.side_effect = FileNotFoundError()
+    monkeypatch.setattr(app_module, "_vault", vault)
+
+    r = client.post("/chat", json={"message": "hello", "chat_slug": "missing-chat"})
+
+    assert r.status_code == 404

--- a/tests/unit/services/test_chat_tools.py
+++ b/tests/unit/services/test_chat_tools.py
@@ -53,7 +53,9 @@ def test_toolbox_search_vault_returns_wrapped_text_and_raw(vault):
 
     assert result.raw == [{"source_file": "notes/attention.md", "score": 0.9,
                             "text": "Attention mechanisms let models weigh input tokens."}]
-    assert 'path="notes/attention.md"' in result.text
+    # Wrapped under the slug (ADR-017: what a footnote's `sources` expects),
+    # not the raw vault-relative path.
+    assert 'path="attention"' in result.text
     assert "Attention mechanisms" in result.text
 
 
@@ -72,14 +74,28 @@ def test_toolbox_search_vault_skips_unreadable_files(vault):
 def test_toolbox_graph_context_returns_wrapped_text(vault):
     chroma = MagicMock()
     kg = MagicMock()
-    kg.query.return_value = [GraphQueryResult(text="- notes/a.md (score=0.8)")]
+    kg.query.return_value = [GraphQueryResult(text="- notes/a.md (score=0.8)", sources=["a", "b"])]
 
     toolbox = ChatToolbox(chroma, kg, vault)
     result = toolbox.call("GRAPH_CONTEXT", "how do these relate")
 
     assert "notes/a.md" in result.text
     assert 'path="knowledge-graph"' in result.text
-    assert result.raw == [{"text": "- notes/a.md (score=0.8)"}]
+    # ADR-017: sources listed explicitly so the model has an unambiguous
+    # list to copy into FOOTNOTES_JSON, not just slugs buried in prose.
+    assert "Sources: a, b" in result.text
+    assert result.raw == [{"text": "- notes/a.md (score=0.8)", "sources": ["a", "b"]}]
+
+
+def test_toolbox_graph_context_omits_sources_header_when_none(vault):
+    chroma = MagicMock()
+    kg = MagicMock()
+    kg.query.return_value = [GraphQueryResult(text="- notes/a.md (score=0.8)")]
+
+    toolbox = ChatToolbox(chroma, kg, vault)
+    result = toolbox.call("GRAPH_CONTEXT", "how do these relate")
+
+    assert "Sources:" not in result.text
 
 
 def test_toolbox_graph_context_empty_when_no_results(vault):

--- a/tests/unit/services/test_knowledge_graph_client.py
+++ b/tests/unit/services/test_knowledge_graph_client.py
@@ -212,7 +212,7 @@ def test_query_passes_params_and_returns_results():
     with patch("prisma.services.knowledge_graph_client.requests.get",
                return_value=_mock_response([{"text": "some context"}])) as mock_get:
         result = client.query("neural networks", budget=500)
-    assert [r.model_dump() for r in result] == [{"text": "some context"}]
+    assert [r.model_dump() for r in result] == [{"text": "some context", "sources": []}]
     assert mock_get.call_args.kwargs["params"] == {"q": "neural networks", "budget": 500}
 
 

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -1105,3 +1105,36 @@ def test_query_returns_text_summary_of_matching_entities(kg, vault):
 
 def test_query_returns_empty_when_no_matches(kg):
     assert kg.query("nothing indexed matches this") == []
+
+
+def test_query_sources_are_slugs_not_raw_paths(kg, vault):
+    # ADR-017: `sources` must be vault slugs (what a Footnote's `sources`
+    # list expects), not the raw source_file path `text` embeds.
+    f = vault.root / "notes" / "test.md"
+    f.write_text("---\ntype: note\n---\nContent about quantum computing.", encoding="utf-8")
+    result = _extraction(nodes=[{"id": "quantum_computing", "label": "Quantum Computing"}])
+
+    with _patch_create(kg, return_value=result), \
+         patch("prisma.services.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")):
+        kg._extract_file(f, "note")
+
+    results = kg.query("quantum")
+
+    assert results[0].sources == ["test"]
+
+
+def test_query_sources_dedup_multiple_entities_from_same_file(kg, vault):
+    f = vault.root / "notes" / "test.md"
+    f.write_text("---\ntype: note\n---\nQuantum computing and quantum entanglement.", encoding="utf-8")
+    result = _extraction(nodes=[
+        {"id": "quantum_computing", "label": "Quantum Computing"},
+        {"id": "quantum_entanglement", "label": "Quantum Entanglement"},
+    ])
+
+    with _patch_create(kg, return_value=result), \
+         patch("prisma.services.resource_lock.acquire", return_value=(True, "local-ollama", "req-1")):
+        kg._extract_file(f, "note")
+
+    results = kg.query("quantum")
+
+    assert results[0].sources == ["test"]

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -79,11 +79,25 @@
     args: Record<string, unknown>;
   }
 
+  // ADR-017: per-claim attribution. `sources` are vault slugs; empty only
+  // when relation is "ai-inference". Rendered as an inline [^N] marker in
+  // the turn's content plus a list at the end of the turn — see
+  // renderFootnoteSegments() below.
+  type FootnoteRelation = "citation" | "attribution" | "relational" | "ai-inference";
+
+  interface FootnoteOut {
+    index: number;
+    relation: FootnoteRelation;
+    sources: string[];
+    claim_text: string | null;
+    faithfulness_checked: boolean | null;
+  }
+
   interface ChatTurn {
     role: "user" | "assistant";
     content: string;
     timestamp: string;
-    sources_cited: string[];
+    footnotes: FootnoteOut[];
     tool_calls: ToolCallOut[];
   }
 
@@ -173,6 +187,36 @@
     if (n >= 1000) return (n / 1000).toFixed(n % 1000 === 0 ? 0 : 1) + "k";
     return String(n);
   }
+
+  // ADR-017: split a turn's raw content (containing literal "[^1]", "[^2]"
+  // markers ChatAgent left in place) into plain-text and marker segments,
+  // for the template to render as text / <sup> respectively. Deliberately
+  // NOT using {@html} on model-generated text — this codebase treats tool
+  // results as untrusted (services/injection_defense.py); the model's own
+  // final reply gets the same caution, so segments stay plain strings
+  // Svelte auto-escapes rather than becoming raw HTML.
+  type ContentSegment = { text: string } | { footnoteIndex: number };
+
+  const FOOTNOTE_MARKER_RE = /\[\^(\d+)\]/g;
+
+  function renderContentSegments(content: string): ContentSegment[] {
+    const segments: ContentSegment[] = [];
+    let lastEnd = 0;
+    for (const m of content.matchAll(FOOTNOTE_MARKER_RE)) {
+      if (m.index! > lastEnd) segments.push({ text: content.slice(lastEnd, m.index) });
+      segments.push({ footnoteIndex: Number(m[1]) });
+      lastEnd = m.index! + m[0].length;
+    }
+    if (lastEnd < content.length) segments.push({ text: content.slice(lastEnd) });
+    return segments;
+  }
+
+  const FOOTNOTE_RELATION_LABEL: Record<FootnoteRelation, string> = {
+    citation: "citation",
+    attribution: "attribution",
+    relational: "relational",
+    "ai-inference": "AI inference",
+  };
 
   function _defaultApiBase(): string {
     if (typeof window === "undefined") return DEFAULT_API;
@@ -603,7 +647,7 @@
     chatSending = true;
     activeChat.messages = [
       ...activeChat.messages,
-      { role: "user", content: text, timestamp: new Date().toISOString(), sources_cited: [], tool_calls: [] },
+      { role: "user", content: text, timestamp: new Date().toISOString(), footnotes: [], tool_calls: [] },
     ];
     try {
       const r = await apiFetch(`${apiBase}/chat`, {
@@ -614,7 +658,7 @@
         const data = await r.json();
         activeChat.messages = [
           ...activeChat.messages,
-          { role: "assistant", content: data.reply, timestamp: new Date().toISOString(), sources_cited: [], tool_calls: data.tool_calls ?? [] },
+          { role: "assistant", content: data.reply, timestamp: new Date().toISOString(), footnotes: data.footnotes ?? [], tool_calls: data.tool_calls ?? [] },
         ];
       }
     } finally {
@@ -1797,7 +1841,23 @@
                       {/each}
                     </div>
                   {/if}
-                  <div class="chat-turn-content text-body">{msg.content}</div>
+                  <div class="chat-turn-content text-body">
+                    {#each renderContentSegments(msg.content) as seg}
+                      {#if "text" in seg}{seg.text}{:else}<sup class="footnote-ref">{seg.footnoteIndex}</sup>{/if}
+                    {/each}
+                  </div>
+                  {#if msg.footnotes?.length}
+                    <ol class="chat-footnotes">
+                      {#each msg.footnotes as fn}
+                        <li id="chat-turn-{i}-footnote-{fn.index}">
+                          <span class="footnote-relation footnote-relation-{fn.relation}">{FOOTNOTE_RELATION_LABEL[fn.relation]}</span>
+                          {#if fn.sources.length}
+                            {#each fn.sources as slug, si}{#if si > 0}, {/if}<button class="footnote-source-link" onclick={() => openNode(slug)}>{slug}</button>{/each}
+                          {/if}
+                        </li>
+                      {/each}
+                    </ol>
+                  {/if}
                 </div>
               {/each}
               {#if chatSending}
@@ -3662,6 +3722,57 @@
     line-height: 1.6;
     white-space: pre-wrap;
     overflow-wrap: anywhere;
+  }
+  .footnote-ref {
+    color: #7fd4c8;
+    font-weight: 600;
+    margin-left: 1px;
+  }
+  .chat-footnotes {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 11px;
+    color: #8ba3c0;
+  }
+  .footnote-relation {
+    display: inline-block;
+    margin-right: 6px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+  .footnote-relation-citation {
+    background: rgba(127, 212, 200, 0.15);
+    color: #7fd4c8;
+  }
+  .footnote-relation-attribution {
+    background: rgba(96, 165, 250, 0.15);
+    color: #60a5fa;
+  }
+  .footnote-relation-relational {
+    background: rgba(192, 132, 252, 0.15);
+    color: #c084fc;
+  }
+  .footnote-relation-ai-inference {
+    background: rgba(148, 163, 184, 0.15);
+    color: #94a3b8;
+  }
+  .footnote-source-link {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #8ba3c0;
+    text-decoration: underline dotted;
+    cursor: pointer;
+    font-size: 11px;
+  }
+  .footnote-source-link:hover {
+    color: #c8ddf0;
   }
   .chat-input-row {
     display: flex;


### PR DESCRIPTION
## Summary

Implements the three real remaining pieces of ADR-017's checklist ("Chat claim attribution / footnotes"): `ChatAgent` self-segmentation/self-report, wiring `relational` footnotes to `ChatToolbox._graph_context`, and UI rendering. Point 4 (`faithfulness_checked`) stays deferred — that's the ADR's own explicit stance (a separate, harder problem), not something skipped here.

- **`ChatAgent` prompting** (`services/chat_tools.py::system_prompt_footnote_section`, `agents/chat_agent.py::_extract_footnotes`): reuses ADR-014's existing tool-marker convention instead of inventing something new — the model writes `[^N]` inline at each claim, then a trailing `FOOTNOTES_JSON: [{"index":1,"relation":"citation","sources":["slug"]}]` line. Parsing is defensive throughout: malformed JSON, an unknown `relation`, or a missing line all degrade to "no footnotes," never break the turn — a self-report is inherently less reliable than a tool-call marker.
- **`relation=relational` wiring**: `GraphQueryResult` gained a `sources: list[str]` field. The per-document `source_file`s already existed inside `KnowledgeGraphService.query()`, they were just being flattened into prose text and discarded before reaching the caller. `_graph_context`'s tool-result text now prepends an explicit `Sources: slug-a, slug-b` line.
- **UI rendering** (`ui/src/routes/+page.svelte`): `renderContentSegments()` splits a turn's content on `[^N]` into text/marker segments, rendered as plain text / `<sup>` — deliberately not `{@html}` on model-generated text, consistent with this codebase already treating tool results as untrusted (`services/injection_defense.py`). A footnote list renders below the turn with a colored relation badge and clickable source slugs (reusing the existing `openNode()`).

## Found and fixed along the way

`docs/ontologia.md` claimed Chat API routes weren't implemented yet — false, `/chat` has been live for days. Worse: the frontend already had a working chat UI using the *old* `ChatMessage.sources_cited` field name that ADR-017 renamed to `footnotes`, so ADR-017's "no live caller to migrate" assumption was wrong by the time this was actually built. Migrated `ChatTurn.sources_cited` → `ChatTurn.footnotes` in the frontend as part of this same pass. Docs (`ontologia.md`, `docs/concepts/footnote.md`, ADR-017 itself, `TODO.md`) all updated to stop claiming this is unbuilt.

## Test plan

- [x] `pytest tests/unit -q` — 787 passed (was 773 before this branch; +14 new tests covering `_extract_footnotes`, the `_graph_context`/`_search_vault` slug changes, `KnowledgeGraphService.query()`'s new `sources` field, and a new `/chat` route test file — the route had zero prior coverage)
- [x] `npm run build` — clean
- [x] `npx svelte-check` — no new errors (1 pre-existing, unrelated `needs_reauth` error confirmed present on `main` too)
- [x] `bash docs/diagrams/gen.sh` — ran clean, no diagram changed (nothing touched references chat/footnote internals)
- [ ] **Not done**: live-LLM-in-browser verification. Nobody has actually watched a real model produce `[^N]` markers and FOOTNOTES_JSON through this UI yet — the prompting strategy is new and untested against real model behavior, only unit-tested against synthetic LLM responses.