### PR TITLE
Fix WebSocket connecting before settings load resolves

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -377,7 +377,6 @@
   }
 
   let _wsRetry = 0;
-  connectWS();
 
   // ── UI dev hot-reload (polling the Web process — dev-only, self-contained) ───
   let _devBuildVersion: number | null = null;
@@ -549,6 +548,11 @@
   async function bootstrap() {
     serverOnline = await ping();
     if (!serverOnline) return;
+    // Deliberately after the ping, not at component init (see removed
+    // top-level call) -- apiBase is still the Tauri loopback placeholder
+    // until loadSettings() resolves, so an eager connectWS() always fails
+    // its first attempt against the wrong host.
+    connectWS();
     await Promise.all([loadTree(), loadHome(), loadStreams(), loadChats(), loadZoteroStatus()]);
     pollStatus();
   }


### PR DESCRIPTION
## Summary
- `connectWS()` ran unconditionally at component init (top-level script execution), before `loadSettings()` resolved and corrected `apiBase` away from its Tauri-only `127.0.0.1:8765` placeholder
- every first WS connection attempt targeted loopback regardless of the real configured server -- pre-existing, surfaced while diagnosing the CORS fix in #76 against a real LAN deployment
- moved the initial `connectWS()` call into `bootstrap()`, right after the same `ping()` that already waits on settings resolution

## Test plan
- [ ] deploy, load the desktop app against a LAN server, confirm no `ws://127.0.0.1:.../ws` connection attempt in devtools and a successful connect to the configured host instead