### PR TITLE
ADR-020: APA citation formatting for claims, including chat UI wiring

### DIFF
--- a/docs/concepts/chat.md
+++ b/docs/concepts/chat.md
@@ -85,7 +85,10 @@ passed.
 
 In the UI, the inline `[^N]` marker is clickable (jumps to its claim's list entry) and colored by
 relation/kind; the claim list at the bottom shows the relation/kind badge, the faithfulness badge
-(when checked, `CitedClaimNode` only), and a clickable link to each cited source.
+(when checked, `CitedClaimNode` only), a clickable link to each cited source, and — below that,
+ADR-020 — the source's formatted APA citation, fetched on demand via `GET /notes/apa?slugs=...`
+(`services/citation_format.py`'s `format_apa()`, resolved fresh on every request, not cached) and
+cached client-side per slug so re-rendering the same chat doesn't re-fetch.
 
 ## Context management
 
@@ -173,5 +176,3 @@ directly. A legacy `.md`-with-`<!-- prisma:meta {...} -->`-comment reader surviv
 - **Thinking-step population** — `TurnNode.thoughts`/`ThinkingNode` ship as schema (ADR-019,
   2026-08-05), but nothing produces them yet; gated behind the still-deferred model-category
   `has_native_reasoning` flag. See [Chat session graph](chat-session-graph.md#status).
-- **APA citation formatting** — `CitedClaimNode.sources` resolve to vault slugs today; formatted
-  APA-style citations off that resolution are a separate, not-yet-built formatting concern.

--- a/docs/wiki/adr/ADR-020-apa-citation-formatting.md
+++ b/docs/wiki/adr/ADR-020-apa-citation-formatting.md
@@ -1,13 +1,22 @@
 # ADR-020: APA Citation Formatting
 
-**Date:** 2026-08-05
+**Date:** 2026-08-05 (open questions resolved and implemented 2026-08-11)
 **Author:** CServinL
-**Status:** Proposed — design drafted, not built. Several open questions
-(marked below) need cservinl's decision before implementation starts.
-Deliberately deferred out of the ADR-019 session-graph work (task tracking:
-"Add APA citation formatting for claims") — a separate formatting concern
-layered on top of [Claim](../../concepts/claim.md)'s existing
-`CitedClaimNode.sources: list[str]` resolution, not a change to that model.
+**Status:** Implemented, including the chat UI wiring originally left out of
+scope. All 4 open questions below resolved 2026-08-11: hard validation (not
+soft degrade), compute-fresh-on-read (not cached), no model behavior change
+(rendering only), one-time backfill command (not accept-degraded). Phases 1-5
+built as scoped; phases 6-7 (cached string, system-prompt instruction) turned
+out to be moot once their blocking questions resolved toward "don't cache" /
+"no model change" — see each open question below for what actually shipped
+instead. `GET /notes/apa?slugs=...` (`notes_routes.py`) + `+page.svelte`
+fetching/caching it per slug, rendering each claim's APA citation as an extra
+line below its source link, landed same day as a follow-on once cservinl
+asked about it directly — not deferred after all. Deliberately deferred out of the
+ADR-019 session-graph work (task tracking: "Add APA citation formatting for
+claims") — a separate formatting concern layered on top of
+[Claim](../../concepts/claim.md)'s existing `CitedClaimNode.sources: list[str]`
+resolution, not a change to that model.
 
 ## Context
 
@@ -58,74 +67,68 @@ references, with the machinery to go both directions between a slug and its APA 
    the reverse of the "slug → APA" direction, not just a variant of the existing semantic search
    (matching a citation string's specific structure, not general semantic similarity).
 
-## Proposed phases
+## Phases (all built 2026-08-11)
 
-1. **Extend `Source` with the missing bibliographic fields**: `journal: str | None`,
-   `volume: str | None`, `issue: str | None`, `pages: str | None`, `publisher: str | None`,
-   `url: str | None` (fixes finding 3 as a side effect), `item_type: str | None` (APA template
-   selector — journal article / book / webpage / etc.). Thread these through
-   `create_source_from_citekey()`, `get_source()`'s frontmatter read, and the Zotero import call
-   site (`zotero_routes.py`) from `ZoteroItem`'s already-fetched fields (finding 2) — no new
-   external data, just stop discarding what's already there.
-2. **`utils/source_metadata.py` (or similar) — a completeness evaluator.** Given a `Source`,
-   return which fields are missing for a *correct* APA citation of its specific `item_type` (a
-   journal article's requirements differ from a book's or a webpage's) — not just "does it have
-   authors and a year." Used by both phase 3's converter (to degrade gracefully — omit
-   volume/issue rather than crash when absent) and a vault-health view flagging under-cited
-   sources.
-3. **Slug → APA converter** — a pure function, `Source` (+ its completeness evaluation) in,
-   an APA 7th-edition-formatted string out, `item_type`-aware templates. Where it lives (new
-   `citation_format.py` service module vs. a `Source` method) is an implementation-time call.
-4. **APA → Slug converter (reverse lookup)** — inherently fuzzy, unlike `[[@citekey]]`'s exact
-   match: parse (author surname, year) at minimum out of an arbitrary APA-shaped string, narrow
-   candidates by `Source.authors`/`Source.year`, disambiguate by title similarity when multiple
-   sources share an author+year. Needs its own tests around malformed/partial input — this is the
-   "APA-based slug finder" finding 5 identified as missing.
-5. **APA validator** — checks a string actually conforms to APA structural rules (regex/structural,
-   not semantic). Two uses: self-check phase 3's own output in tests, and reject-early on garbage
-   input to phase 4's parser before attempting extraction.
-6. **Whether/how metadata carries a cached APA string** — see open question 2 below; if resolved
-   toward caching, this phase writes the rendered string into frontmatter (`fm["apa"] = ...`)
-   at the same points phase 1's fields get written/edited.
-7. **System-prompt instruction** — see open question 3 below; blocked on resolving what the model
-   is actually being asked to change, since today it never writes citation text at all (only
-   `[^N]` markers + slugs — APA rendering already happens entirely server/UI-side per
-   [Claim](../../concepts/claim.md)'s existing rendering model).
+1. **Extended `Source`** with `journal`/`volume`/`issue`/`pages`/`publisher`/`url`/`item_type`
+   (`vault_models.py`). Threaded through `create_source_from_citekey()`, `get_source()`'s
+   frontmatter read, and the Zotero import route (`zotero_routes.py`, from `ZoteroItem`'s already-
+   fetched fields including `get_field("publisher")` for the one field with no named `ZoteroItem`
+   attribute). Fixed finding 3's `url` silent-drop bug as a side effect.
+2. **`prisma/services/citation_format.py`: `missing_fields_for_apa(source)`** — completeness
+   evaluator, `item_type`-aware (journal-like/book-like/web-like/generic), used by `format_apa()`
+   to degrade gracefully rather than crash on absent fields.
+3. **`citation_format.py`: `format_apa(source) -> str`** — the slug → APA converter. Handles
+   1/2/3+ author lists (APA's `&`-before-last convention), no-author (title leads instead of a
+   repeated title), `n.d.` for a missing year, DOI preferred over a bare URL when both present.
+4. **`citation_format.py`: `find_source_by_apa(text, sources) -> list[Source]`** — the reverse
+   lookup, confirmed fuzzy as expected: parses a leading surname + year (or `n.d.`) out of `text`,
+   filters candidates by both, ranks remaining ties by title word overlap. A real bug caught by its
+   own test suite during implementation: the initial `n.d.` handling matched *any* source
+   regardless of whether that source itself had no year — fixed to require the candidate's own
+   `year is None` too.
+5. **`citation_format.py`: `validate_apa_format(text) -> bool`** — structural check (an
+   author/title lead-in followed by `(Year).`/`(n.d.).`, the shape `format_apa()` itself always
+   produces), not semantic.
+6. **Not built — resolved moot.** Open question 2 resolved toward compute-fresh-on-read; there is
+   no cached APA string to write or regenerate.
+7. **Not built — resolved moot.** Open question 3 resolved toward "no model behavior change";
+   `system_prompt_footnote_section()` is untouched by this ADR.
 
-## Open questions (need cservinl's decision before implementation)
+Additionally, resolving open question 1 required a real design call not anticipated by phases
+1-5: hard-validating `CitedClaimNode.sources` needs vault I/O, which doesn't belong inside a
+Pydantic field validator (no vault access, breaks construction in tests, dependency-free models).
+Built instead as `ChatToolbox.slug_resolves(slug) -> bool` + `ChatAgent._sources_resolve(claim)`,
+wired into `respond()` right after `_extract_claims()` — a claim citing an unresolvable slug is
+now dropped (logged), not just left with `faithfulness_checked = None`. `InferenceNode` trivially
+resolves (no sources to check). And resolving open question 4 needed a real write path that didn't
+exist: `VaultService.update_source_bibliographic_fields()` (merges into existing frontmatter,
+never blanks a field just because a re-fetch didn't return it), plus
+`prisma/services/source_backfill.py` + the `prisma backfill-source-metadata` CLI command
+(dry-run by default, `--apply` to write, mirroring `migrate-chats-to-sess`'s existing UX) —
+skips sources with no `zotero_key` or already-populated fields, re-fetches the rest via
+`ZoteroClient.get_item()`.
 
-1. **Hard-validate `CitedClaimNode.sources` against real vault slugs?** (finding 4) A Pydantic
-   validator or construction-time check would turn today's soft "faithfulness_checked degrades to
-   None" signal into an actual rejection/error — more correct, but changes failure behavior
-   (`ChatAgent` would need a defined response to a model citing a slug that doesn't exist, beyond
-   today's silent degrade).
-2. **Cached APA string in frontmatter, or always computed on demand?** cservinl's ask ("slug
-   metadata containing its APA representation") points at caching, but the codebase's existing
-   precedent for derived text (`RichContent.rendered_html`) is compute-fresh-on-every-read, not
-   cache-at-rest, specifically to avoid staleness drift when the source data changes. If cached,
-   needs a defined regeneration trigger (every `save_source`? explicit re-render command?) so a
-   hand-edited `journal`/`year` in frontmatter can't leave a stale cached APA string behind.
-3. **What does "instruct the model to use APA in references" actually change?** The model doesn't
-   generate reference text today — it emits `[^N]` markers plus a `sources: [slug]` list; APA
-   rendering (once built) would happen entirely at claim-list render time (server/UI), not in the
-   model's own output. Possible actual intents, needing cservinl to pick one: (a) nothing changes
-   about what the model does, this bullet is actually about the renderer, already covered by
-   phases 1-3; (b) the model's *inline prose* should start citing in APA in-text style (e.g. "...as
-   shown by (Smith, 2024)...") in addition to or instead of the `[^N]` marker convention — a real
-   UX change to how claims read, not just how the reference list at the bottom is formatted.
-4. **Backfill for existing sources** — phase 1's new fields are only populated going forward
-   (new Zotero imports). Existing vault sources imported before this lands have no
-   `journal`/`volume`/`issue`/`pages`/`url`/`item_type` on file. Needs either a one-time backfill
-   command (re-fetch from Zotero's API by `zotero_key`, already stored on every `Source`) or
-   acceptance that pre-existing sources render degraded (author/year/title-only) APA citations
-   until re-imported.
+## Open questions — all resolved 2026-08-11
+
+1. **Hard-validate `CitedClaimNode.sources` against real vault slugs?** → **Yes, hard-validate.**
+   See phase list above for where this actually landed (not a Pydantic validator).
+2. **Cached APA string in frontmatter, or always computed on demand?** → **Compute fresh on read.**
+   Matches `RichContent.rendered_html`'s existing precedent; no staleness-drift risk, and
+   `format_apa()` is cheap enough (`missing_fields_for_apa()` + string formatting only, both
+   pure/no I/O) that caching would have been optimizing something that was never slow.
+3. **What does "instruct the model to use APA in references" actually change?** → **Nothing about
+   the model.** Resolved as (a) from the original options — `system_prompt_footnote_section()` is
+   untouched; APA rendering is purely a `format_apa()` call at claim-list render time, same
+   rendering model [Claim](../../concepts/claim.md) already had.
+4. **Backfill for existing sources** → **One-time backfill command**, not accept-degraded. See
+   phase list above.
 
 ## Related
 
 - [Claim](../../concepts/claim.md) — `CitedClaimNode.sources` is what this ADR formats; not
   changed in shape by this work, only rendered differently.
 - [Citation](../../concepts/citation.md) — the `[[@citekey]]` DSL's existing exact-match
-  resolution is the precedent open question 1 is asking whether to extend to claims.
+  resolution was the precedent for hard-validating `CitedClaimNode.sources` too (open question 1).
 - [ADR-017](ADR-017-claim-attribution-and-footnote-model.md) /
   [ADR-019](ADR-019-persisted-format-governance-and-migrations.md) — where `CitedClaimNode` and
   its `sources` field came from.

--- a/docs/wiki/adr/README.md
+++ b/docs/wiki/adr/README.md
@@ -23,4 +23,4 @@ Each ADR documents a significant design decision: what was decided, why, and wha
 | [ADR-017](ADR-017-claim-attribution-and-footnote-model.md) | Claim Attribution & Footnote Model for Chat — per-claim sourcing, distinct from grounding | Implemented |
 | [ADR-018](ADR-018-chat-compaction-points.md) | Chat Compaction Points — bounding long-chat context growth beyond what pinning/Excerpt cap today | Superseded |
 | [ADR-019](ADR-019-persisted-format-governance-and-migrations.md) | Persisted-Format Governance & Migrations — `.sess` pure-JSON chat storage, `VersionedModel` migrations, chat-as-session-graph (`TurnNode`/`SessionOrchestrator`/`RECALL`) | Implemented |
-| [ADR-020](ADR-020-apa-citation-formatting.md) | APA Citation Formatting — slug↔APA converters, `Source` metadata completeness, validator, referencing-to-slug enforcement | Proposed |
+| [ADR-020](ADR-020-apa-citation-formatting.md) | APA Citation Formatting — slug↔APA converters, `Source` metadata completeness, validator, referencing-to-slug enforcement | Implemented |

--- a/prisma/agents/chat_agent.py
+++ b/prisma/agents/chat_agent.py
@@ -249,6 +249,17 @@ class ChatAgent:
         verdict = _parse_faithfulness_verdict(self.complete_once(system_prompt, content))
         return claim.model_copy(update={"faithfulness_checked": verdict})
 
+    def _sources_resolve(self, claim: ClaimNode) -> bool:
+        """ADR-020: hard-validates CitedClaimNode.sources against real
+        vault slugs -- system_prompt_footnote_section() already instructs
+        the model to never invent a slug, but a small local model can
+        still hallucinate one; this turns that into an actual rejection
+        instead of _verify_claim's softer "faithfulness_checked degrades
+        to None" signal. InferenceNode has no sources, trivially resolves."""
+        if not isinstance(claim, CitedClaimNode):
+            return True
+        return all(self._toolbox.slug_resolves(s) for s in claim.sources)
+
     def respond(
         self, history: list[TurnNode], user_text: str, excerpt_notes: list[Note] | None = None,
         chat_slug: str | None = None,
@@ -311,7 +322,15 @@ class ChatAgent:
             match = TOOL_CALL_RE.search(reply)
             if not match:
                 content, claims = _extract_claims(reply)
-                claims = [self._verify_claim(c) for c in claims]
+                resolved_claims, dropped = [], 0
+                for c in claims:
+                    if self._sources_resolve(c):
+                        resolved_claims.append(c)
+                    else:
+                        dropped += 1
+                if dropped:
+                    _log.warning("chat claims: dropped %d claim(s) citing an unresolvable slug", dropped)
+                claims = [self._verify_claim(c) for c in resolved_claims]
                 return TurnNode(
                     role=ChatRole.assistant, content=RichContent(format=ContentFormat.markdown, value=content),
                     tool_calls=tool_calls, claims=claims, recalls=recalls, model=self.model,

--- a/prisma/cli/prisma_cli.py
+++ b/prisma/cli/prisma_cli.py
@@ -302,6 +302,47 @@ def migrate_chats_to_sess_cmd(vault_root: str | None, apply_: bool, remove_md: b
     click.echo(f"\n{ok}/{len(results)} converted{' (dry run — nothing written)' if not apply_ else ''}.")
 
 
+@cli.command("backfill-source-metadata")
+@click.option("--vault", "vault_root", default=None, help="Vault root (defaults to config.toml's vault_root)")
+@click.option(
+    "--apply", "apply_", is_flag=True,
+    help="Actually write the fetched fields (default is dry-run: report only, write nothing)",
+)
+def backfill_source_metadata_cmd(vault_root: str | None, apply_: bool):
+    """One-time backfill (ADR-020): re-fetch journal/volume/issue/pages/
+    publisher/item_type from Zotero for sources imported before those
+    fields existed on Source, using each source's already-stored
+    zotero_key. Dry-run by default — pass --apply to actually write."""
+    from prisma.integrations.zotero.client import ZoteroClient
+    from prisma.services.source_backfill import backfill_source_metadata
+    from prisma.services.vault import VaultService
+    from prisma.utils.config import ConfigLoader
+
+    config_loader = ConfigLoader()
+    root = vault_root or str(config_loader.get_vault_root())
+    vault = VaultService(vault_root=root)
+    zotero = ZoteroClient.from_config(config_loader.config)
+    results = backfill_source_metadata(vault, zotero, dry_run=not apply_)
+
+    if not results:
+        click.echo("No sources found.")
+        return
+
+    verb = "would update" if not apply_ else "updated"
+    for r in results:
+        if r.error:
+            click.echo(f"  SKIP   {r.slug}: {r.error}")
+        elif r.updated:
+            click.echo(f"  {verb} {r.slug}")
+
+    updated = sum(1 for r in results if r.updated)
+    skipped = len(results) - updated
+    click.echo(
+        f"\n{updated}/{len(results)} sources {verb}, {skipped} skipped"
+        f"{' (dry run — nothing written)' if not apply_ else ''}.",
+    )
+
+
 cli.add_command(auth_group)
 cli.add_command(schema_group)
 

--- a/prisma/server/notes_routes.py
+++ b/prisma/server/notes_routes.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 from prisma.services.asset_rewrite import asset_prefix, rewrite_html
 from prisma.services.renderer import render as vault_render
 from prisma.services.vault import VaultService
-from prisma.storage.models.vault_models import NodeType, RenderedNode, Stream, VaultListing
+from prisma.storage.models.vault_models import NodeType, RenderedNode, Source, Stream, VaultListing
 
 _activity = logging.getLogger("prisma.activity")
 
@@ -120,6 +120,29 @@ def build_notes_router(
     @router.get("", response_model=VaultListing)
     def list_notes(node_type: Optional[NodeType] = Query(None)):
         return get_vault().list_nodes(node_type)
+
+    @router.get("/apa")
+    def get_apa_citations(slugs: str = Query(..., description="Comma-separated slugs")) -> dict[str, str]:
+        """ADR-020: bulk slug -> APA-citation-string lookup, for the chat
+        UI's claim source links. A claim's `sources` can point to a Note
+        or Chat too, not just a Source (see chat_tools.get_node_text) --
+        this only ever resolves genuine Source nodes; anything else, or an
+        unresolvable slug, is simply omitted from the response rather than
+        erroring the whole batch over one bad slug. Registered before
+        `/{slug}` below so "apa" isn't swallowed as a slug parameter."""
+        from prisma.services.citation_format import format_apa
+        vault = get_vault()
+        result: dict[str, str] = {}
+        for slug in (s.strip() for s in slugs.split(",")):
+            if not slug:
+                continue
+            try:
+                node = vault.get_any(slug)
+            except FileNotFoundError:
+                continue
+            if isinstance(node, Source):
+                result[slug] = format_apa(node)
+        return result
 
     @router.get("/{slug}", response_model=RenderedNode)
     def get_note(slug: str, request: Request, format: str = "html"):

--- a/prisma/server/zotero_routes.py
+++ b/prisma/server/zotero_routes.py
@@ -223,6 +223,9 @@ def build_zotero_router(
             citekey, item.title, body,
             zotero_key=item.key, authors=item.authors, tags=[t.tag for t in item.tags],
             year=item.year, doi=item.doi, url=item.url,
+            journal=item.publication_title, volume=item.volume, issue=item.issue,
+            pages=item.pages, item_type=item.item_type,
+            publisher=item.get_field("publisher"),
         )
         get_indexer().mark_stale()
         _activity.info("action=import_zotero key=%s slug=%s title=%r", key, source.slug, source.title)

--- a/prisma/services/chat_tools.py
+++ b/prisma/services/chat_tools.py
@@ -210,6 +210,18 @@ class ChatToolbox:
             return "\n\n".join(m.content.value for m in node.messages) or None
         return getattr(node, "body", None) or None
 
+    def slug_resolves(self, slug: str) -> bool:
+        """ADR-020: hard-validates a claim's `sources` entries against real
+        vault nodes -- existence only, unlike get_node_text() above, which
+        also treats an empty-body node as unresolved (wrong check here: a
+        real but currently-empty Note is still a real slug, just not
+        useful as faithfulness-check input)."""
+        try:
+            self._vault.get_any(slug)
+            return True
+        except FileNotFoundError:
+            return False
+
     def _search_vault(self, query: str, top_k: int = 5) -> ToolResult:
         hits = self._chroma.query(query, top_k=top_k)
         items = []

--- a/prisma/services/citation_format.py
+++ b/prisma/services/citation_format.py
@@ -1,0 +1,163 @@
+"""APA 7th-edition citation formatting for Source nodes (ADR-020).
+
+Two directions: `format_apa()` renders a `Source` as an APA-formatted
+reference string; `find_source_by_apa()` (companion module work, see
+`validate_apa_format`/`find_source_by_apa` below) goes the other way,
+resolving an APA-shaped string back to a vault slug. `missing_fields_for_apa()`
+is what both `format_apa()` (to degrade gracefully) and a future vault-health
+view (to flag under-cited sources) use to know what's absent, keyed off
+`Source.item_type` -- a journal article's requirements differ from a book's
+or a webpage's, not just "does it have authors and a year."
+"""
+from __future__ import annotations
+
+import re
+
+from prisma.storage.models.vault_models import Source
+
+_JOURNAL_LIKE_TYPES = {"journalArticle", "conferencePaper", "magazineArticle", "newspaperArticle"}
+_BOOK_LIKE_TYPES = {"book", "bookSection", "thesis", "report"}
+_WEB_LIKE_TYPES = {"webpage"}
+
+
+def _apa_kind(item_type: str | None) -> str:
+    if item_type in _JOURNAL_LIKE_TYPES:
+        return "journal"
+    if item_type in _BOOK_LIKE_TYPES:
+        return "book"
+    if item_type in _WEB_LIKE_TYPES:
+        return "web"
+    return "generic"  # unknown/missing item_type -- author/year/title only, no type-specific tail
+
+
+def missing_fields_for_apa(source: Source) -> list[str]:
+    """Which fields are missing for a *correct*, complete APA citation of
+    this source's specific item_type -- not just "does it have authors and
+    a year." A generic/unrecognized item_type only ever requires the
+    always-required fields, since there's no type-specific template to
+    hold it to."""
+    missing: list[str] = []
+    if not source.authors:
+        missing.append("authors")
+    if not source.title:
+        missing.append("title")
+    kind = _apa_kind(source.item_type)
+    if kind == "journal" and not source.journal:
+        missing.append("journal")
+    if kind == "book" and not source.publisher:
+        missing.append("publisher")
+    if kind == "web" and not source.url:
+        missing.append("url")
+    return missing
+
+
+def _apa_author(name: str) -> str:
+    """'Jane Smith' -> 'Smith, J.'; 'Jane Q. Smith' -> 'Smith, J. Q.'.
+    Best-effort -- a single-token name (an organization/collective author,
+    or a name this can't parse) is returned unchanged rather than mangled."""
+    parts = name.split()
+    if len(parts) < 2:
+        return name
+    *given, family = parts
+    initials = " ".join(f"{p[0]}." for p in given if p)
+    return f"{family}, {initials}" if initials else family
+
+
+def _apa_author_list(authors: list[str]) -> str:
+    """APA 7th: an '&' before the last author, 1-20 authors. The
+    21+-authors ellipsis-plus-final-author rule is deliberately not
+    implemented -- not a case this codebase's academic-paper/book sources
+    realistically hit."""
+    formatted = [_apa_author(a) for a in authors]
+    if len(formatted) == 1:
+        return formatted[0]
+    if len(formatted) == 2:
+        return f"{formatted[0]}, & {formatted[1]}"
+    return ", ".join(formatted[:-1]) + f", & {formatted[-1]}"
+
+
+def format_apa(source: Source) -> str:
+    """Render `source` as an APA 7th-edition-formatted citation string.
+    Degrades gracefully when fields are missing (omits volume/issue/etc.
+    rather than raising) -- call `missing_fields_for_apa()` first if a
+    caller needs to know ahead of time whether the result will be
+    incomplete."""
+    year = str(source.year) if source.year else "n.d."
+    kind = _apa_kind(source.item_type)
+    if source.authors:
+        lead = f"{_apa_author_list(source.authors)} ({year}). {source.title}."
+    else:
+        # APA: no author -> the title moves into the author position,
+        # not repeated -- e.g. a webpage with no byline.
+        lead = f"{source.title} ({year})."
+    parts = [lead]
+    if kind == "journal" and source.journal:
+        tail = source.journal
+        if source.volume:
+            tail += f", {source.volume}"
+            if source.issue:
+                tail += f"({source.issue})"
+        if source.pages:
+            tail += f", {source.pages}"
+        parts.append(f"{tail}.")
+    elif kind == "book" and source.publisher:
+        parts.append(f"{source.publisher}.")
+    if source.doi:
+        parts.append(f"https://doi.org/{source.doi}")
+    elif source.url:
+        parts.append(source.url)
+    return " ".join(parts)
+
+
+# ── APA validator + reverse lookup (ADR-020 phases 4-5) ───────────────────────
+
+# Structural, not semantic: some author/title lead-in followed by
+# "(Year)." or "(n.d.)." -- matches the shape format_apa() itself always
+# produces (`"{lead} ({year})."`), and is permissive enough to accept
+# hand-written/pasted APA text that follows the same convention.
+_APA_STRUCTURE_RE = re.compile(r"^.+?\((\d{4}|n\.d\.)\)\.")
+
+
+def validate_apa_format(text: str) -> bool:
+    """Structural check only -- does `text` start with an author/title
+    lead-in followed by a (Year). or (n.d.). marker, the way format_apa()'s
+    own output always does. Not a semantic/correctness check (a
+    well-formed but factually wrong citation still passes)."""
+    return bool(_APA_STRUCTURE_RE.match(text.strip()))
+
+
+_YEAR_RE = re.compile(r"\((\d{4}|n\.d\.)\)")
+_SURNAME_RE = re.compile(r"^([A-Z][\w'-]*)")
+
+
+def find_source_by_apa(text: str, sources: list[Source]) -> list[Source]:
+    """Reverse of format_apa(): given an APA-shaped string, find which
+    `sources` it most likely refers to. Inherently fuzzy, unlike the
+    `[[@citekey]]` DSL's exact match -- parses a leading surname and a
+    year out of `text`, filters by both, and (if more than one source
+    still matches) ranks by title word overlap. Returns candidates
+    best-match-first; empty if `text` doesn't parse or nothing matches."""
+    text = text.strip()
+    year_match = _YEAR_RE.search(text)
+    surname_match = _SURNAME_RE.match(text)
+    if not year_match or not surname_match:
+        return []
+    year_str = year_match.group(1)
+    surname = surname_match.group(1).lower()
+
+    def _year_matches(s: Source) -> bool:
+        return s.year is None if year_str == "n.d." else str(s.year) == year_str
+
+    candidates = [
+        s for s in sources
+        if any(surname in a.lower() for a in s.authors) and _year_matches(s)
+    ]
+    if len(candidates) <= 1:
+        return candidates
+
+    title_words = set(re.findall(r"\w+", text.lower()))
+
+    def _overlap(source: Source) -> int:
+        return len(title_words & set(re.findall(r"\w+", source.title.lower())))
+
+    return sorted(candidates, key=_overlap, reverse=True)

--- a/prisma/services/source_backfill.py
+++ b/prisma/services/source_backfill.py
@@ -1,0 +1,47 @@
+"""ADR-020: one-time backfill of bibliographic fields (journal/volume/
+issue/pages/publisher/item_type) onto sources imported before those fields
+existed on `Source`, by re-fetching each one from Zotero's API via its
+already-stored `zotero_key`. Sources with no `zotero_key` (non-Zotero
+origin) or that already have at least one of the new fields (already
+backfilled, or imported after this landed) are skipped, not overwritten.
+"""
+from dataclasses import dataclass
+
+from prisma.integrations.zotero.client import ZoteroClient
+from prisma.services.vault import VaultService
+from prisma.storage.models.vault_models import NodeType
+
+
+@dataclass
+class BackfillResult:
+    slug: str
+    updated: bool
+    error: str | None = None
+
+
+def backfill_source_metadata(
+    vault: VaultService, zotero: ZoteroClient, *, dry_run: bool = True,
+) -> list[BackfillResult]:
+    results: list[BackfillResult] = []
+    for meta in vault.list_nodes(node_type=NodeType.source).sources:
+        source = vault.get_source(meta.slug)
+        if not source.zotero_key:
+            results.append(BackfillResult(slug=source.slug, updated=False, error="no zotero_key on file"))
+            continue
+        if source.journal or source.publisher or source.item_type:
+            results.append(BackfillResult(slug=source.slug, updated=False))
+            continue
+        item = zotero.get_item(source.zotero_key)
+        if item is None:
+            results.append(BackfillResult(
+                slug=source.slug, updated=False, error="Zotero item not found (deleted/moved?)",
+            ))
+            continue
+        if not dry_run:
+            vault.update_source_bibliographic_fields(
+                source.slug,
+                journal=item.publication_title, volume=item.volume, issue=item.issue,
+                pages=item.pages, publisher=item.get_field("publisher"), item_type=item.item_type,
+            )
+        results.append(BackfillResult(slug=source.slug, updated=True))
+    return results

--- a/prisma/services/vault.py
+++ b/prisma/services/vault.py
@@ -477,12 +477,21 @@ class VaultService:
             path=path,
             created_at=datetime.fromtimestamp(stat.st_mtime),
             modified_at=datetime.fromtimestamp(stat.st_mtime),
+            journal=fm.get("journal"),
+            volume=fm.get("volume"),
+            issue=fm.get("issue"),
+            pages=fm.get("pages"),
+            publisher=fm.get("publisher"),
+            url=fm.get("url"),
+            item_type=fm.get("item_type"),
         )
 
     def create_source_from_citekey(
         self, citekey: str, title: str, body: str, *,
         zotero_key: str, authors: list[str], tags: list[str],
         year: int | None = None, doi: str | None = None, url: str | None = None,
+        journal: str | None = None, volume: str | None = None, issue: str | None = None,
+        pages: str | None = None, publisher: str | None = None, item_type: str | None = None,
     ) -> Source:
         """Create a source node from Zotero-derived metadata -- the
         vault-side half of POST /zotero/import/{key}."""
@@ -498,8 +507,45 @@ class VaultService:
             fm["doi"] = doi
         if url:
             fm["url"] = url
+        if journal:
+            fm["journal"] = journal
+        if volume:
+            fm["volume"] = volume
+        if issue:
+            fm["issue"] = issue
+        if pages:
+            fm["pages"] = pages
+        if publisher:
+            fm["publisher"] = publisher
+        if item_type:
+            fm["item_type"] = item_type
         path = self.default_dirs[NodeType.source] / f"{slug}.md"
         path.write_text(_render_frontmatter(fm) + body, encoding="utf-8")
+        return self.get_source(slug)
+
+    def update_source_bibliographic_fields(
+        self, slug: str, *, journal: str | None = None, volume: str | None = None,
+        issue: str | None = None, pages: str | None = None, publisher: str | None = None,
+        url: str | None = None, item_type: str | None = None,
+    ) -> Source:
+        """Merges the given fields into `slug`'s existing frontmatter,
+        leaving the body and every other field untouched -- the ADR-020
+        backfill command's write path, for sources imported before these
+        fields existed on Source. Only overwrites a field when a non-empty
+        value is given, so re-running backfill against a partially-filled
+        source doesn't blank out fields Zotero didn't return this time."""
+        path = self._find_md(slug)
+        if path is None:
+            raise FileNotFoundError(f"source not found: {slug!r}")
+        raw = path.read_text(encoding="utf-8")
+        fm, content = _parse_frontmatter(raw)
+        for key, value in [
+            ("journal", journal), ("volume", volume), ("issue", issue), ("pages", pages),
+            ("publisher", publisher), ("url", url), ("item_type", item_type),
+        ]:
+            if value:
+                fm[key] = value
+        path.write_text(_render_frontmatter(fm) + content, encoding="utf-8")
         return self.get_source(slug)
 
     def get_chat(self, slug: str) -> Chat:

--- a/prisma/storage/models/vault_models.py
+++ b/prisma/storage/models/vault_models.py
@@ -104,6 +104,23 @@ class Source(VaultNodeBase):
     # Extension of the companion original file, e.g. ".pdf", ".html", ".svg".
     # Companion lives at <Zotero Imported dir>/<slug><original_ext>. None when only .md exists.
     original_ext: str | None = None
+    # ADR-020: bibliographic fields APA citation formatting needs beyond
+    # author/year/title -- all already fetched from Zotero at import time
+    # (ZoteroItem has every one of these) but previously discarded rather
+    # than persisted. url specifically fixes a standing bug: it was being
+    # written into frontmatter by create_source_from_citekey() but never
+    # read back out by get_source() -- silently dropped on every load.
+    journal: str | None = None  # Zotero's publicationTitle -- journal/venue name
+    volume: str | None = None
+    issue: str | None = None
+    pages: str | None = None
+    publisher: str | None = None
+    url: str | None = None
+    # Zotero's raw itemType (e.g. "journalArticle", "book", "webpage") --
+    # the APA template selector. Distinct from source_kind (paper/document/
+    # web/media), which is a coarser 4-value classification predating this;
+    # item_type is additive, not a replacement for it.
+    item_type: str | None = None
 
 
 CHAT_SCHEMA_VERSION = 2

--- a/schemas/source.schema.json
+++ b/schemas/source.schema.json
@@ -66,6 +66,42 @@
       "default": null,
       "title": "Doi"
     },
+    "issue": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Issue"
+    },
+    "item_type": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Item Type"
+    },
+    "journal": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Journal"
+    },
     "modified_at": {
       "format": "date-time",
       "title": "Modified At",
@@ -93,10 +129,34 @@
       "default": null,
       "title": "Original Ext"
     },
+    "pages": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Pages"
+    },
     "path": {
       "format": "path",
       "title": "Path",
       "type": "string"
+    },
+    "publisher": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Publisher"
     },
     "slug": {
       "title": "Slug",
@@ -128,6 +188,30 @@
     "title": {
       "title": "Title",
       "type": "string"
+    },
+    "url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Url"
+    },
+    "volume": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Volume"
     },
     "year": {
       "anyOf": [

--- a/tests/unit/agents/test_chat_agent.py
+++ b/tests/unit/agents/test_chat_agent.py
@@ -702,6 +702,60 @@ def test_respond_faithfulness_checked_true_when_verifier_says_yes():
     assert "Kùzu is embedded, no server process" in verify_messages[1]["content"]
 
 
+def test_respond_drops_claim_citing_an_unresolvable_slug():
+    llm = MagicMock()
+    llm.model = "test-model"
+    llm.context_window = 1_000_000
+    llm.complete.side_effect = [
+        'Kùzu is embedded, no server process[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["made-up-slug"]}]',
+    ]
+    toolbox = MagicMock()
+    toolbox.slug_resolves.return_value = False
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="why Kùzu?")
+
+    assert reply.claims == []
+    toolbox.slug_resolves.assert_called_once_with("made-up-slug")
+
+
+def test_respond_keeps_claim_when_all_sources_resolve():
+    llm = MagicMock()
+    llm.model = "test-model"
+    llm.context_window = 1_000_000
+    llm.complete.side_effect = [
+        'Kùzu is embedded, no server process[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "attribution", "sources": ["kg-decision"]}]',
+    ]
+    toolbox = MagicMock()
+    toolbox.slug_resolves.return_value = True
+    toolbox.get_node_text.return_value = None  # skip the faithfulness LLM call
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="why Kùzu?")
+
+    assert len(reply.claims) == 1
+    assert reply.claims[0].sources == ["kg-decision"]
+
+
+def test_respond_inference_claims_never_check_source_resolution():
+    llm = MagicMock()
+    llm.model = "test-model"
+    llm.context_window = 1_000_000
+    llm.complete.side_effect = [
+        'This is my own reasoning[^1].\n'
+        'FOOTNOTES_JSON: [{"index": 1, "relation": "ai-inference", "sources": []}]',
+    ]
+    toolbox = MagicMock()
+    agent = _agent(llm=llm, toolbox=toolbox)
+
+    reply = agent.respond(history=[], user_text="what do you think?")
+
+    assert len(reply.claims) == 1
+    toolbox.slug_resolves.assert_not_called()
+
+
 def test_respond_faithfulness_checked_false_when_verifier_says_no():
     llm = MagicMock()
     llm.model = "test-model"

--- a/tests/unit/server/test_notes_routes.py
+++ b/tests/unit/server/test_notes_routes.py
@@ -171,3 +171,44 @@ def test_generate_md_format_rejects_non_html_node(client, vault):
 def test_generate_md_format_not_found(client):
     r = client.post("/notes/does-not-exist/md")
     assert r.status_code == 404
+
+
+# ── GET /notes/apa (ADR-020 bulk slug -> APA-citation lookup) ─────────────────
+
+def test_get_apa_citations_returns_formatted_string(client, vault):
+    source = vault.create_source_from_citekey(
+        "smith2024", "A Great Paper", "body", zotero_key="ZK1", authors=["Jane Smith"], tags=[], year=2024,
+    )
+    r = client.get(f"/notes/apa?slugs={source.slug}")
+    assert r.status_code == 200
+    assert r.json() == {"smith2024": "Smith, J. (2024). A Great Paper."}
+
+
+def test_get_apa_citations_bulk_lookup(client, vault):
+    a = vault.create_source_from_citekey("a2024", "Paper A", "body", zotero_key="A", authors=[], tags=[])
+    b = vault.create_source_from_citekey("b2024", "Paper B", "body", zotero_key="B", authors=[], tags=[])
+    r = client.get(f"/notes/apa?slugs={a.slug},{b.slug}")
+    assert set(r.json().keys()) == {"a2024", "b2024"}
+
+
+def test_get_apa_citations_omits_missing_slugs(client, vault):
+    source = vault.create_source_from_citekey("smith2024", "A Great Paper", "body", zotero_key="ZK1", authors=[], tags=[])
+    r = client.get(f"/notes/apa?slugs={source.slug},does-not-exist")
+    assert list(r.json().keys()) == ["smith2024"]
+
+
+def test_get_apa_citations_omits_notes_not_just_sources(client, vault):
+    # A claim's sources can point to a Note, not only a Source -- format_apa()
+    # would misfire on one (empty authors, note title as "citation title"),
+    # so this must be skipped rather than producing a garbage citation.
+    note = vault.create_note("A Note", body="text")
+    r = client.get(f"/notes/apa?slugs={note.slug}")
+    assert r.json() == {}
+
+
+def test_get_apa_citations_registered_before_slug_route(client, vault):
+    # Regression test for the route-ordering requirement noted in
+    # notes_routes.py: /apa must not be swallowed by GET /{slug}.
+    r = client.get("/notes/apa?slugs=whatever")
+    assert r.status_code == 200
+    assert isinstance(r.json(), dict)

--- a/tests/unit/server/test_zotero_routes.py
+++ b/tests/unit/server/test_zotero_routes.py
@@ -223,3 +223,9 @@ def test_zotero_import_creates_source_from_abstract_when_no_pdf(isolated_client,
     source = vault.get_source(data["slug"])
     assert source.zotero_key == "K2"
     assert source.doi == "10.1/xyz"
+    # ADR-020: these were fetched from ZoteroItem but discarded before --
+    # only ever used to build unstructured body prose, never persisted as
+    # structured fields.
+    assert source.journal == "Journal of Things"
+    assert source.item_type == "journalArticle"
+    assert source.url == "https://example.com/paper"

--- a/tests/unit/services/test_chat_tools.py
+++ b/tests/unit/services/test_chat_tools.py
@@ -162,6 +162,32 @@ def test_get_node_text_returns_none_for_empty_body(vault):
     assert toolbox.get_node_text(note.slug) is None
 
 
+# ── slug_resolves() — ADR-020 hard-validation of CitedClaimNode.sources ───────
+
+def test_slug_resolves_true_for_a_real_note(vault):
+    note = vault.create_note("Attention", body="text")
+    toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
+
+    assert toolbox.slug_resolves(note.slug) is True
+
+
+def test_slug_resolves_false_for_a_missing_slug(vault):
+    toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
+
+    assert toolbox.slug_resolves("does-not-exist") is False
+
+
+def test_slug_resolves_true_for_a_real_but_empty_note(vault):
+    # Unlike get_node_text() (which treats an empty body as unresolved --
+    # correct for "is there text to check faithfulness against"), a real
+    # slug with an empty body is still a real slug -- correct for "does
+    # this claim cite something that actually exists."
+    note = vault.create_note("Empty", body="")
+    toolbox = ChatToolbox(MagicMock(), MagicMock(), vault)
+
+    assert toolbox.slug_resolves(note.slug) is True
+
+
 # ── RECALL (ADR-019, docs/concepts/chat-session-graph.md) ────────────────────
 
 def _graph_with_two_turns(text_a: str, text_b: str):

--- a/tests/unit/services/test_citation_format.py
+++ b/tests/unit/services/test_citation_format.py
@@ -1,0 +1,169 @@
+"""Unit tests for APA 7th-edition citation formatting (ADR-020)."""
+from pathlib import Path
+
+from prisma.services.citation_format import (
+    find_source_by_apa, format_apa, missing_fields_for_apa, validate_apa_format,
+)
+from prisma.storage.models.vault_models import Source
+
+
+def _source(**overrides) -> Source:
+    defaults = dict(slug="smith2024", title="A Great Paper", path=Path("/tmp/smith2024.md"), citekey="smith2024")
+    defaults.update(overrides)
+    return Source(**defaults)
+
+
+# ── missing_fields_for_apa ────────────────────────────────────────────────────
+
+def test_missing_fields_journal_article_complete():
+    source = _source(authors=["Jane Smith"], year=2024, item_type="journalArticle", journal="J")
+    assert missing_fields_for_apa(source) == []
+
+
+def test_missing_fields_journal_article_missing_journal():
+    source = _source(authors=["Jane Smith"], year=2024, item_type="journalArticle")
+    assert "journal" in missing_fields_for_apa(source)
+
+
+def test_missing_fields_book_missing_publisher():
+    source = _source(authors=["Jane Smith"], year=2024, item_type="book")
+    assert "publisher" in missing_fields_for_apa(source)
+
+
+def test_missing_fields_webpage_missing_url():
+    source = _source(authors=["Jane Smith"], year=2024, item_type="webpage")
+    assert "url" in missing_fields_for_apa(source)
+
+
+def test_missing_fields_no_authors():
+    source = _source(authors=[], year=2024)
+    assert "authors" in missing_fields_for_apa(source)
+
+
+def test_missing_fields_unknown_item_type_only_needs_base_fields():
+    source = _source(authors=["Jane Smith"], year=2024, item_type="artwork")
+    assert missing_fields_for_apa(source) == []
+
+
+# ── format_apa ────────────────────────────────────────────────────────────────
+
+def test_format_apa_single_author():
+    source = _source(authors=["Jane Smith"], year=2024)
+    assert format_apa(source) == "Smith, J. (2024). A Great Paper."
+
+
+def test_format_apa_two_authors_joined_with_ampersand():
+    source = _source(authors=["Jane Smith", "John Doe"], year=2024)
+    assert format_apa(source).startswith("Smith, J., & Doe, J. (2024).")
+
+
+def test_format_apa_three_authors():
+    source = _source(authors=["Jane Smith", "John Doe", "Amy Lee"], year=2024)
+    assert format_apa(source).startswith("Smith, J., Doe, J., & Lee, A. (2024).")
+
+
+def test_format_apa_no_authors_puts_title_first():
+    source = _source(authors=[], year=2024, title="Untitled Report")
+    assert format_apa(source) == "Untitled Report (2024)."
+
+
+def test_format_apa_no_year_uses_nd():
+    source = _source(authors=["Jane Smith"], year=None)
+    assert "(n.d.)" in format_apa(source)
+
+
+def test_format_apa_journal_article_full_tail():
+    source = _source(
+        authors=["Jane Smith"], year=2024, item_type="journalArticle",
+        journal="Journal of Examples", volume="12", issue="3", pages="45-67",
+    )
+    assert format_apa(source) == (
+        "Smith, J. (2024). A Great Paper. Journal of Examples, 12(3), 45-67."
+    )
+
+
+def test_format_apa_journal_article_without_issue():
+    source = _source(
+        authors=["Jane Smith"], year=2024, item_type="journalArticle",
+        journal="Journal of Examples", volume="12",
+    )
+    assert "Journal of Examples, 12." in format_apa(source)
+
+
+def test_format_apa_book_uses_publisher():
+    source = _source(authors=["Jane Smith"], year=2024, item_type="book", publisher="Example Press")
+    assert format_apa(source) == "Smith, J. (2024). A Great Paper. Example Press."
+
+
+def test_format_apa_prefers_doi_over_url():
+    source = _source(authors=["Jane Smith"], year=2024, doi="10.1/xyz", url="https://example.com")
+    assert format_apa(source).endswith("https://doi.org/10.1/xyz")
+
+
+def test_format_apa_falls_back_to_url_without_doi():
+    source = _source(authors=["Jane Smith"], year=2024, url="https://example.com")
+    assert format_apa(source).endswith("https://example.com")
+
+
+def test_format_apa_degrades_gracefully_with_nothing_but_title():
+    source = _source(authors=[], year=None, title="Mystery Document")
+    assert format_apa(source) == "Mystery Document (n.d.)."
+
+
+# ── validate_apa_format ────────────────────────────────────────────────────────
+
+def test_validate_apa_format_accepts_format_apas_own_output():
+    source = _source(authors=["Jane Smith"], year=2024, item_type="journalArticle", journal="J")
+    assert validate_apa_format(format_apa(source)) is True
+
+
+def test_validate_apa_format_accepts_no_date_output():
+    source = _source(authors=[], year=None)
+    assert validate_apa_format(format_apa(source)) is True
+
+
+def test_validate_apa_format_rejects_plain_prose():
+    assert validate_apa_format("just some random text with no citation shape") is False
+
+
+def test_validate_apa_format_rejects_empty_string():
+    assert validate_apa_format("") is False
+
+
+# ── find_source_by_apa ────────────────────────────────────────────────────────
+
+def test_find_source_by_apa_matches_surname_and_year():
+    sources = [
+        _source(slug="a", title="A Great Paper", authors=["Jane Smith"], year=2024),
+        _source(slug="b", title="Another Paper", authors=["John Doe"], year=2020),
+    ]
+    found = find_source_by_apa("Smith, J. (2024). A Great Paper.", sources)
+    assert [s.slug for s in found] == ["a"]
+
+
+def test_find_source_by_apa_returns_empty_when_nothing_matches():
+    sources = [_source(slug="a", authors=["Jane Smith"], year=2024)]
+    assert find_source_by_apa("Doe, J. (2020). Something Else.", sources) == []
+
+
+def test_find_source_by_apa_returns_empty_when_unparseable():
+    sources = [_source(slug="a", authors=["Jane Smith"], year=2024)]
+    assert find_source_by_apa("not a citation at all", sources) == []
+
+
+def test_find_source_by_apa_disambiguates_same_author_year_by_title_overlap():
+    sources = [
+        _source(slug="a", title="Attention Is All You Need", authors=["Jane Smith"], year=2024),
+        _source(slug="b", title="A Completely Unrelated Subject", authors=["Jane Smith"], year=2024),
+    ]
+    found = find_source_by_apa("Smith, J. (2024). Attention mechanisms in transformers.", sources)
+    assert found[0].slug == "a"
+
+
+def test_find_source_by_apa_matches_nd_literally():
+    sources = [
+        _source(slug="a", authors=["Jane Smith"], year=None),
+        _source(slug="b", authors=["Jane Smith"], year=2020),
+    ]
+    found = find_source_by_apa("Smith, J. (n.d.). Undated Work.", sources)
+    assert [s.slug for s in found] == ["a"]

--- a/tests/unit/services/test_source_backfill.py
+++ b/tests/unit/services/test_source_backfill.py
@@ -1,0 +1,113 @@
+"""Unit tests for the ADR-020 one-time source-metadata backfill."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from prisma.services.source_backfill import backfill_source_metadata
+from prisma.services.vault import VaultService
+from prisma.storage.models.zotero_models import ZoteroItem
+
+
+@pytest.fixture
+def vault(tmp_path):
+    v = VaultService(vault_root=tmp_path / "vault")
+    v.ensure_dirs()
+    return v
+
+
+def _zotero_item(**overrides) -> ZoteroItem:
+    defaults = dict(
+        key="ZK1", title="A Great Paper", item_type="journalArticle", creators=[],
+        publication_title="Journal of Examples", volume="12", issue="3", pages="45-67",
+    )
+    defaults.update(overrides)
+    return ZoteroItem(**defaults)
+
+
+def test_dry_run_reports_without_writing(vault):
+    source = vault.create_source_from_citekey(
+        "smith2024", "A Great Paper", "body", zotero_key="ZK1", authors=["Jane Smith"], tags=[],
+    )
+    zotero = MagicMock()
+    zotero.get_item.return_value = _zotero_item()
+
+    results = backfill_source_metadata(vault, zotero, dry_run=True)
+
+    assert len(results) == 1
+    assert results[0].slug == source.slug
+    assert results[0].updated is True
+    reloaded = vault.get_source(source.slug)
+    assert reloaded.journal is None  # nothing written
+
+
+def test_apply_writes_the_fetched_fields(vault):
+    source = vault.create_source_from_citekey(
+        "smith2024", "A Great Paper", "body", zotero_key="ZK1", authors=["Jane Smith"], tags=[],
+    )
+    zotero = MagicMock()
+    zotero.get_item.return_value = _zotero_item()
+
+    backfill_source_metadata(vault, zotero, dry_run=False)
+
+    reloaded = vault.get_source(source.slug)
+    assert reloaded.journal == "Journal of Examples"
+    assert reloaded.volume == "12"
+    assert reloaded.issue == "3"
+    assert reloaded.pages == "45-67"
+    assert reloaded.item_type == "journalArticle"
+
+
+def test_skips_source_with_no_zotero_key(vault):
+    vault.create_source_from_citekey(
+        "manual2024", "Manually Added", "body", zotero_key="", authors=[], tags=[],
+    )
+    zotero = MagicMock()
+
+    results = backfill_source_metadata(vault, zotero, dry_run=True)
+
+    assert results[0].updated is False
+    assert "no zotero_key" in results[0].error
+    zotero.get_item.assert_not_called()
+
+
+def test_skips_source_already_partially_backfilled(vault):
+    vault.create_source_from_citekey(
+        "smith2024", "A Great Paper", "body", zotero_key="ZK1", authors=[], tags=[],
+        journal="Already Here",
+    )
+    zotero = MagicMock()
+
+    results = backfill_source_metadata(vault, zotero, dry_run=True)
+
+    assert results[0].updated is False
+    assert results[0].error is None
+    zotero.get_item.assert_not_called()
+
+
+def test_reports_error_when_zotero_item_not_found(vault):
+    vault.create_source_from_citekey(
+        "smith2024", "A Great Paper", "body", zotero_key="ZK-GONE", authors=[], tags=[],
+    )
+    zotero = MagicMock()
+    zotero.get_item.return_value = None
+
+    results = backfill_source_metadata(vault, zotero, dry_run=True)
+
+    assert results[0].updated is False
+    assert "not found" in results[0].error
+
+
+def test_backfills_multiple_sources_independently(vault):
+    vault.create_source_from_citekey(
+        "a2024", "Paper A", "body", zotero_key="ZKA", authors=[], tags=[],
+    )
+    vault.create_source_from_citekey(
+        "b2024", "Paper B", "body", zotero_key="ZKB", authors=[], tags=[],
+    )
+    zotero = MagicMock()
+    zotero.get_item.side_effect = lambda key: _zotero_item(key=key, title=f"Paper for {key}")
+
+    results = backfill_source_metadata(vault, zotero, dry_run=False)
+
+    assert {r.slug for r in results} == {"a2024", "b2024"}
+    assert all(r.updated for r in results)

--- a/tests/unit/services/test_vault_public_surface.py
+++ b/tests/unit/services/test_vault_public_surface.py
@@ -112,6 +112,10 @@ class TestCreateSourceFromCitekey:
         assert source.authors == ["Jane Smith"]
         assert source.year == 2024
         assert source.doi == "10.1/xyz"
+        # ADR-020: url was previously written to frontmatter but never read
+        # back by get_source() -- silently dropped on every load. This
+        # assertion is the regression test for that fix.
+        assert source.url == "https://example.com/paper"
 
     def test_omits_optional_fields_when_not_given(self, vault):
         source = vault.create_source_from_citekey(
@@ -120,6 +124,23 @@ class TestCreateSourceFromCitekey:
         )
         assert source.year is None
         assert source.doi is None
+        assert source.url is None
+        assert source.journal is None
+        assert source.item_type is None
+
+    def test_creates_source_with_apa_bibliographic_fields(self, vault):
+        source = vault.create_source_from_citekey(
+            "smith2024", "A Great Paper", "body",
+            zotero_key="ABC123", authors=["Jane Smith"], tags=[],
+            journal="Journal of Examples", volume="12", issue="3", pages="45-67",
+            publisher="Example Press", item_type="journalArticle",
+        )
+        assert source.journal == "Journal of Examples"
+        assert source.volume == "12"
+        assert source.issue == "3"
+        assert source.pages == "45-67"
+        assert source.publisher == "Example Press"
+        assert source.item_type == "journalArticle"
 
     def test_slug_disambiguated_on_citekey_collision(self, vault):
         vault.create_source_from_citekey(
@@ -129,3 +150,39 @@ class TestCreateSourceFromCitekey:
             "smith2024", "Second", "body2", zotero_key="B", authors=[], tags=[],
         )
         assert second.slug == "smith2024-1"
+
+
+class TestUpdateSourceBibliographicFields:
+    def test_merges_new_fields_leaving_existing_ones_untouched(self, vault):
+        source = vault.create_source_from_citekey(
+            "smith2024", "A Great Paper", "the body text",
+            zotero_key="ABC123", authors=["Jane Smith"], tags=["ml"], year=2024,
+        )
+
+        updated = vault.update_source_bibliographic_fields(
+            source.slug, journal="Journal of Examples", volume="12", item_type="journalArticle",
+        )
+
+        assert updated.journal == "Journal of Examples"
+        assert updated.volume == "12"
+        assert updated.item_type == "journalArticle"
+        # untouched
+        assert updated.title == "A Great Paper"
+        assert updated.authors == ["Jane Smith"]
+        assert updated.year == 2024
+        assert updated.body == "the body text"
+
+    def test_does_not_blank_out_fields_when_called_with_none(self, vault):
+        source = vault.create_source_from_citekey(
+            "smith2024", "A Great Paper", "body",
+            zotero_key="ABC123", authors=[], tags=[], journal="Original Journal",
+        )
+
+        updated = vault.update_source_bibliographic_fields(source.slug, volume="5")
+
+        assert updated.journal == "Original Journal"
+        assert updated.volume == "5"
+
+    def test_raises_file_not_found_for_missing_slug(self, vault):
+        with pytest.raises(FileNotFoundError):
+            vault.update_source_bibliographic_fields("does-not-exist", journal="X")

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -706,6 +706,24 @@
     } catch {}
   }
 
+  // ADR-020: slug -> APA-citation-string cache, populated on demand
+  // whenever a chat's messages (could) contain new claim source slugs --
+  // fetchApaCitations() only requests what's not already cached.
+  let apaCitations = $state<Record<string, string>>({});
+
+  async function fetchApaCitations(messages: ChatTurn[]) {
+    const slugs = new Set<string>();
+    for (const msg of messages) {
+      for (const claim of msg.claims ?? []) {
+        if (claim.kind === "claim") for (const s of claim.sources) slugs.add(s);
+      }
+    }
+    const missing = [...slugs].filter(s => !(s in apaCitations));
+    if (missing.length === 0) return;
+    const r = await apiFetch(`${apiBase}/notes/apa?slugs=${missing.map(encodeURIComponent).join(",")}`);
+    if (r.ok) apaCitations = { ...apaCitations, ...(await r.json()) };
+  }
+
   async function openChat(slug: string) {
     clearInterval(excerptPollInterval);  // stop any poll for the chat we're leaving, immediately
     activeNode = null;
@@ -715,7 +733,11 @@
     loadingNode = true;
     try {
       const r = await apiFetch(`${apiBase}/chats/${encodeURIComponent(slug)}`);
-      if (r.ok) activeChat = await r.json();
+      if (r.ok) {
+        const chat: ChatDetail = await r.json();
+        activeChat = chat;
+        void fetchApaCitations(chat.messages);
+      }
     } finally {
       loadingNode = false;
     }
@@ -760,6 +782,7 @@
             tool_calls: data.tool_calls ?? [], recalls: data.recalls ?? [],
           },
         ];
+        void fetchApaCitations(activeChat.messages);
       }
     } finally {
       chatSending = false;
@@ -775,7 +798,11 @@
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ model: model ?? null }),
       });
-      if (r.ok && activeChat?.slug === slug) activeChat = await r.json();
+      if (r.ok && activeChat?.slug === slug) {
+        const chat: ChatDetail = await r.json();
+        activeChat = chat;
+        void fetchApaCitations(chat.messages);
+      }
     } finally {
       chatSending = false;
     }
@@ -2066,6 +2093,11 @@
                               <div class="claim-sources">
                                 {#each claim.sources as slug, si}{#if si > 0}, {/if}<button class="claim-source-link" onclick={() => openNode(slug)}>{slug}</button>{/each}
                               </div>
+                              {#each claim.sources as slug}
+                                {#if apaCitations[slug]}
+                                  <div class="claim-apa">{apaCitations[slug]}</div>
+                                {/if}
+                              {/each}
                             {/if}
                           </li>
                         {/each}
@@ -4089,6 +4121,12 @@
   }
   .claim-source-link:hover {
     color: #c8ddf0;
+  }
+  .claim-apa {
+    margin-top: 2px;
+    font-size: 10px;
+    font-style: italic;
+    color: #6a7a8f;
   }
   .chat-input-row {
     display: flex;


### PR DESCRIPTION
## Summary
- `Source` gains the bibliographic fields APA needs beyond author/year/title (`journal`/`volume`/`issue`/`pages`/`publisher`/`url`/`item_type`), threaded through Zotero import — fixes a standing bug as a side effect: `url` was written to frontmatter on import but never read back, silently dropped on every load.
- `prisma/services/citation_format.py`: `missing_fields_for_apa()`, `format_apa()` (slug → APA), `find_source_by_apa()` (fuzzy reverse lookup), `validate_apa_format()`.
- `CitedClaimNode.sources` is now hard-validated against real vault slugs instead of the previous soft degrade — a claim citing a hallucinated slug is dropped and logged.
- One-time backfill: `prisma backfill-source-metadata` CLI command (dry-run by default, `--apply` to write) for sources imported before this landed.
- Chat UI wiring: `GET /notes/apa?slugs=...` + `+page.svelte` fetching/caching it, rendering each claim's APA citation as an extra line below its source link.
- ADR-020 updated to Implemented, with all 4 originally-open decisions resolved and documented.

## Test plan
- [x] `pytest tests/unit` — 987 passing
- [x] `svelte-check` clean, 0 errors/warnings
- [x] `npm run build` (UI production build) succeeds
- [x] A real bug caught and fixed by the new test suite itself: `find_source_by_apa()`'s `n.d.` handling initially matched any source regardless of whether that source itself had no year