### PR TITLE
chore: use descriptive names for dev/test machines

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1136,7 +1136,7 @@ no dual-format support, no auto-migration script: only two call sites ever
 read this file at all (`ConfigLoader._load_config()`,
 `supervisor.py`'s 3 `cfg_path` reads for `compute_pools`), and nothing
 writes it programmatically — it's hand-edited, and the one real instance of
-it (the user's own forge deployment) gets converted by hand once this
+it (the user's own test server deployment) gets converted by hand once this
 ships. `ConfigLoader`/`supervisor.py` now use stdlib `tomllib` (Python 3.11+,
 already this project's floor) — `supervisor.py` in particular drops its only
 third-party import (`yaml`) as a result, going one step further into the
@@ -1201,7 +1201,7 @@ This does **not** require "a good programmer to come in and rewrite it" — it n
 ## Deferred feature: vault unlock over LAN instead of an at-rest key (2026-07-22)
 
 Follows up on the "Encryption at rest ... deferred" line in `docs/ontologia.md`.
-Context: the vault is planned to live on a Longhorn-backed volume (Forge/k3s), with
+Context: the vault is planned to live on a Longhorn-backed volume (Test Prisma Server/k3s), with
 an app-level encrypted overlay (gocryptfs, chosen for portability — the encrypted
 directory doesn't care what storage backend sits under it, same reasoning as the
 existing rclone-crypt setup used elsewhere) instead of Longhorn's native
@@ -1241,11 +1241,11 @@ reboots unattended) and for gdrive-crypt (key saved, not re-typed).
 
 Raised, not started — user has higher-priority work right now. `flatpak` +
 `org.gnome.Platform//50` (matching webkit2gtk-4.1, same as the host) are
-already installed on Anvil; `flatpak-builder` is not. Two approaches
+already installed on the desktop client; `flatpak-builder` is not. Two approaches
 discussed, decision not yet made:
 1. **Pragmatic**: `cargo build --release` outside the sandbox, manifest just
    packages the binary + assets + `.desktop` file. Fast, fine for personal
-   use on Anvil, not Flathub-submittable as-is (Flathub requires sandboxed,
+   use on the desktop client, not Flathub-submittable as-is (Flathub requires sandboxed,
    network-free builds).
 2. **Flathub-correct**: build the Rust binary *inside* the sandbox with no
    network access, which needs `flatpak-cargo-generator` to vendor every
@@ -1255,7 +1255,7 @@ discussed, decision not yet made:
 ## Desktop↔server sync via prisma-api, not OS-level file sync (2026-07-22, revised 2026-07-24, implemented 2026-07-25)
 
 Corrects an assumption made earlier in the same planning session: prisma-desktop
-(local, anvil) and a server-side Prisma instance (Forge/k3s) do **not** share one
+(local, desktop client) and a server-side Prisma instance (Test Prisma Server/k3s) do **not** share one
 vault folder at the OS/filesystem level. Options considered and rejected for the
 desktop↔server link specifically: NFS (not practical/safe to expose to the
 internet — no real auth story for that), Syncthing, rclone (crypt + `bisync`).
@@ -1299,7 +1299,7 @@ sync": both directions go through Prisma's own API/WS, never a shared mount.
 well-understood way to expose functionality across the open internet safely
 (proper auth, already need TLS regardless per the ClusterIssuer/Ingress work
 done alongside this). It also means prisma-desktop can reach the server from
-**any** network, not just when on the same LAN/WireGuard as Forge — file-sync-
+**any** network, not just when on the same LAN/WireGuard as the test server — file-sync-
 based approaches were implicitly LAN-bound.
 
 **Where this lives:** inside `prisma-desktop` itself (extending it well beyond

--- a/docs/llamacpp-vulkan-home-server-vs-desktop-client-benchmark.md
+++ b/docs/llamacpp-vulkan-home-server-vs-desktop-client-benchmark.md
@@ -1,8 +1,8 @@
-# llama.cpp + Vulkan: forge vs. anvil, initial benchmark
+# llama.cpp + Vulkan: home server vs. desktop client, initial benchmark
 
-Context: setting up a local llama.cpp (Vulkan backend) dev loop on both `forge`
-(the always-on home server, no dedicated GPU) and `anvil` (daily-driver
-workstation, also no dedicated GPU) so Prisma can eventually talk to either
+Context: setting up a local llama.cpp (Vulkan backend) dev loop on both the
+always-on home server (no dedicated GPU) and the daily-driver desktop client
+workstation (also no dedicated GPU) so Prisma can eventually talk to either
 Ollama or llama.cpp as interchangeable backends, tested locally on both
 machines before anything ships to either box for real. Run 2026-07-23, while
 the 4090M laptop (the machine all prior model-evaluation docs in this folder
@@ -10,7 +10,7 @@ used) is out for repair.
 
 ## Hardware
 
-| | forge | anvil |
+| | home server | desktop client |
 |---|---|---|
 | CPU | AMD Ryzen 7 PRO 6850U (8C/16T) | AMD Ryzen AI 5 PRO 340 (6C/12T, up to 4.9GHz) |
 | GPU | Radeon 680M (RDNA2, "Rembrandt") | Radeon 840M (RDNA3.5, "Krackan1") |
@@ -30,7 +30,7 @@ Q4_K_M, 1.79GiB) on both machines.
 
 ## Results
 
-| | forge (680M, no matrix cores) | anvil (840M, `coopmat`) |
+| | home server (680M, no matrix cores) | desktop client (840M, `coopmat`) |
 |---|---|---|
 | pp512 (prompt processing, compute-bound) | **651.78 t/s** | 247.34 t/s |
 | tg128 (generation, memory-bandwidth-bound) | 33.01 t/s | **35.88 t/s** |
@@ -40,27 +40,29 @@ Q4_K_M, 1.79GiB) on both machines.
 Two results, in opposite directions from what "newer architecture + hardware
 matrix acceleration" would suggest at first glance:
 
-- **tg128 (decode)**: anvil slightly ahead (35.88 vs 33.01 t/s), consistent
-  with decode being memory-bandwidth-bound rather than compute-bound — matrix
-  cores don't help here regardless of generation, this is just whichever
-  machine's RAM subsystem is faster.
-- **pp512 (prefill)**: anvil is **2.6x slower** than forge, despite having
-  `coopmat` matrix-core support that forge's 680M completely lacks (forge
-  reports `matrix cores: none` in `ggml_vulkan`'s device log). Not root-caused
-  yet, but the leading hypothesis is **compute unit (CU) count**, not
-  architecture generation: forge's 680M (Rembrandt) is a relatively
-  CU-generous config for its class; the 840M here is a lower/mid tier
-  "Ryzen AI 5" part, and RDNA-generation improvements plus a `coopmat`
-  efficiency win on paper don't necessarily overcome having meaningfully
-  fewer raw shader/compute units to begin with. Not confirmed via an actual
-  CU-count lookup for either chip — flagged as a follow-up if this matters
-  enough to chase further.
+- **tg128 (decode)**: the desktop client slightly ahead (35.88 vs 33.01 t/s),
+  consistent with decode being memory-bandwidth-bound rather than
+  compute-bound — matrix cores don't help here regardless of generation,
+  this is just whichever machine's RAM subsystem is faster.
+- **pp512 (prefill)**: the desktop client is **2.6x slower** than the home
+  server, despite having `coopmat` matrix-core support that the home
+  server's 680M completely lacks (it reports `matrix cores: none` in
+  `ggml_vulkan`'s device log). Not root-caused yet, but the leading
+  hypothesis is **compute unit (CU) count**, not architecture generation:
+  the home server's 680M (Rembrandt) is a relatively CU-generous config for
+  its class; the 840M here is a lower/mid tier "Ryzen AI 5" part, and
+  RDNA-generation improvements plus a `coopmat` efficiency win on paper
+  don't necessarily overcome having meaningfully fewer raw shader/compute
+  units to begin with. Not confirmed via an actual CU-count lookup for
+  either chip — flagged as a follow-up if this matters enough to chase
+  further.
 
 ## Takeaway for the Prisma dev-loop setup
 
 Don't assume "newer chip generation" or "has matrix cores" predicts faster
 inference — measure per-machine, per-workload (prefill vs decode behave
 completely differently), same as every other model-choice finding in this
-folder. anvil is not a strict upgrade over forge for this purpose: better for
-decode-heavy/short-generation workloads, meaningfully worse for anything
-prompt-processing-heavy (e.g. feeding it long context).
+folder. The desktop client is not a strict upgrade over the home server for
+this purpose: better for decode-heavy/short-generation workloads,
+meaningfully worse for anything prompt-processing-heavy (e.g. feeding it
+long context).

--- a/docs/nuextract-2.0-kg-extraction-evaluation.md
+++ b/docs/nuextract-2.0-kg-extraction-evaluation.md
@@ -5,7 +5,7 @@ Closes a gap flagged in `docs/kg-extraction-context-length.md` and
 instruct-tuned chat models (qwen2.5:3b/7b, qwen3 family) prompted for
 extraction — neither ever tested a model actually specialized for structured
 extraction. NuExtract-2.0 (NuMind, built on Qwen2.5) is exactly that. Run
-2026-07-24 on Anvil (Radeon 840M, Vulkan), `NuExtract-2.0-4B-Q4_K_M` served
+2026-07-24 on the desktop client (Radeon 840M, Vulkan), `NuExtract-2.0-4B-Q4_K_M` served
 via `llama-swap`.
 
 ## Method

--- a/docs/wiki/adr/ADR-008-enhanced-zotero-integration.md
+++ b/docs/wiki/adr/ADR-008-enhanced-zotero-integration.md
@@ -190,7 +190,7 @@ The Local-API-primary architecture (`ZoteroHybridClient` → `ZoteroLocalAPIClie
 prompted this reversal — the server (`prisma serve`) never actually selected it,
 because the assumption underlying this whole ADR (the process reading from Zotero
 Desktop's local HTTP server is *also* the process running on the user's machine) broke
-once prisma split into a server (running on a dedicated machine, "forge") and a
+once prisma split into a server (running on a dedicated machine) and a
 desktop client (running on the user's own machine, "prisma-desktop"). The local API at
 `localhost:23119` is, definitionally, only reachable from whatever machine Zotero
 Desktop itself runs on — the server has no guarantee of being that machine.
@@ -239,7 +239,7 @@ pyzotero-backed, richer Zotero-API-faithful models in
 `storage/models/zotero_models.py`). `services/zotero.py` also still carried a
 genuine local-Zotero-Desktop-SQLite-reading fallback path
 (`ZoteroMode.offline` → `_detect_db_path()` scanning `~/Zotero/zotero.sqlite`
-and its WSL2 equivalent) — dead on forge, but a real contradiction of this
+and its WSL2 equivalent) — dead on a server deployment, but a real contradiction of this
 ADR's own "Web API only, everywhere" follow-up above.
 
 **Decision: consolidate onto `integrations/zotero/client.py`** — pyzotero

--- a/prisma/server/supervisor.py
+++ b/prisma/server/supervisor.py
@@ -279,7 +279,7 @@ def _profile_missing_models(
     load via Ollama's native /api/generate, which llama-server/llama-swap
     don't implement. Those pools must have `vram_mb` set explicitly in
     config for every model (no auto-profiling fallback) — see
-    docs/llamacpp-vulkan-forge-vs-anvil-benchmark.md in this repo for real
+    docs/llamacpp-vulkan-home-server-vs-desktop-client-benchmark.md in this repo for real
     measured numbers to use as a starting point.
     """
     saved_profiles = _load_vram_profiles()

--- a/prisma/server/sync_routes.py
+++ b/prisma/server/sync_routes.py
@@ -119,7 +119,7 @@ def build_sync_router(
         # is_relevant_path) -- streams/*.yaml (the one other synced type,
         # see _safe_sync_path) is excluded from the KG's own file watcher,
         # so a bare unconditional mark_stale() here would set "stale" with
-        # nothing ever able to clear it (confirmed live 2026-07-25 on Forge,
+        # nothing ever able to clear it (confirmed live 2026-07-25 on a test server,
         # right after the vault-sync engine pushed a stream file).
         mark_stale_fn(req.path)
         client_id = request.headers.get(_CLIENT_ID_HEADER)

--- a/prisma/services/knowledge_graph_service.py
+++ b/prisma/services/knowledge_graph_service.py
@@ -800,7 +800,7 @@ class KnowledgeGraphService:
         # Migration: CREATE TABLE IF NOT EXISTS is a no-op against a Kùzu DB
         # that already has an IndexedFile table from before extracted_by
         # existed (true for any pre-2026-07-24 database, including whatever
-        # ends up on forge) — the column never gets added for those without
+        # ends up on a test server) — the column never gets added for those without
         # this explicit ALTER. Kùzu has no "ADD COLUMN IF NOT EXISTS", so
         # just swallow the one error it raises when the column is already
         # there (a fresh DB created by the statement above already has it).

--- a/tests/unit/services/test_knowledge_graph_service.py
+++ b/tests/unit/services/test_knowledge_graph_service.py
@@ -646,7 +646,7 @@ def test_mark_stale_ignores_stream_paths(kg, vault):
     # from the KG's own file watcher (_VaultChangeHandler never adds it to
     # _pending), so calling mark_stale() for a stream write set "stale" with
     # nothing ever able to clear it -- stuck forever. Confirmed live on
-    # Forge right after the vault-sync engine pushed a stream file.
+    # a test server right after the vault-sync engine pushed a stream file.
     with kg._lock:
         kg._state = "idle"
     kg.mark_stale(vault.root / "streams" / "my-topic.yaml")

--- a/ui/src/lib/platform.ts
+++ b/ui/src/lib/platform.ts
@@ -15,9 +15,9 @@ export interface SavedServer {
 // kept in sync manually since the two aren't generated from one schema.
 export const DEFAULT_SAVED_SERVERS: SavedServer[] = [
   { name: "Local", url: "http://127.0.0.1:8765" },
-  // Generic label — "Forge" is this maintainer's own private server name,
-  // not a sensible default for other users of this software.
-  { name: "Remote", url: "https://prisma.forge.internal" },
+  // Generic placeholder — never a real maintainer server name/hostname,
+  // see docs/wiki/deployment-models.md for real-world examples.
+  { name: "Remote", url: "https://prisma.yourdomain.com" },
 ];
 
 export interface AppSettings {


### PR DESCRIPTION
## Summary
- "forge"/"anvil" as machine nicknames weren't descriptive of their actual role. Replaced with "home server"/"desktop client" (and "test server" in a couple of more generic spots) across code comments, docs, and one default UI preset value.
- Renamed and rewrote `docs/llamacpp-vulkan-*-benchmark.md`, which used the old names in its filename and throughout its comparison tables.

## Test plan
- [x] `pytest -q` — 829 passed, 37 skipped, no test logic changed (only comments/one string constant)
- [x] `npx svelte-check` — 1 pre-existing, unrelated error (`SyncStatusInfo.needs_reauth`), no new errors
- [x] `docs/diagrams/gen.sh` regenerated — no changes