### PR TITLE
docs: fix stale/inaccurate claims in README, architecture, roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 - **🔗 Zotero Bookmarking**: Saves discovered papers into your existing Zotero library via its Web API — Zotero stays the library, Prisma adds to it
 - **🌊 Research Streams**: Persistent topic monitoring — scheduled searches automatically discover, deduplicate, and file new papers into a dedicated Zotero collection per stream
 - **⭐ Quality-Rated Sources**: Each search source is rated 1-5 stars by API reliability/structure, prioritizing curated academic APIs over scraping-dependent ones
-- **🛡️ Academic Validation**: Filters out non-academic content (blogs, ads, spam) via keyword/structure heuristics plus LLM confidence scoring
+- **🛡️ Academic Validation**: Filters out non-academic content (blogs, ads, spam) via keyword/structure heuristics plus a weighted confidence score
 - **📖 Abstract-Level Relevance**: LLM assessment runs on title + abstract, not full PDF text — importing a paper into your vault separately converts its PDF to readable Markdown
 - **🤖 AI-Powered Curation**: Local or cloud-capable LLMs (Ollama, OpenRouter, llama.cpp) assess relevance, score confidence, and summarize what's found
 - **🏷️ Smart Tagging (Streams only)**: Papers saved via a Research Stream are auto-tagged with confidence score, source, topic, and stream ID
@@ -140,7 +140,7 @@ Changes to source files are immediately active — no reinstall needed.
 ## Technology Stack
 
 - **🐍 Python 3.12+** — pip/setuptools, no Poetry
-- **🤖 Ollama** for local LLM backend (analysis, chat, and knowledge-graph extraction)
+- **🤖 Ollama / llama.cpp** for local LLM backend (analysis, chat, knowledge-graph extraction, and ChromaDB embeddings) — interchangeable providers, configurable per-service; OpenRouter for cloud-capable chat
 - **🔗 Zotero** for reference management — the bookmark layer; the vault is the second brain
 - **⌨️ Click** for the command-line interface
 - **🗂️ Flat Markdown vault** — no database; notes, sources, chats, and streams are plain `.md`/`.yaml` files

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -221,19 +221,18 @@ see ADR-012. Clients differ only in how they wrap the page.
 | Platform | Client | How UI is delivered |
 |----------|--------|---------------------|
 | Linux | Tauri shell (`prisma-desktop`) | Native window → `http://127.0.0.1:8766/app` |
-| Windows / WSL2 | Tauri shell (`prisma-desktop`) | Native window → `http://127.0.0.1:8766/app` |
 | macOS / iOS / Android | Browser PWA | `http://<host>:8766/app` → install via browser |
 
-> **Follow-up needed:** `prisma-desktop`'s window URL is currently configured
-> against the old single-port assumption (`:8765/app`). It needs updating to
-> point at the Web process's port (`8766`) now that UI serving and the API
-> are separate processes. Out of scope for this (Python-side) change —
-> tracked as a `prisma-desktop` repo follow-up.
+> WSL2 support existed in `prisma-desktop` as a stopgap before native Linux
+> hardware was available, and was dropped 2026-07-30 — Linux-only for now.
+> Native Windows/macOS Tauri builds are planned once I've got hardware to test on,
+> but aren't a port of the old WSL2-aware code (see `prisma-desktop`'s own
+> `.claude/CLAUDE.md` and its CI workflow comments for the current state).
 
 **Tauri shell** (`prisma-desktop/src-tauri/`) is thin — Rust handles only:
 - Window lifecycle (create, resize, minimize, maximize, close, drag)
 - Settings persistence (`~/.config/prisma-desktop/settings.json`) — server URL, zoom scale, window state
-- WSL2-aware URL opener (`open_url` command)
+- URL opener (`open_url` command) — `xdg-open`, Linux-only for now
 
 The SvelteKit app detects its runtime via `"__TAURI_INTERNALS__" in window`:
 - **Tauri**: uses `@tauri-apps/api` for window commands and settings; `apiBase` from `localStorage` (defaults to the API port, `8765`)

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -8,16 +8,15 @@ active feature work, not "is this usable yet." Core pipeline:
 | Feature | Status |
 |---------|--------|
 | arXiv, Semantic Scholar, OpenLibrary, Google Books search | ✅ Done |
+| PubMed, IEEE Xplore search | ✅ Done |
 | Academic validation + confidence scoring | ✅ Done |
 | LLM relevance assessment (Ollama) | ✅ Done |
 | Duplicate detection | ✅ Done |
 | Literature review report generation | ✅ Done |
 | Research Streams | ✅ Done |
-| Zotero hybrid client (read local / write web) | ✅ Done |
+| Zotero Web API client (Web API only, everywhere — no local Desktop API path) | ✅ Done |
 | Offline write queue | ✅ Done |
-| PubMed search | ❌ Not started |
-| Academia.edu search | ⚠️ Stub only |
-| ResearchGate search | ❌ Not started |
+| Academia.edu, ResearchGate, JSTOR/Web of Science, grey literature | 🚫 Not planned — no reliable API for any of them, see Phase 3 |
 
 ---
 
@@ -126,11 +125,18 @@ Platform matrix:
 | Target | Client |
 |--------|--------|
 | Linux | Tauri desktop (primary) |
-| Windows (WSL2) | Tauri desktop — server runs in WSL2, UI is native Windows |
-| macOS / iOS / iPadOS / Android | Web client — browser points at a Linux/WSL2 host |
+| Windows / macOS | Planned, native Tauri builds once I've got hardware to test on — not started |
+| iOS / iPadOS / Android | Web client — browser points at a Linux host |
 
-- **Server** (`prisma serve`) — Linux only, including WSL2. No macOS or Windows native server planned.
-- **Tauri desktop** — Linux and Windows only. No native Mac/iOS build planned.
+`prisma-desktop` briefly supported WSL2 as a stopgap before native Linux hardware was
+available, then dropped it (2026-07-30) once that stopgap was no longer needed — Linux-only
+for now. That was never a real multi-platform story (WSL2 just runs the same Linux binary
+under Windows), so it isn't a step toward this Phase; genuine native Windows/macOS builds
+are separate, not-yet-started work.
+
+- **Server** (`prisma serve`) — Linux only. No macOS or Windows native server planned.
+- **Tauri desktop** — Linux only today. Native Windows/macOS builds planned once hardware
+  exists to build/test them on — not a port of the old WSL2-aware code.
 - **Web client (PWA)** — ✅ Done. SvelteKit static build with `@vite-pwa/sveltekit` (manifest + Workbox service worker), served alongside `prisma serve` at `/app`. On Android, iOS, and macOS, users install it from the browser ("Add to home screen") and it runs as a standalone app — own icon, no browser chrome, appears in the app launcher. No store, no fee, no review. Remote access (outside the home LAN) is covered by the zone-based deployment model — see [deployment-models.md](deployment-models.md) and ADR-011 — rather than Tailscale specifically.
 - Shared research projects and multi-user Zotero group support
 - Distributed processing for large-scale reviews


### PR DESCRIPTION
## Summary

Broad accuracy pass across `README.md`, `docs/wiki/architecture.md`, and `docs/wiki/roadmap.md` — every claim below was verified against actual code, not assumed.

**`README.md`**
- Technology Stack only listed Ollama; llama.cpp is an equally first-class provider (validated in `LLMConfig`/`ChatConfig`/ChromaDB's embedding config, actually used across analysis/chat/kg/embeddings) but was missing from this section, even though Features already mentioned it.
- "Academic Validation... plus **LLM** confidence scoring" was wrong — `get_academic_confidence_score()` is pure weighted-heuristic arithmetic (source-quality baseline + field-presence checks + keyword matching), no LLM call anywhere in it. Real LLM-based confidence scoring exists elsewhere (`AnalysisAgent`'s relevance/identity checks) but isn't part of this specific feature.

**`docs/wiki/architecture.md`**
- Client Architecture table had a redundant "Windows / WSL2" row identical to Linux's — WSL2 support was dropped in `prisma-desktop` (2026-07-30).
- "WSL2-aware URL opener" → simplified to plain `xdg-open`, same drop.
- The "Follow-up needed" callout about `prisma-desktop`'s window URL being misconfigured against `:8765` was itself stale — verified `tauri.conf.json` already points at `:8766` correctly.

**`docs/wiki/roadmap.md`**
- The top status table **contradicted the document's own body text**: PubMed/IEEE Xplore listed "Not started" while Phase 3's text says "Done as of 2026-07-29"; Academia.edu listed "Stub only" when Phase 3 says the stub was removed the same day; ResearchGate listed "Not started" when Phase 3 says it was evaluated and deliberately dropped.
- "Zotero hybrid client (read local / write web)" describes the ADR-008 architecture removed 2026-07-27 (Web API only, everywhere — confirmed no `hybrid_client` references remain anywhere in the codebase).
- Phase 6's platform matrix described the old WSL2 architecture (server running in WSL2, UI native Windows) — rewritten to match `prisma-desktop`'s actual current state.

## Found, not fixed here — flagged for a separate decision

`ChatConfig.provider`'s validator accepts `"anthropic"` as a valid config value, but `chat_llm.py::_resolve_base_url()` has no case for it — falls through to a `ValueError` unless you manually set `chat.base_url`, and even then the client is OpenAI-compatible, not Anthropic's real protocol. It's a validated-but-unimplemented provider, not a real fourth backend. Almost got propagated into this same README edit before catching it — worth either implementing it for real or removing it from the validator, your call.

## Test plan

- [x] `pytest tests/unit -q` — 787 passed (doc-only change, no test impact)
- [x] `bash docs/diagrams/gen.sh` — ran clean, nothing changed