### PR TITLE
feat: implement author analysis / research directory (roadmap Phase 5)

### DIFF
--- a/docs/wiki/features.md
+++ b/docs/wiki/features.md
@@ -73,7 +73,7 @@ The Report Agent synthesizes all summaries into a Markdown report with:
 - Individual paper summaries
 - Thematic analysis: trends, conflicts, research gaps
 - Research recommendations
-- Optional author analysis (key researchers, affiliation)
+- Optional author analysis (research directory: paper count, specialization keywords, key publications per author — no institutional affiliation, no search source captures it)
 - Pipeline metadata (timing, source breakdown, paper counts)
 
 Reports are saved to the configured output directory.

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -97,19 +97,19 @@ integration path exists.
 
 ## Phase 5 — Analytics & Visualization
 
-- **⚠️ Author Analysis / Research Directory — advertised, not implemented.** The
-  README lists this under Key Features ("Identifies key researchers and
-  creates academic contact directory"), but `ReportAgent.analyze_authors()`,
-  `.create_research_directory()`, and `.map_collaboration_networks()` in
-  `prisma/agents/report_agent.py` are all literal `pass` stubs — nothing has
-  ever been implemented. This has been silently dropped across multiple past
-  sessions; calling it out explicitly here so it isn't missed again. Scope:
-  extract unique authors from a corpus of paper summaries, build per-author
-  profiles (institutional affiliation, specializations, key publications),
-  and render a Markdown "research directory" — the co-authorship/network
-  and trajectory analysis below can come later as a separate increment. Not
-  meant to be a standalone report — it's an enrichment step feeding the
-  stream newsletter in Phase 4.
+- **✅ Author Analysis / Research Directory — done 2026-08-02.**
+  `ReportAgent.analyze_authors()`/`.create_research_directory()` build a
+  per-author profile (paper count, specialization keywords from titles/key
+  findings, key publications ranked by `analysis_confidence`) and render it
+  as a Markdown section, opt-in via `POST /review`'s `include_authors`
+  flag. Scope cut deliberately from the original sketch: **no institutional
+  affiliation** — no search source Prisma indexes captures it anywhere in
+  the pipeline (`PaperMetadata`/`PaperSummary` both lack it), and guessing
+  it from an LLM reading the abstract risked fabricating exactly the kind
+  of detail an academic tool shouldn't invent. `map_collaboration_networks`
+  (co-authorship/network analysis) stays unbuilt, a separate increment —
+  see below. Not meant to be a standalone report — it's an enrichment step
+  that could feed the stream newsletter in Phase 4, once that exists.
 - **ConnectedPapers integration** — auto-generate links using DOI/arXiv ID/Semantic Scholar URL for citation network visualization. ConnectedPapers has no public API, but direct URL construction works
 - Citation network analysis
 - Author intelligence (extended): collaboration networks, research trajectories, institution mapping — builds on the author-analysis MVP above

--- a/prisma/agents/report_agent.py
+++ b/prisma/agents/report_agent.py
@@ -2,10 +2,41 @@
 Report Agent - Generates final literature review reports.
 """
 
+from collections import Counter
 from typing import List, Optional
 from datetime import datetime
 
-from ..storage.models.agent_models import LiteratureReviewReport, ReportMetadata, AnalysisResult
+from ..storage.models.agent_models import (
+    LiteratureReviewReport, ReportMetadata, AnalysisResult,
+    AuthorAnalysis, AuthorProfile, AuthorPublication, PaperSummary,
+)
+
+_MAX_KEY_PUBLICATIONS_PER_AUTHOR = 5
+_MAX_SPECIALIZATIONS_PER_AUTHOR = 5
+
+
+def _keywords(text: str, limit: int) -> list[str]:
+    """Most frequent content words in `text`, original (non-stemmed) form,
+    most common first. Same NLTK stopword/tokenize approach as
+    `utils.text.significant_words`, but keeping the real word instead of a
+    Porter stem -- these are shown directly to a human in the research
+    directory, and a stem like "quantiz" reads worse than "quantization"."""
+    try:
+        from nltk.tokenize import word_tokenize
+        from nltk.corpus import stopwords as _sw
+        tokens = word_tokenize(text.lower())
+        stop = set(_sw.words("english"))
+    except LookupError:
+        import nltk as _nltk
+        _nltk.download("punkt_tab", quiet=True)
+        _nltk.download("stopwords", quiet=True)
+        from nltk.tokenize import word_tokenize
+        from nltk.corpus import stopwords as _sw
+        tokens = word_tokenize(text.lower())
+        stop = set(_sw.words("english"))
+
+    words = [t for t in tokens if t.isalpha() and t not in stop and len(t) > 2]
+    return [word for word, _count in Counter(words).most_common(limit)]
 
 
 class ReportAgent:
@@ -38,7 +69,14 @@ class ReportAgent:
         
         # Generate main content
         content = self._generate_content(analysis_result, config)
-        
+
+        # Optional author analysis / research directory (docs/wiki/features.md's
+        # "Optional author analysis" report section) -- off by default, since
+        # not every review wants a per-author breakdown appended.
+        if config.get('include_authors'):
+            author_analysis = self.analyze_authors(analysis_result.summaries)
+            content += "\n" + self.create_research_directory(author_analysis)
+
         # Generate bibliography
         bibliography = self._generate_bibliography(analysis_result.summaries)
         
@@ -140,42 +178,67 @@ This review analyzed **{analysis_result.total_papers} papers** on the topic of "
         # TODO: Future: Include ConnectedPapers integration links
         pass
     
-    def analyze_authors(self, summaries: list) -> dict:
-        """
-        Analyze authors across the literature corpus for research directory.
-        
-        Args:
-            summaries: List of paper summaries with author information
-            
-        Returns:
-            Author analysis including profiles, trajectories, and networks
-        """
-        # TODO: Extract unique authors from all papers
-        # TODO: Build comprehensive author profiles
-        # TODO: Track research evolution over time
-        # TODO: Identify collaboration patterns
-        # TODO: Map institutional affiliations
-        # TODO: Classify expertise areas
-        pass
-    
-    def create_research_directory(self, author_analysis: dict) -> str:
-        """
-        Create academic 'telephone guide' of researchers in the field.
-        
-        Args:
-            author_analysis: Results from analyze_authors()
-            
-        Returns:
-            Formatted markdown directory of researchers
-        """
-        # TODO: Generate researcher profiles with:
-        # - Contact information (institutional emails)
-        # - Research specializations and keywords
-        # - Key publications and contributions
-        # - Current institutional affiliation
-        # - Research trajectory and evolution
-        # - Collaboration patterns
-        pass
+    def analyze_authors(self, summaries: List[PaperSummary]) -> AuthorAnalysis:
+        """Build a per-author profile for every author appearing in this
+        corpus of paper summaries: paper count, specialization keywords
+        (frequent words across their titles/key findings), and key
+        publications (highest analysis_confidence first, capped).
+
+        No institutional affiliation, research trajectory, or collaboration
+        mapping -- see AuthorProfile's docstring for why affiliation is
+        left out; trajectory/collaboration are map_collaboration_networks's
+        job (unbuilt, a separate increment per docs/wiki/roadmap.md)."""
+        by_author: dict[str, list[PaperSummary]] = {}
+        for paper in summaries:
+            for author in paper.authors:
+                by_author.setdefault(author, []).append(paper)
+
+        profiles = []
+        for name, papers in by_author.items():
+            corpus_text = " ".join(
+                p.title + " " + " ".join(p.key_findings) for p in papers
+            )
+            ranked_papers = sorted(
+                papers, key=lambda p: p.analysis_confidence or 0.0, reverse=True,
+            )
+            profiles.append(AuthorProfile(
+                name=name,
+                paper_count=len(papers),
+                specializations=_keywords(corpus_text, _MAX_SPECIALIZATIONS_PER_AUTHOR),
+                key_publications=[
+                    AuthorPublication(title=p.title, url=p.url)
+                    for p in ranked_papers[:_MAX_KEY_PUBLICATIONS_PER_AUTHOR]
+                ],
+            ))
+        profiles.sort(key=lambda p: p.paper_count, reverse=True)
+        return AuthorAnalysis(authors=profiles, total_unique_authors=len(profiles))
+
+    def create_research_directory(self, author_analysis: AuthorAnalysis) -> str:
+        """Render `analyze_authors()`'s result as a Markdown directory --
+        one section per author, most prolific (in this corpus) first."""
+        lines = [
+            "## Research Directory",
+            "",
+            f"{author_analysis.total_unique_authors} unique author"
+            f"{'s' if author_analysis.total_unique_authors != 1 else ''} "
+            "in this corpus.",
+            "",
+            "*Institutional affiliation isn't shown -- no search source Prisma "
+            "indexes captures it, and guessing from an abstract risks "
+            "fabricating a detail that matters for an academic tool.*",
+            "",
+        ]
+        for profile in author_analysis.authors:
+            lines.append(f"### {profile.name}")
+            lines.append(f"**Papers in this corpus:** {profile.paper_count}")
+            if profile.specializations:
+                lines.append(f"**Specializations:** {', '.join(profile.specializations)}")
+            if profile.key_publications:
+                lines.append("**Key publications:**")
+                for pub in profile.key_publications:
+                    lines.append(f"- [{pub.title}]({pub.url})")
+            lines.append("")
+        return "\n".join(lines)
     
     def map_collaboration_networks(self, summaries: list) -> dict:
         """

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -511,6 +511,7 @@ class ReviewRequest(BaseModel):
     sources: Optional[list[str]] = None
     limit: Optional[int] = None
     zotero_only: bool = False
+    include_authors: bool = False  # appends a per-author research-directory section
 
 
 class RenderRequest(BaseModel):
@@ -568,7 +569,7 @@ def _run_review(job_id: str, req: ReviewRequest) -> None:
             "limit": req.limit or search_cfg.default_limit,
             "output_file": f"{output_cfg.directory}/literature_review_{topic_safe}.md",
             "stream_name": None,
-            "include_authors": False,
+            "include_authors": req.include_authors,
             "zotero_collections": None,
             "zotero_recent_years": None,
         }

--- a/prisma/storage/models/agent_models.py
+++ b/prisma/storage/models/agent_models.py
@@ -169,6 +169,39 @@ class AnalysisResult(BaseModel):
         return v
 
 
+class AuthorPublication(BaseModel):
+    """One paper by an author, as shown in their research-directory entry."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    title: str
+    url: str
+
+
+class AuthorProfile(BaseModel):
+    """Per-author profile built from a corpus's PaperSummary list.
+
+    Deliberately has no institutional-affiliation field -- no search source
+    Prisma indexes captures author affiliation anywhere in the pipeline
+    (PaperMetadata/PaperSummary don't have it either), and guessing it from
+    an LLM reading the abstract would risk fabricating exactly the kind of
+    detail an academic tool shouldn't invent. Left out rather than faked."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str
+    paper_count: int = Field(..., ge=0)
+    specializations: List[str] = Field(default_factory=list, description="Frequent keywords across this author's titles/key findings in the corpus, most common first")
+    key_publications: List[AuthorPublication] = Field(default_factory=list, description="This author's papers in the corpus, highest analysis_confidence first, capped")
+
+
+class AuthorAnalysis(BaseModel):
+    """Corpus-wide author analysis -- ReportAgent.analyze_authors()'s result,
+    consumed by create_research_directory()."""
+    model_config = ConfigDict(populate_by_name=True)
+
+    authors: List[AuthorProfile] = Field(default_factory=list, description="Sorted by paper_count descending")
+    total_unique_authors: int = Field(..., ge=0)
+
+
 class ReportMetadata(BaseModel):
     """Report generation metadata"""
     model_config = ConfigDict(populate_by_name=True)

--- a/tests/unit/agents/test_report_agent.py
+++ b/tests/unit/agents/test_report_agent.py
@@ -1,0 +1,113 @@
+"""Unit tests for ReportAgent's author analysis / research directory
+(docs/wiki/roadmap.md's Phase 5 MVP: analyze_authors + create_research_directory,
+map_collaboration_networks stays a separate, unbuilt increment)."""
+from prisma.agents.report_agent import ReportAgent
+from prisma.storage.models.agent_models import AnalysisResult, PaperSummary
+
+
+def _summary(title: str, authors: list[str], key_findings: list[str] | None = None,
+             confidence: float | None = None, url: str | None = None) -> PaperSummary:
+    return PaperSummary(
+        title=title, authors=authors, abstract="an abstract", summary="a summary",
+        key_findings=key_findings or [], url=url or f"https://example.com/{title}",
+        analysis_confidence=confidence,
+    )
+
+
+def test_analyze_authors_groups_papers_by_author():
+    summaries = [
+        _summary("Attention Is All You Need", ["Vaswani", "Shazeer"]),
+        _summary("Scaling Transformers", ["Vaswani"]),
+    ]
+    analysis = ReportAgent().analyze_authors(summaries)
+
+    by_name = {p.name: p for p in analysis.authors}
+    assert analysis.total_unique_authors == 2
+    assert by_name["Vaswani"].paper_count == 2
+    assert by_name["Shazeer"].paper_count == 1
+
+
+def test_analyze_authors_sorts_by_paper_count_descending():
+    summaries = [
+        _summary("Paper A", ["Prolific"]),
+        _summary("Paper B", ["Prolific"]),
+        _summary("Paper C", ["Prolific", "OneOff"]),
+    ]
+    analysis = ReportAgent().analyze_authors(summaries)
+
+    assert [a.name for a in analysis.authors] == ["Prolific", "OneOff"]
+
+
+def test_analyze_authors_key_publications_ranked_by_confidence_and_capped():
+    summaries = [_summary(f"Paper {i}", ["Author"], confidence=i / 10) for i in range(10)]
+    analysis = ReportAgent().analyze_authors(summaries)
+
+    profile = analysis.authors[0]
+    assert profile.paper_count == 10
+    assert len(profile.key_publications) == 5  # capped, not all 10
+    assert profile.key_publications[0].title == "Paper 9"  # highest confidence first
+    assert profile.key_publications[-1].title == "Paper 5"
+
+
+def test_analyze_authors_specializations_reflect_frequent_title_words():
+    summaries = [
+        _summary("Quantization for Neural Networks", ["Author"], key_findings=["Quantization reduces memory"]),
+        _summary("Advances in Quantization", ["Author"], key_findings=["Quantization improves speed"]),
+    ]
+    analysis = ReportAgent().analyze_authors(summaries)
+
+    assert "quantization" in analysis.authors[0].specializations
+
+
+def test_analyze_authors_no_institutional_affiliation_field():
+    # Regression guard for the deliberate MVP scope cut -- AuthorProfile
+    # must not grow an affiliation field until real data backs it (see its
+    # docstring). Catches an accidental re-introduction.
+    analysis = ReportAgent().analyze_authors([_summary("P", ["A"])])
+    assert not hasattr(analysis.authors[0], "affiliation")
+    assert not hasattr(analysis.authors[0], "institution")
+
+
+def test_analyze_authors_empty_corpus_returns_empty_analysis():
+    analysis = ReportAgent().analyze_authors([])
+    assert analysis.authors == []
+    assert analysis.total_unique_authors == 0
+
+
+def test_create_research_directory_lists_each_author_with_publications():
+    summaries = [_summary("Attention Is All You Need", ["Vaswani"], confidence=0.9)]
+    analysis = ReportAgent().analyze_authors(summaries)
+
+    directory = ReportAgent().create_research_directory(analysis)
+
+    assert "## Research Directory" in directory
+    assert "### Vaswani" in directory
+    assert "[Attention Is All You Need](https://example.com/Attention Is All You Need)" in directory
+
+
+def test_create_research_directory_does_not_mention_affiliation_as_available():
+    directory = ReportAgent().create_research_directory(
+        ReportAgent().analyze_authors([_summary("P", ["A"])])
+    )
+    assert "affiliation isn't shown" in directory.lower()
+
+
+def test_generate_omits_author_directory_by_default():
+    result = AnalysisResult(
+        summaries=[_summary("Paper", ["Author"], confidence=0.9)], author_count=1, total_papers=1,
+        avg_processing_time=0.0,
+    )
+    report = ReportAgent().generate(result, {"topic": "test"})
+
+    assert "Research Directory" not in report.content
+
+
+def test_generate_includes_author_directory_when_requested():
+    result = AnalysisResult(
+        summaries=[_summary("Paper", ["Author"], confidence=0.9)], author_count=1, total_papers=1,
+        avg_processing_time=0.0,
+    )
+    report = ReportAgent().generate(result, {"topic": "test", "include_authors": True})
+
+    assert "## Research Directory" in report.content
+    assert "### Author" in report.content

--- a/tests/unit/server/test_review_route.py
+++ b/tests/unit/server/test_review_route.py
@@ -1,0 +1,65 @@
+"""Unit tests for app.py's POST /review route -- specifically that
+include_authors (ADR-less, roadmap Phase 5) actually reaches
+PrismaCoordinator.run_review()'s config dict. Previously this field
+existed on ReviewRequest's sibling `include_authors` review_config key but
+was hardcoded to False -- nothing threaded the request field through.
+"""
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from prisma.server.app import app
+from prisma.storage.models.agent_models import CoordinatorResult, PipelineMetadata
+
+client = TestClient(app, client=("127.0.0.1", 12345))
+
+
+def _coordinator_result() -> CoordinatorResult:
+    return CoordinatorResult(
+        success=True, papers_analyzed=0, authors_found=0, output_file="out.md",
+        total_duration=0.0, pipeline_metadata=PipelineMetadata(),
+    )
+
+
+def test_review_route_threads_include_authors_true_into_review_config(monkeypatch):
+    from prisma.server import app as app_module
+
+    coordinator = MagicMock()
+    coordinator.run_review.return_value = _coordinator_result()
+    monkeypatch.setattr(app_module, "PrismaCoordinator", lambda: coordinator)
+
+    r = client.post("/review", json={"topic": "quantum computing", "include_authors": True})
+    assert r.status_code == 202
+    job_id = r.json()["job_id"]
+
+    # /review runs the actual work in a background ThreadPoolExecutor --
+    # poll the job status until it's no longer pending rather than
+    # asserting on the mock immediately after the request returns.
+    import time
+    for _ in range(50):
+        status = client.get(f"/review/{job_id}").json()
+        if status["status"] != "pending":
+            break
+        time.sleep(0.05)
+
+    assert coordinator.run_review.call_args[0][0]["include_authors"] is True
+
+
+def test_review_route_include_authors_defaults_to_false(monkeypatch):
+    from prisma.server import app as app_module
+
+    coordinator = MagicMock()
+    coordinator.run_review.return_value = _coordinator_result()
+    monkeypatch.setattr(app_module, "PrismaCoordinator", lambda: coordinator)
+
+    r = client.post("/review", json={"topic": "quantum computing"})
+    job_id = r.json()["job_id"]
+
+    import time
+    for _ in range(50):
+        status = client.get(f"/review/{job_id}").json()
+        if status["status"] != "pending":
+            break
+        time.sleep(0.05)
+
+    assert coordinator.run_review.call_args[0][0]["include_authors"] is False


### PR DESCRIPTION
## Summary

`ReportAgent.analyze_authors()`/`.create_research_directory()`/`.map_collaboration_networks()` were literal `pass` stubs — silently dropped across multiple past sessions despite being advertised as a feature at one point. This implements the real MVP scope: per-author profile (paper count, specialization keywords from titles/key findings, key publications ranked by `analysis_confidence` and capped), rendered as a Markdown research-directory section.

**Deliberately scoped down**: no institutional affiliation. No search source Prisma indexes captures it anywhere in the pipeline — neither `PaperMetadata` nor `PaperSummary` has an affiliation field — and guessing it from an LLM reading the abstract risked fabricating exactly the kind of detail an academic tool shouldn't invent. Left out rather than faked, documented on `AuthorProfile` itself (and guarded by a regression test) so it isn't silently re-added later without real data behind it.

**Wired end-to-end**: `POST /review` gained an `include_authors` flag — threading into a `review_config` dict key (`"include_authors"`) that already existed, hardcoded to `False`, referenced nowhere downstream. Someone had already anticipated this wiring point and never finished it. Off by default, so existing reviews don't suddenly grow a new section.

`map_collaboration_networks` (co-authorship/network analysis) stays unbuilt — always scoped as a separate, later increment per the roadmap, not part of this MVP.

## Found and fixed along the way

Two stale doc claims in the same area: `docs/wiki/features.md`'s "Optional author analysis (key researchers, affiliation)" promised the affiliation field that got cut; `docs/wiki/roadmap.md`'s Phase 5 entry referenced a README claim ("Identifies key researchers and creates academic contact directory") that no longer exists in the current README.

## Test plan

- [x] `pytest tests/unit -q` — 799 passed (was 787; +12 new tests covering `analyze_authors`/`create_research_directory`/the `generate()` gating, plus the `/review` route's `include_authors` wiring — both `report_agent.py` and the `/review` route had zero prior coverage)
- [x] `bash docs/diagrams/gen.sh` — ran clean, nothing changed