### PR TITLE
feat: build ADR-017's faithfulness_checked verification

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1389,7 +1389,7 @@ has tray/background OS-integration via Tauri, which this can build on.
   at-rest is still deferred to a future session (as of 2026-07-24), so a
   locked/encrypted vault's interaction with sync is still unresolved.
 
-## Chat claim attribution / footnotes (2026-07-26, see ADR-017) — 1-3 done 2026-07-31
+## Chat claim attribution / footnotes (2026-07-26, see ADR-017) — done (1-3: 2026-07-31, faithfulness_checked: 2026-08-03)
 
 Design settled: distinguishing which claims in an assistant turn are traceable to a specific
 vault document vs. the model's own inference — mirroring academic citation practice ("what is
@@ -1425,5 +1425,14 @@ since ADR-017 was written. Fixed alongside this.
   call the existing `openNode()`). No live-LLM-in-browser verification done — `npm run build`
   and `svelte-check` are clean, but nobody's actually watched a real model produce `[^N]`
   markers in this UI yet.
-- [ ] `faithfulness_checked` verification — still explicitly deferred as a separate, harder
-  problem (ADR-017's own stance, not scoped here). Not part of this pass.
+- [x] `faithfulness_checked` verification (done 2026-08-03) — automatic every turn (user's
+  choice over an on-demand "Verify" button, accepting the extra LLM call per sourced footnote on
+  the shared compute pool). `claim_text` extracted deterministically from the rendered reply
+  (`ChatAgent._extract_claim_texts`, not model self-reported), then checked against its cited
+  source(s) via a one-shot LLM-judge call (`ChatAgent._verify_footnote`/`complete_once`, the
+  latter renamed from `summarize` now that it serves two callers). New
+  `ChatToolbox.get_node_text(slug)` resolves a source slug to text (Note/Source body, or a
+  Chat's joined transcript). `None` (not `False`) whenever there's nothing to check —
+  `ai-inference`, missing `claim_text`, unresolvable slug, or verifier-unreachable all count as
+  "not checked." UI: a ✓ verified / ⚠ unsupported badge next to each footnote's relation badge,
+  shown only when a check actually ran. See ADR-017's implementation notes for the full design.

--- a/docs/concepts/footnote.md
+++ b/docs/concepts/footnote.md
@@ -26,8 +26,8 @@ linked [Note](note.md)/[Source](source.md)(s).
 | `index` | int | Sequential per message, 1-based — the superscript number shown inline |
 | `relation` | `FootnoteRelation` | What kind of sourcing this claim has — see below |
 | `sources` | list[str] | Vault node slugs (`Note`/`Source`) this claim ties to. Empty only when `relation == ai-inference` |
-| `claim_text` | str \| None | The specific span of `content` this footnote covers (anchor for tooling; not necessarily rendered) |
-| `faithfulness_checked` | bool \| None | Whether an automated/manual check confirmed the claim accurately represents the cited source(s). Only meaningful when `sources` is non-empty — orthogonal to `relation`, not a relation type itself |
+| `claim_text` | str \| None | The specific span of `content` this footnote covers — extracted deterministically (the sentence preceding the `[^N]` marker), not model self-reported. Used as `faithfulness_checked`'s verification input; not separately rendered |
+| `faithfulness_checked` | bool \| None | Whether an automated check confirmed the claim accurately represents the cited source(s): `True`/`False` from an LLM-judge verification call run automatically every turn, `None` when there was nothing to check (`ai-inference`, no `claim_text`, or an unresolvable source slug). Only meaningful when `sources` is non-empty — orthogonal to `relation`, not a relation type itself |
 
 ### FootnoteRelation
 
@@ -53,14 +53,16 @@ linked [Note](note.md)/[Source](source.md)(s).
 > (chat-wide context scope, [Axiom 5](../ontologia.md)) and from faithfulness (accuracy of
 > representation, tracked per-footnote via `faithfulness_checked`, not a `relation` value).
 
-## Not yet implemented
+## Build status
 
 Built (2026-07-31): the data model, `ChatAgent` self-segmenting its output into per-claim `[^N]`
 markers and self-reporting `relation`/`sources` via a trailing `FOOTNOTES_JSON:` line,
 `relation=relational` sourcing from `ChatToolbox._graph_context`, and UI rendering.
 
-Automated `faithfulness_checked` verification (checking a footnoted claim against what its
-source(s) actually say) is a further, harder, and separately deferred problem — see ADR-017.
-Also unaddressed: an LLM can mis-self-report (e.g. label something `citation` that isn't one) —
-`faithfulness_checked` is the intended future hook for eventually catching that, not something
-this build guarantees today.
+Built (2026-08-03): `faithfulness_checked` verification — see ADR-017. `claim_text` is extracted
+deterministically from the rendered reply (not model self-reported), then every sourced footnote
+is checked against its cited source(s) via a one-shot LLM-judge call
+(`ChatAgent._verify_footnote`), run automatically after every turn. This is a heuristic check,
+not a guarantee: an LLM judge can itself be wrong, so a `True` doesn't certify accuracy the way a
+citekey resolving to a real document does — it catches the common, egregious cases (a claim that
+plainly contradicts or isn't addressed by its cited source), not subtle misrepresentation.

--- a/docs/ontologia.md
+++ b/docs/ontologia.md
@@ -174,7 +174,7 @@ Concepts that belong to the domain and are defined here, but whose code support 
 
 - **SmartTag** — defined in ontology; not yet applied during stream runs or import.
 - **PaperSummary per stream item** — produced during `prisma review`; not yet generated per-item during stream runs.
-- **Footnote / claim attribution** — data model defined (`Footnote`, `FootnoteRelation`), Axiom 16 and ADR-017 written; `ChatAgent` self-segmentation, `ChatToolbox._graph_context` wiring, and UI rendering are built (2026-07-31, see ADR-017). `faithfulness_checked` verification is still unbuilt, deliberately deferred as a separate problem.
+- **Footnote / claim attribution** — data model defined (`Footnote`, `FootnoteRelation`), Axiom 16 and ADR-017 written; `ChatAgent` self-segmentation, `ChatToolbox._graph_context` wiring, UI rendering, and automated `faithfulness_checked` verification are all built (2026-07-31 / 2026-08-03, see ADR-017).
 - **ChromaDB / semantic search** — integrated (ADR-009); see `services/chroma_service.py`, wired into `/search/deep`.
 - **Async rewrite** — `PrismaCoordinator` and agents are synchronous; `ThreadPoolExecutor` offloads blocking I/O. Full async rewrite deferred.
 - **Encryption at rest** — vault files are plaintext. `fscrypt` / `gocryptfs` / `age` deferred.

--- a/docs/wiki/adr/ADR-017-claim-attribution-and-footnote-model.md
+++ b/docs/wiki/adr/ADR-017-claim-attribution-and-footnote-model.md
@@ -2,12 +2,10 @@
 
 **Date:** 2026-07-27
 **Author:** CServinL
-**Status:** Implemented (2026-07-31) — data model, ontology (Axiom 16,
-`docs/concepts/footnote.md`), `ChatAgent` self-segmentation/self-report,
-`ChatToolbox._graph_context` wiring, and UI rendering are all built. Only
-`faithfulness_checked` verification remains unbuilt, per this ADR's own
-"Negative consequences" section below — deliberately deferred as a
-separate, harder problem, not an oversight.
+**Status:** Implemented (2026-07-31, `faithfulness_checked` added 2026-08-03) —
+data model, ontology (Axiom 16, `docs/concepts/footnote.md`), `ChatAgent`
+self-segmentation/self-report, `ChatToolbox._graph_context` wiring, UI
+rendering, and automated `faithfulness_checked` verification are all built.
 
 ### Implementation notes (added 2026-07-31, not part of the original decision)
 
@@ -27,6 +25,40 @@ separate, harder problem, not an oversight.
   `{@html}`, even for the model's own final reply — consistent with this
   codebase already treating tool results as untrusted content
   (`services/injection_defense.py`).
+
+### `faithfulness_checked` implementation notes (added 2026-08-03)
+
+- **Trigger: automatic, every turn** (user decision) — every footnote with
+  a non-empty `sources` list gets a verification call right after
+  `_extract_footnotes`, not gated behind a UI action. Accepted cost: on the
+  shared compute pool (ADR-014/016), a turn with N sourced footnotes makes
+  N additional sequential LLM calls before the turn is considered done.
+- `claim_text` (previously always `None` — nothing populated it) is now
+  filled deterministically: the sentence immediately preceding each `[^N]`
+  marker in the rendered reply (`_extract_claim_texts`), not a model
+  self-report. Keeps the self-report JSON minimal (still just
+  `index`/`relation`/`sources`), same reasoning as everywhere else in this
+  ADR that a self-report is less reliable than something derived from text
+  that's already there.
+- Verification method: LLM-as-judge, one-shot (`ChatAgent.complete_once`,
+  renamed from `summarize` since it now serves two callers — ADR-015's
+  Excerpt regeneration and this). Same spirit as `services/dedup.py`'s
+  level 4→5 cascade (cheap check first, LLM only when it actually needs
+  judgment) — except there's no cheap prefilter for entailment the way
+  NLTK stem-overlap works as one for duplicate detection, so every sourced
+  footnote gets the LLM call, not just ambiguous ones.
+- Source text resolution: `ChatToolbox.get_node_text(slug)`, new — resolves
+  a footnote's source slug the same way a wiki-link would (`VaultService.
+  get_any`), covering Note/Source body and Chat message transcripts (the
+  same past-chat retrieval this session's chat-instructions change made
+  explicit in the system prompt). Returns `None` on a missing slug rather
+  than raising, so one hallucinated slug doesn't break verification for the
+  turn's other footnotes.
+- Result stays `None` (not `False`) whenever there's nothing to check:
+  `ai-inference` footnotes (no source by design), a `claim_text` that
+  failed to extract, an unresolvable source slug, or the verifier LLM call
+  itself failing. `None` means "not checked," never conflated with "checked
+  and failed."
 
 ## Context
 
@@ -129,14 +161,16 @@ actual source).
   `faithfulness_checked == True`.
 
 ### Negative
-- Requires `ChatAgent` to self-segment its own output into per-claim spans
+- Required `ChatAgent` to self-segment its own output into per-claim spans
   and self-report `relation`/`sources` at generation time — new prompting
-  complexity, not yet designed or built (see `TODO.md`).
+  complexity (built 2026-07-31, see the implementation notes above).
 - An LLM can mis-self-report — e.g. label a fabricated/misremembered
-  "quote" as `citation` when it isn't one. This ADR does not solve that.
-  `faithfulness_checked` is the intended (currently unbuilt) hook for
-  eventually catching it — a real, harder, separately-deferred problem, not
-  a guarantee this design provides today.
+  "quote" as `citation` when it isn't one. `faithfulness_checked` (built
+  2026-08-03, see its implementation notes above) catches *some* of this —
+  an LLM-judge call comparing `claim_text` against the cited source(s) — but
+  it's a heuristic, not a guarantee: the judge is itself an LLM call and can
+  be wrong, particularly on subtle misrepresentation rather than outright
+  contradiction.
 - `ChatMessage.sources_cited`'s shape is replaced, not extended — this was
   written assuming there was no live caller to migrate (Chat API routes
   were believed not yet implemented, per `docs/ontologia.md`'s stale "Not

--- a/prisma/agents/chat_agent.py
+++ b/prisma/agents/chat_agent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Callable, Literal
 
 from pydantic import ValidationError
@@ -62,6 +63,26 @@ def _estimate_tokens(text: str) -> int:
     return len(text) // 4  # same rough char/4 heuristic used by semchunk elsewhere in this codebase
 
 
+_FOOTNOTE_MARKER_RE = re.compile(r"\[\^(\d+)\]")
+
+
+def _extract_claim_texts(content: str) -> dict[int, str]:
+    """Best-effort span extraction: the sentence immediately preceding each
+    [^N] marker in the model's rendered reply, keyed by N. Deliberately NOT
+    part of the model's FOOTNOTES_JSON self-report (ADR-017 keeps that
+    self-report minimal/less error-prone) -- this is derived deterministically
+    from text that's already there, used as faithfulness_checked's input
+    (ChatAgent._verify_footnote)."""
+    claims: dict[int, str] = {}
+    cursor = 0
+    for m in _FOOTNOTE_MARKER_RE.finditer(content):
+        preceding = content[cursor:m.start()].strip()
+        sentences = re.split(r"(?<=[.!?])\s+", preceding)
+        claims[int(m.group(1))] = (sentences[-1] if sentences else preceding).strip()
+        cursor = m.end()
+    return claims
+
+
 def _extract_footnotes(reply: str) -> tuple[str, list[Footnote]]:
     """ADR-017: split the model's FOOTNOTES_JSON self-report off the visible
     reply text. Defensive throughout -- an LLM self-report can be malformed
@@ -82,13 +103,49 @@ def _extract_footnotes(reply: str) -> tuple[str, list[Footnote]]:
     if not isinstance(raw_items, list):
         _log.warning("chat footnotes: FOOTNOTES_JSON was not a JSON array, dropping")
         return content, []
+    claim_texts = _extract_claim_texts(content)
     footnotes: list[Footnote] = []
     for item in raw_items:
         try:
-            footnotes.append(Footnote.model_validate(item))
+            fn = Footnote.model_validate(item)
         except ValidationError as exc:
             _log.warning("chat footnotes: skipping malformed entry %r: %s", item, exc)
+            continue
+        if fn.claim_text is None and fn.index in claim_texts:
+            fn = fn.model_copy(update={"claim_text": claim_texts[fn.index]})
+        footnotes.append(fn)
     return content, footnotes
+
+
+# ADR-017's faithfulness_checked hook: is a sourced footnote's claim_text
+# actually supported by the vault content it cites? Same "cheap prefilter,
+# LLM call only when it matters" spirit as services/dedup.py's level 4→5
+# cascade, just without a cheap prefilter here -- there's no NLTK-stem-style
+# shortcut for entailment, so every sourced footnote gets the LLM call.
+_FAITHFULNESS_SOURCE_CHARS = 3000
+
+_FAITHFULNESS_SYSTEM_PROMPT = (
+    "You are a fact-checker. You will be given a CLAIM and one or more SOURCE "
+    "excerpts. Reply with exactly one word: YES if the claim is accurately "
+    "supported by the source(s), NO if it is unsupported, contradicted, or "
+    "not addressed by the source(s) at all."
+)
+
+
+def _build_faithfulness_prompt(claim_text: str, source_texts: list[str]) -> tuple[str, str]:
+    joined = "\n\n---\n\n".join(t[:_FAITHFULNESS_SOURCE_CHARS] for t in source_texts)
+    return _FAITHFULNESS_SYSTEM_PROMPT, f"CLAIM:\n{claim_text}\n\nSOURCE(S):\n{joined}"
+
+
+def _parse_faithfulness_verdict(reply: str | None) -> bool | None:
+    if reply is None:
+        return None
+    verdict = reply.strip().upper()
+    if verdict.startswith("YES"):
+        return True
+    if verdict.startswith("NO"):
+        return False
+    return None  # unparseable -- don't guess, leave faithfulness_checked at None
 
 
 class ChatAgent:
@@ -147,16 +204,33 @@ class ChatAgent:
         raw_tokens = _estimate_tokens(pinned_raw_text)
         return "verbatim" if raw_tokens <= self.context_window * VERBATIM_MODE_MAX_RATIO else "compressed"
 
-    def summarize(self, system_prompt: str, content: str) -> str | None:
-        """One-shot completion, bypassing the tool loop entirely — used for
-        Excerpt summary regeneration (ADR-015), not a conversational turn.
-        Returns None on the same conditions `complete()` does (lease denied,
-        backend unreachable) — caller decides the fallback text."""
+    def complete_once(self, system_prompt: str, content: str) -> str | None:
+        """One-shot completion, bypassing the tool loop entirely -- shared by
+        Excerpt summary regeneration (ADR-015) and faithfulness_checked
+        verification (ADR-017, `_verify_footnote` below), neither of which
+        is a conversational turn. Returns None on the same conditions
+        `complete()` does (lease denied, backend unreachable) — caller
+        decides the fallback."""
         messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": content},
         ]
         return self._llm.complete(messages)
+
+    def _verify_footnote(self, footnote: Footnote) -> Footnote:
+        """ADR-017's faithfulness_checked hook: does claim_text actually say
+        what the cited source(s) say? Left at None (not False) when there's
+        nothing to check against -- an ai-inference footnote has no source
+        by design, and a missing claim_text or unresolvable source slug is a
+        "couldn't check," not a "checked and failed.\""""
+        if not footnote.sources or not footnote.claim_text:
+            return footnote
+        source_texts = [t for t in (self._toolbox.get_node_text(s) for s in footnote.sources) if t]
+        if not source_texts:
+            return footnote
+        system_prompt, content = _build_faithfulness_prompt(footnote.claim_text, source_texts)
+        verdict = _parse_faithfulness_verdict(self.complete_once(system_prompt, content))
+        return footnote.model_copy(update={"faithfulness_checked": verdict})
 
     def respond(
         self, history: list[ChatMessage], user_text: str, excerpt_notes: list[Note] | None = None,
@@ -180,6 +254,7 @@ class ChatAgent:
             match = TOOL_CALL_RE.search(reply)
             if not match:
                 content, footnotes = _extract_footnotes(reply)
+                footnotes = [self._verify_footnote(fn) for fn in footnotes]
                 return ChatMessage(
                     role=ChatRole.assistant, content=content, tool_calls=tool_calls, footnotes=footnotes,
                 )

--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -1106,7 +1106,7 @@ def _regenerate_excerpt_now(slug: str, pinned_indices: list[int], generation: in
     """ADR-015: regenerates the chat's single Excerpt note from whatever's
     currently pinned, in whichever mode currently applies
     (ChatAgent.excerpt_mode(), budget-driven) — compressed (LLM-condensed
-    Summary via ChatAgent.summarize() + load_excerpt_summary_prompt()) or
+    Summary via ChatAgent.complete_once() + load_excerpt_summary_prompt()) or
     verbatim (no LLM call, no Summary section, pinned turns kept exactly as
     written). Synchronous — call via _regenerate_excerpt_async unless
     already off the request thread.
@@ -1114,7 +1114,7 @@ def _regenerate_excerpt_now(slug: str, pinned_indices: list[int], generation: in
     `generation` is checked immediately before the actual write: if a newer
     pin/unpin has since been dispatched for this chat, this call's result is
     stale (it was likely computed from an older pinned set, possibly after a
-    slow summarize() call) and is discarded rather than overwriting the
+    slow complete_once() call) and is discarded rather than overwriting the
     newer request's — eventual — result."""
     chat_node = _vault.get_chat(slug)
     pinned_turns = [chat_node.messages[i] for i in pinned_indices]
@@ -1126,7 +1126,7 @@ def _regenerate_excerpt_now(slug: str, pinned_indices: list[int], generation: in
         if _chat_agent.excerpt_mode(turns_text) == "verbatim":
             summary = None
         else:
-            summary = _chat_agent.summarize(load_excerpt_summary_prompt(), turns_text)
+            summary = _chat_agent.complete_once(load_excerpt_summary_prompt(), turns_text)
             if summary is None:
                 summary = "(summary unavailable — the language model couldn't be reached; raw pinned turns below are still current)"
     with _excerpt_regenerating_lock:

--- a/prisma/services/chat_tools.py
+++ b/prisma/services/chat_tools.py
@@ -22,6 +22,7 @@ from prisma.services.chroma_service import ChromaIndexer
 from prisma.services.injection_defense import wrap_untrusted
 from prisma.services.knowledge_graph_client import KnowledgeGraphClient
 from prisma.services.vault import VaultService
+from prisma.storage.models.vault_models import Chat
 
 _EXCERPT_CHARS = 800
 
@@ -152,6 +153,22 @@ class ChatToolbox:
         if marker == "GRAPH_CONTEXT":
             return self._graph_context(query)
         raise ValueError(f"unknown tool marker: {marker!r}")
+
+    def get_node_text(self, slug: str) -> str | None:
+        """Resolves a footnote's `sources` slug back to plain text, for
+        ADR-017's faithfulness_checked verification (ChatAgent._verify_footnote).
+        Covers the same node types footnotes/wiki-links can point to --
+        Note/Source's `body`, or a Chat's full message transcript joined.
+        Returns None on a missing/unresolvable slug rather than raising, so
+        one stale or hallucinated slug doesn't break verification for the
+        other footnotes in the same turn."""
+        try:
+            node = self._vault.get_any(slug)
+        except FileNotFoundError:
+            return None
+        if isinstance(node, Chat):
+            return "\n\n".join(m.content for m in node.messages) or None
+        return getattr(node, "body", None) or None
 
     def _search_vault(self, query: str, top_k: int = 5) -> ToolResult:
         hits = self._chroma.query(query, top_k=top_k)

--- a/tests/unit/agents/test_chat_agent.py
+++ b/tests/unit/agents/test_chat_agent.py
@@ -8,9 +8,18 @@ from prisma.storage.models.vault_models import ChatMessage, ChatRole, Note
 
 
 def _agent(llm=None, toolbox=None, max_history_tokens=16000):
+    if toolbox is None:
+        # Unconfigured MagicMock.get_node_text() would return a truthy
+        # MagicMock, not real text or None -- _verify_footnote would then
+        # try to slice/join it and blow up. None means "can't resolve this
+        # source," which _verify_footnote already handles by skipping the
+        # check, so tests that don't care about faithfulness_checked (most
+        # of them) aren't forced to configure this explicitly.
+        toolbox = MagicMock()
+        toolbox.get_node_text.return_value = None
     return ChatAgent(
         llm=llm or MagicMock(),
-        toolbox=toolbox or MagicMock(),
+        toolbox=toolbox,
         max_history_tokens=max_history_tokens,
         system_prompt="You are a test assistant.",
     )
@@ -204,14 +213,15 @@ def test_respond_excerpt_notes_survive_history_truncation():
     assert "x" * 400 not in contents
 
 
-# ── summarize() — Excerpt summary regeneration (ADR-015) ──────────────────────
+# ── complete_once() — one-shot completions (ADR-015 excerpt summary, ─────────
+# ── ADR-017 faithfulness verification), bypassing the tool loop ──────────────
 
-def test_summarize_sends_system_and_user_content_bypassing_tool_loop():
+def test_complete_once_sends_system_and_user_content_bypassing_tool_loop():
     llm = MagicMock()
     llm.complete.return_value = "Condensed summary."
     agent = _agent(llm=llm)
 
-    result = agent.summarize("Summarize these turns.", "user: hi\nassistant: hello")
+    result = agent.complete_once("Summarize these turns.", "user: hi\nassistant: hello")
 
     assert result == "Condensed summary."
     sent_messages = llm.complete.call_args[0][0]
@@ -221,12 +231,12 @@ def test_summarize_sends_system_and_user_content_bypassing_tool_loop():
     ]
 
 
-def test_summarize_returns_none_when_llm_unreachable():
+def test_complete_once_returns_none_when_llm_unreachable():
     llm = MagicMock()
     llm.complete.return_value = None
     agent = _agent(llm=llm)
 
-    assert agent.summarize("sys", "content") is None
+    assert agent.complete_once("sys", "content") is None
 
 
 # ── excerpt_mode() — ADR-015's compressed-vs-verbatim threshold ───────────────
@@ -414,3 +424,118 @@ def test_system_prompt_includes_footnote_instructions():
     system_content = sent_messages[0]["content"]
     assert "FOOTNOTES_JSON" in system_content
     assert "ai-inference" in system_content
+
+
+# ── claim_text extraction (ADR-017's faithfulness_checked input) ─────────────
+
+def test_extract_footnotes_populates_claim_text_from_preceding_sentence():
+    reply = (
+        'Kùzu has no server process. It was chosen for its embedded mode[^1]. '
+        'Neo4j needs a JVM[^2].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["a"]}, '
+        '{"index": 2, "relation": "attribution", "sources": ["b"]}]'
+    )
+
+    _, footnotes = _extract_footnotes(reply)
+
+    assert footnotes[0].claim_text == "It was chosen for its embedded mode"
+    assert footnotes[1].claim_text == "Neo4j needs a JVM"
+
+
+def test_extract_footnotes_claim_text_none_when_no_markers_in_content():
+    # Malformed input the model never actually produces (a FOOTNOTES_JSON
+    # entry with no matching [^N] in the text) -- must degrade gracefully,
+    # not raise a KeyError.
+    reply = 'No markers here.\nFOOTNOTES_JSON: [{"index": 1, "relation": "ai-inference", "sources": []}]'
+
+    _, footnotes = _extract_footnotes(reply)
+
+    assert footnotes[0].claim_text is None
+
+
+# ── faithfulness_checked verification (ADR-017, automatic every turn) ────────
+
+def test_respond_faithfulness_checked_true_when_verifier_says_yes():
+    llm = MagicMock()
+    llm.complete.side_effect = [
+        'Kùzu is embedded, no server process[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["kg-decision"]}]',
+        "YES",
+    ]
+    toolbox = MagicMock()
+    toolbox.get_node_text.return_value = "Kùzu runs embedded in-process, with no separate server."
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="why Kùzu?")
+
+    assert reply.footnotes[0].faithfulness_checked is True
+    toolbox.get_node_text.assert_called_once_with("kg-decision")
+    # Second complete() call is the verification prompt, not another chat turn.
+    verify_messages = llm.complete.call_args_list[1][0][0]
+    assert verify_messages[0]["role"] == "system"
+    assert "fact-checker" in verify_messages[0]["content"].lower()
+    assert "Kùzu is embedded, no server process" in verify_messages[1]["content"]
+
+
+def test_respond_faithfulness_checked_false_when_verifier_says_no():
+    llm = MagicMock()
+    llm.complete.side_effect = [
+        'Kùzu requires a JVM[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["kg-decision"]}]',
+        "NO",
+    ]
+    toolbox = MagicMock()
+    toolbox.get_node_text.return_value = "Kùzu is embedded and needs no JVM."
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="why Kùzu?")
+
+    assert reply.footnotes[0].faithfulness_checked is False
+
+
+def test_respond_faithfulness_checked_none_when_source_unresolvable():
+    llm = MagicMock()
+    llm.complete.return_value = (
+        'A claim[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["missing-slug"]}]'
+    )
+    toolbox = MagicMock()
+    toolbox.get_node_text.return_value = None  # stale/hallucinated slug
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="hello")
+
+    assert reply.footnotes[0].faithfulness_checked is None
+    assert llm.complete.call_count == 1  # no verification call made
+
+
+def test_respond_faithfulness_checked_none_when_verifier_unreachable():
+    llm = MagicMock()
+    llm.complete.side_effect = [
+        'A claim[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["a"]}]',
+        None,  # verification call fails
+    ]
+    toolbox = MagicMock()
+    toolbox.get_node_text.return_value = "some source text"
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="hello")
+
+    assert reply.footnotes[0].faithfulness_checked is None
+
+
+def test_respond_ai_inference_footnote_never_triggers_verification():
+    llm = MagicMock()
+    llm.complete.return_value = (
+        'Just my own reasoning[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "ai-inference", "sources": []}]'
+    )
+    toolbox = MagicMock()
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="hello")
+
+    assert reply.footnotes[0].faithfulness_checked is None
+    toolbox.get_node_text.assert_not_called()
+    assert llm.complete.call_count == 1

--- a/tests/unit/services/test_chat_tools.py
+++ b/tests/unit/services/test_chat_tools.py
@@ -114,3 +114,41 @@ def test_toolbox_call_unknown_marker_raises(vault):
     toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
     with pytest.raises(ValueError, match="unknown tool marker"):
         toolbox.call("NOT_A_TOOL", "query")
+
+
+# ── get_node_text() — ADR-017 faithfulness_checked's source-text resolver ────
+
+def test_get_node_text_returns_note_body(vault):
+    note = vault.create_note("Attention", body="Attention mechanisms let models weigh tokens.")
+    toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
+
+    assert toolbox.get_node_text(note.slug) == "Attention mechanisms let models weigh tokens."
+
+
+def test_get_node_text_joins_chat_messages(vault):
+    from prisma.storage.models.vault_models import ChatMessage, ChatRole
+
+    chat = vault.create_chat(title="Kùzu decision")
+    vault.save_chat(chat.slug, [
+        ChatMessage(role=ChatRole.user, content="Why Kùzu over Neo4j?"),
+        ChatMessage(role=ChatRole.assistant, content="Kùzu is embedded, no JVM needed."),
+    ])
+    toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
+
+    text = toolbox.get_node_text(chat.slug)
+
+    assert "Why Kùzu over Neo4j?" in text
+    assert "Kùzu is embedded, no JVM needed." in text
+
+
+def test_get_node_text_returns_none_for_missing_slug(vault):
+    toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
+
+    assert toolbox.get_node_text("does-not-exist") is None
+
+
+def test_get_node_text_returns_none_for_empty_body(vault):
+    note = vault.create_note("Empty", body="")
+    toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
+
+    assert toolbox.get_node_text(note.slug) is None

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1888,6 +1888,14 @@
                       {#each msg.footnotes as fn}
                         <li id="chat-turn-{i}-footnote-{fn.index}">
                           <span class="footnote-relation footnote-relation-{fn.relation}">{FOOTNOTE_RELATION_LABEL[fn.relation]}</span>
+                          {#if fn.faithfulness_checked !== null}
+                            <span
+                              class="footnote-faithfulness"
+                              class:faithful={fn.faithfulness_checked}
+                              class:unfaithful={!fn.faithfulness_checked}
+                              title={fn.faithfulness_checked ? "Automated check: claim is supported by the cited source(s)" : "Automated check: claim does NOT appear to be supported by the cited source(s)"}
+                            >{fn.faithfulness_checked ? "✓ verified" : "⚠ unsupported"}</span>
+                          {/if}
                           {#if fn.sources.length}
                             {#each fn.sources as slug, si}{#if si > 0}, {/if}<button class="footnote-source-link" onclick={() => openNode(slug)}>{slug}</button>{/each}
                           {/if}
@@ -3825,6 +3833,12 @@
     background: rgba(148, 163, 184, 0.15);
     color: #94a3b8;
   }
+  .footnote-faithfulness {
+    margin-right: 6px;
+    font-size: 10px;
+  }
+  .footnote-faithfulness.faithful { color: #4ade80; }
+  .footnote-faithfulness.unfaithful { color: #f87171; }
   .footnote-source-link {
     background: none;
     border: none;


### PR DESCRIPTION
## Summary
- Closes the last open piece of ADR-017 (claim attribution/footnotes): `faithfulness_checked` was the one field always left `None`, deliberately deferred as "a real, harder problem."
- **Trigger: automatic, every turn** — explicit user choice over an on-demand "Verify" button, made after flagging the tradeoff: on the shared compute pool (ADR-014/016), a turn with N sourced footnotes now makes N extra sequential LLM calls before the turn is considered done.
- `claim_text` (previously always `None` — nothing populated it) is now extracted deterministically: the sentence immediately preceding each `[^N]` marker in the rendered reply (`ChatAgent._extract_claim_texts`), not a new model self-report field — keeps `FOOTNOTES_JSON`'s self-report surface unchanged.
- Verification: one-shot LLM-judge call (`ChatAgent._verify_footnote`), same "cheap check first, LLM only when needed" spirit as `services/dedup.py`'s level 4→5 cascade — except there's no cheap prefilter for entailment, so every sourced footnote gets the call.
- `ChatAgent.summarize()` renamed to `complete_once()` since it now serves two callers (ADR-015's excerpt regeneration and this) — the old name only made sense for the first.
- New `ChatToolbox.get_node_text(slug)` resolves a footnote's source slug back to text (Note/Source body, or a Chat's joined message transcript) via `VaultService.get_any` — the same resolution a wiki-link would use.
- `faithfulness_checked` stays `None` (not `False`) whenever there's nothing to check: `ai-inference`, missing `claim_text`, an unresolvable source slug, or the verifier call itself failing — `None` means "not checked," never conflated with "checked and failed."
- UI: a ✓ verified / ⚠ unsupported badge next to each footnote's relation badge, shown only when a check actually ran.
- Docs updated: ADR-017 (status + new implementation-notes section + corrected two other stale "not yet built" claims found along the way), `docs/concepts/footnote.md`, `docs/ontologia.md`, `TODO.md`.

## Test plan
- [x] `pytest -q` — 829 passed, 37 skipped (11 new tests: claim_text extraction, faithfulness verification's true/false/unresolvable-source/verifier-unreachable/ai-inference-skip paths, `ChatToolbox.get_node_text`)
- [x] `npx svelte-check` — 1 pre-existing, unrelated error (`SyncStatusInfo.needs_reauth`), no new errors
- [x] `npm run build` — clean
- [x] `docs/diagrams/gen.sh` regenerated — no changes (expected)
- [ ] Live-LLM verification (a real model actually producing a YES/NO verdict) not done this session — no Ollama backend running on this test machine. Same known gap as ADR-017's original PR (#66), which also shipped without live-LLM-in-browser verification.