### PR TITLE
Allow extra CORS origins via PRISMA_CORS_EXTRA_ORIGINS

### DIFF
--- a/prisma/server/app.py
+++ b/prisma/server/app.py
@@ -43,6 +43,7 @@ from prisma.server.access_log import AccessLogMiddleware
 from prisma.server.auth import (
     AuthMiddleware, LoginRequest, LoginResponse, classify_zone, issue_token, verify_password,
 )
+from prisma.server.cors import extra_origins
 _t("fastapi ok")
 
 _t("importing coordinator")
@@ -458,7 +459,7 @@ app.add_middleware(AuthMiddleware)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["tauri://localhost"],
+    allow_origins=["tauri://localhost", *extra_origins()],
     # Any port on localhost/127.0.0.1 — covers the API's own port, the Web
     # process's port (ADR-012), and whichever hostname variant the browser
     # resolved (CORS origin matching is exact-string, so both "localhost"

--- a/prisma/server/cors.py
+++ b/prisma/server/cors.py
@@ -1,0 +1,16 @@
+"""Shared CORS origin config for the api/web processes (ADR-012 split).
+
+Both processes default to allowing only `tauri://localhost` and any
+localhost/127.0.0.1 port (single-machine dev/desktop use). A LAN deployment
+where the web and api processes are reachable at different host:port pairs
+(e.g. via separate NodePorts) needs the api process to also allow the web
+process's origin — supplied via PRISMA_CORS_EXTRA_ORIGINS (comma-separated
+full origins, scheme://host:port) rather than hardcoded here, since this
+module has no business knowing any specific deployment's hostname.
+"""
+import os
+
+
+def extra_origins() -> list[str]:
+    raw = os.environ.get("PRISMA_CORS_EXTRA_ORIGINS", "")
+    return [o.strip() for o in raw.split(",") if o.strip()]

--- a/prisma/server/web_app.py
+++ b/prisma/server/web_app.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from prisma.server.cors import extra_origins
 from prisma.server.static import CleanUrlStaticFiles
 
 _log = logging.getLogger("prisma.web")
@@ -37,7 +38,7 @@ app = FastAPI(title="Prisma Web")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["tauri://localhost"],
+    allow_origins=["tauri://localhost", *extra_origins()],
     allow_origin_regex=r"^http://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- api/web processes (ADR-012) can sit behind different host:port pairs in a LAN deployment where the desktop client's `api_port`/`web_port` both point at the same hostname
- when that happens, the browser treats the web process's page origin as cross-origin against the api process, and CORS silently blocks every fetch unless that origin is allow-listed
- adds `PRISMA_CORS_EXTRA_ORIGINS` (comma-separated full origins), read once at import time, appended to both processes' `allow_origins` — no hostname hardcoded in this repo

## Test plan
- [x] verified root cause live: SPA loaded from the web-process origin, `/health` fetch to the api-process origin rejected client-side
- [ ] deploy with `PRISMA_CORS_EXTRA_ORIGINS` set to the web process's origin, confirm the desktop app connects instead of falling back to the offline page