### PR TITLE
feat: surface chat instructions file via Settings UI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -136,17 +136,33 @@ design, not just a prompt-phrasing caveat:
       vault file) *and*, once the graph store exists, any nodes/edges
       extracted from that chat.
 
-### Deferred: user-fact extraction from chat (not now — noted for later)
+### User preferences for chat (done 2026-08-03 — manual, CLAUDE.md-style)
 
-Gemini-style pattern: extract small, durable *user-stated facts* from chat
-(e.g. "lives in Aguascalientes," "interested in starting a carwash
-business") into their own curated memory, separate from the raw transcript.
-This is a different case from the self-citation risk above — safe
-specifically because the user is the authoritative source for facts about
-*themselves*, unlike citing the model's own past inference as if it were
-external fact. Likely its own trust tier (arguably higher than "chat" for
-self-facts specifically, since the user is ground truth here) — design when
-actually picked up, not now.
+- [x] A user-editable file the chat assistant always reads — standing
+      preferences and instructions ("always answer in Spanish," tone,
+      things to always/never do), not one-off requests. **Turned out to
+      already half-exist**: `chat_prompts.py`'s `~/.config/prisma/chat_system_prompt.md`
+      was already the ChatAgent's system prompt source, just undiscoverable
+      (no docs, no UI — editing meant knowing the dotfile existed and
+      curling `POST /reload/chat` by hand). Closed the gap: `GET`/`PUT
+      /chat/system-prompt` (`save_system_prompt()` + PUT triggers the
+      existing reload) and a "Chat instructions" panel in the Settings
+      page (`ui/src/routes/+page.svelte`) — a textarea, Save button,
+      applies immediately, no restart.
+- [x] Default prompt now says explicitly that retrieval covers past chat
+      transcripts too, not just notes/sources — true today (`search_vault`'s
+      ChromaDB query has no folder-type filter yet, see "Chat trust tiers"
+      below), so the model should know it, not just legal/architectural
+      docs.
+
+Deliberately **manual only** — the user picked this over a semi-automatic
+"propose then confirm" flow. A separate, still-unbuilt idea stays out of
+scope here: automatically extracting durable *user-stated facts* from the
+chat transcript itself (Gemini-style — "lives in Aguascalientes," "interested
+in starting a carwash business") into their own curated memory. That's a
+different mechanism (write path is the model, not the user typing into a
+box) and was intentionally not what got built today; pick up separately if
+ever wanted, under a name that doesn't read as chat surveillance.
 
 ## Storage
 

--- a/docs/wiki/features.md
+++ b/docs/wiki/features.md
@@ -108,6 +108,16 @@ All vault operations go through the REST API (`GET /notes`, `PUT /notes/{slug}`,
 
 ---
 
+## Chat
+
+The chat assistant (see `ADR-014-chat-llm-backend-interface.md`) has retrieval access to the whole vault — notes, sources, and **past chat transcripts**, not just the current conversation — via `search_vault` (ChromaDB semantic search) and `graph_context` (knowledge graph traversal), both called on demand as the model needs them. Claims it makes are self-reported with footnotes back to the source vault item (see `docs/concepts/footnote.md` / ADR-017).
+
+### Chat instructions
+
+Settings → **Chat instructions** is a standing, user-edited system prompt — CLAUDE.md-style: preferences and rules that apply to every chat, every turn ("always answer in Spanish," tone, things to always/never do), not one-off requests (those belong in the chat itself). Manual only — the assistant never writes to it. Backed by `GET`/`PUT /chat/system-prompt`, which persists to `~/.config/prisma/chat_system_prompt.md` and applies immediately (no restart).
+
+---
+
 ## Search
 
 ### Regular Search

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -91,7 +91,7 @@ _t("vault_models ok")
 _t("importing chat")
 from prisma.agents.chat_agent import ChatAgent
 from prisma.services.chat_llm import ChatLLM
-from prisma.services.chat_prompts import load_excerpt_summary_prompt, load_system_prompt
+from prisma.services.chat_prompts import load_excerpt_summary_prompt, load_system_prompt, save_system_prompt
 from prisma.services.chat_tools import ChatToolbox
 _t("chat ok")
 
@@ -688,6 +688,29 @@ def reload_chat():
     with no prior way to pick up a change short of a full process restart."""
     _reload_chat()
     return {"status": "reloaded"}
+
+
+class ChatSystemPromptResponse(BaseModel):
+    content: str
+
+
+class UpdateChatSystemPromptRequest(BaseModel):
+    content: str
+
+
+@app.get("/chat/system-prompt", response_model=ChatSystemPromptResponse)
+def get_chat_system_prompt():
+    """Settings page's "Chat instructions" panel — same file `chat_prompts.py`
+    materializes at ~/.config/prisma/chat_system_prompt.md and ChatAgent is
+    built from; this just makes it readable/editable without shelling in."""
+    return {"content": load_system_prompt()}
+
+
+@app.put("/chat/system-prompt", response_model=ChatSystemPromptResponse)
+def update_chat_system_prompt(req: UpdateChatSystemPromptRequest):
+    save_system_prompt(req.content)
+    _reload_chat()  # so the running ChatAgent picks up the edit immediately
+    return {"content": load_system_prompt()}
 
 
 @app.post("/supervisor/restart/{name}")

--- a/prisma/services/chat_prompts.py
+++ b/prisma/services/chat_prompts.py
@@ -12,10 +12,13 @@ from pathlib import Path
 DEFAULT_CHAT_SYSTEM_PROMPT = """\
 You are Prisma, a research assistant with access to the user's personal \
 knowledge vault: notes, saved papers, and a knowledge graph of concepts \
-extracted from them. Ground your answers in the user's own material when \
-it's relevant, and say so explicitly when you're answering from general \
-knowledge instead. When you use retrieved content, mention which source \
-file it came from.
+extracted from them, all searchable through a semantic index (ChromaDB) \
+and the knowledge graph. This includes past chat transcripts, not just \
+notes and sources -- you may pull in relevant information from earlier \
+conversations the same way you would from any other vault content. Ground \
+your answers in the user's own material when it's relevant, and say so \
+explicitly when you're answering from general knowledge instead. When you \
+use retrieved content, mention which source file it came from.
 """
 
 # Used by compressed-mode Excerpt regeneration (ADR-015): condenses the
@@ -59,6 +62,16 @@ def load_system_prompt() -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(DEFAULT_CHAT_SYSTEM_PROMPT, encoding="utf-8")
     return DEFAULT_CHAT_SYSTEM_PROMPT.strip()
+
+
+def save_system_prompt(content: str) -> None:
+    """User-facing edit path (Settings page's "Chat instructions" panel) --
+    caller is still responsible for calling POST /reload/chat afterwards so
+    the running ChatAgent picks it up, same as any manual edit of this file
+    always required."""
+    path = _prompt_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content.strip() + "\n", encoding="utf-8")
 
 
 def load_excerpt_summary_prompt() -> str:

--- a/tests/unit/server/test_chat_system_prompt_route.py
+++ b/tests/unit/server/test_chat_system_prompt_route.py
@@ -1,0 +1,38 @@
+"""Unit tests for GET/PUT /chat/system-prompt -- the Settings page's "Chat
+instructions" panel backing routes. Wraps chat_prompts.py's
+load_system_prompt/save_system_prompt; PUT also triggers _reload_chat so the
+running ChatAgent picks up the edit without a full restart.
+"""
+from fastapi.testclient import TestClient
+
+from prisma.server.app import app
+
+client = TestClient(app, client=("127.0.0.1", 12345))
+
+
+def test_get_chat_system_prompt_returns_current_content(monkeypatch):
+    from prisma.server import app as app_module
+
+    monkeypatch.setattr(app_module, "load_system_prompt", lambda: "You are Prisma.")
+
+    r = client.get("/chat/system-prompt")
+
+    assert r.status_code == 200
+    assert r.json() == {"content": "You are Prisma."}
+
+
+def test_put_chat_system_prompt_saves_and_reloads(monkeypatch):
+    from prisma.server import app as app_module
+
+    saved = {}
+    monkeypatch.setattr(app_module, "save_system_prompt", lambda content: saved.setdefault("content", content))
+    monkeypatch.setattr(app_module, "load_system_prompt", lambda: saved.get("content", ""))
+    reload_calls = []
+    monkeypatch.setattr(app_module, "_reload_chat", lambda *a, **kw: reload_calls.append(1))
+
+    r = client.put("/chat/system-prompt", json={"content": "Always answer in Spanish."})
+
+    assert r.status_code == 200
+    assert r.json() == {"content": "Always answer in Spanish."}
+    assert saved["content"] == "Always answer in Spanish."
+    assert reload_calls == [1]

--- a/tests/unit/services/test_chat_prompts.py
+++ b/tests/unit/services/test_chat_prompts.py
@@ -1,0 +1,32 @@
+"""Unit tests for chat_prompts.py's save_system_prompt() -- the write path
+behind the Settings page's "Chat instructions" panel (PUT /chat/system-prompt).
+load_system_prompt() already has implicit coverage via every test that builds
+a ChatAgent; this is the first test for writing the file."""
+from prisma.services import chat_prompts
+
+
+def test_save_system_prompt_writes_stripped_content(tmp_path, monkeypatch):
+    path = tmp_path / "chat_system_prompt.md"
+    monkeypatch.setattr(chat_prompts, "_prompt_path", lambda: path)
+
+    chat_prompts.save_system_prompt("  Always answer in Spanish.  \n\n")
+
+    assert path.read_text(encoding="utf-8") == "Always answer in Spanish.\n"
+
+
+def test_save_system_prompt_creates_parent_dir(tmp_path, monkeypatch):
+    path = tmp_path / "nested" / "chat_system_prompt.md"
+    monkeypatch.setattr(chat_prompts, "_prompt_path", lambda: path)
+
+    chat_prompts.save_system_prompt("hi")
+
+    assert path.exists()
+
+
+def test_save_then_load_round_trips(tmp_path, monkeypatch):
+    path = tmp_path / "chat_system_prompt.md"
+    monkeypatch.setattr(chat_prompts, "_prompt_path", lambda: path)
+
+    chat_prompts.save_system_prompt("Custom instructions.")
+
+    assert chat_prompts.load_system_prompt() == "Custom instructions."

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1056,6 +1056,36 @@
   let syncDiffInfo = $state<SyncDiffInfo | null>(null);
   let syncDiffLoading = $state(false);
 
+  let chatSystemPrompt = $state("");
+  let chatSystemPromptLoading = $state(false);
+  let chatSystemPromptSaving = $state(false);
+  let chatSystemPromptSaved = $state(false);
+
+  async function loadChatSystemPrompt() {
+    chatSystemPromptLoading = true;
+    try {
+      const r = await apiFetch(`${apiBase}/chat/system-prompt`);
+      chatSystemPrompt = (await r.json()).content;
+    } catch { /* leave the field blank rather than clobber a load-in-progress edit */ }
+    chatSystemPromptLoading = false;
+  }
+
+  async function saveChatSystemPrompt() {
+    chatSystemPromptSaving = true;
+    chatSystemPromptSaved = false;
+    try {
+      const r = await apiFetch(`${apiBase}/chat/system-prompt`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: chatSystemPrompt }),
+      });
+      chatSystemPrompt = (await r.json()).content;
+      chatSystemPromptSaved = true;
+      setTimeout(() => { chatSystemPromptSaved = false; }, 2000);
+    } catch { /* button label falls back to "Save" below; no toast system to report the failure through */ }
+    chatSystemPromptSaving = false;
+  }
+
   async function refreshSyncInfo() {
     syncStatus = await syncEngineStatus();
     syncDiffLoading = true;
@@ -1079,6 +1109,13 @@
   // polled, since this is a manual-refresh status view, not a live feed.
   $effect(() => {
     if (showSettings && isTauri) refreshSyncInfo();
+  });
+
+  // Unlike the sync status above, this applies to every server (Tauri
+  // desktop and plain web UI alike) — the file it reads/writes lives on
+  // whichever machine is running `prisma serve`, not the client.
+  $effect(() => {
+    if (showSettings) loadChatSystemPrompt();
   });
 
   async function loadSettings() {
@@ -2198,6 +2235,32 @@
                 <span class="scale-slider-value">{cfg.scale === DEFAULT_SCALE ? `${cfg.scale}× (default)` : `${cfg.scale}×`}</span>
               </div>
               <span class="setting-hint">Applied immediately — persisted across restarts.</span>
+            </div>
+
+            <div class="resource-card">
+              <div class="resource-card-header">
+                <span class="resource-pool-name">Chat instructions</span>
+              </div>
+              <textarea
+                class="chat-system-prompt-input"
+                rows="8"
+                bind:value={chatSystemPrompt}
+                disabled={chatSystemPromptLoading}
+                placeholder="Standing instructions and preferences for the chat assistant — tone, language, things to always/never do…"
+              ></textarea>
+              <span class="setting-hint">
+                Applies to every chat, every turn — this is the assistant's system prompt. It already has
+                access to your notes, sources, past chats, and the knowledge graph, so it can pull in
+                relevant material on its own; use this box for standing preferences (e.g. "always answer in
+                Spanish") rather than one-off requests, which belong in the chat itself.
+              </span>
+              <button
+                class="btn-primary"
+                onclick={saveChatSystemPrompt}
+                disabled={chatSystemPromptLoading || chatSystemPromptSaving}
+              >
+                {chatSystemPromptSaving ? "Saving…" : chatSystemPromptSaved ? "Saved" : "Save"}
+              </button>
             </div>
 
             {#if isTauri}
@@ -4146,10 +4209,31 @@
     flex-shrink: 0;
   }
 
+  .chat-system-prompt-input {
+    width: 100%;
+    padding: 10px 12px;
+    background: #0d1320;
+    border: 1px solid #1a2d4a;
+    border-radius: 5px;
+    color: #e8edf8;
+    font-size: 12px;
+    font-family: inherit;
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+    margin-bottom: 8px;
+  }
+  .chat-system-prompt-input:focus { border-color: #4a9eff; }
+  .chat-system-prompt-input:disabled { opacity: 0.6; }
+
   .setting-hint {
     font-size: 10px;
     color: #2a4060;
     line-height: 1.5;
+  }
+  .chat-system-prompt-input + .setting-hint {
+    display: block;
+    margin-bottom: 10px;
   }
   .setting-hint code {
     font-family: "JetBrains Mono", monospace;


### PR DESCRIPTION
## Summary
- The TODO survey's "user-fact extraction from chat" item was renamed/reframed per user request to a manual, CLAUDE.md-style preferences file (not automatic extraction, which reads as covert profiling).
- Turned out to already half-exist: `chat_prompts.py`'s `~/.config/prisma/chat_system_prompt.md` was already the `ChatAgent`'s system prompt source — just completely undocumented and unreachable without knowing the dotfile existed and manually curling `POST /reload/chat`.
- Closes that gap: `GET`/`PUT /chat/system-prompt` (new `save_system_prompt()`, PUT triggers the existing reload) + a "Chat instructions" panel in Settings (textarea, Save button, applies immediately — no restart).
- Deliberately **manual only** (user's explicit choice over a semi-automatic propose/confirm flow). True automatic fact-extraction from chat transcripts stays a separate, still-unbuilt idea, noted in `TODO.md` under a name that doesn't read as chat surveillance.
- Default chat system prompt now states explicitly that retrieval covers past chat transcripts too, not just notes/sources — true today (`search_vault`'s ChromaDB query has no folder-type filter yet), so the model should know it.
- Documented in `docs/wiki/features.md` under a new "Chat" section (previously had none, despite chat being a real shipped feature).

## Test plan
- [x] `pytest -q` — 818 passed, 37 skipped (5 new tests: `save_system_prompt()` round-trip + GET/PUT route tests)
- [x] `npx svelte-check` — 1 pre-existing, unrelated error (`SyncStatusInfo.needs_reauth`, confirmed present on clean `main` in a prior session), no new errors
- [x] `docs/diagrams/gen.sh` regenerated — no diagram changes (expected, no diagram-relevant surface touched)
- [ ] Live UI click-through (Settings → Chat instructions → edit → Save → verify next chat turn reflects it) not done this session